### PR TITLE
feat/rls/#29: User ID 통합 및 RLS 1차 정책 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ next-env.d.ts
 
 # Cursor IDE settings
 .cursor/
+.claude/

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -166,7 +166,7 @@ export async function completeSignupAction(data: CompleteSignupInput): Promise<A
   // public.user 테이블에 최종적인 데이터 upsert <- update + insert
   const { error: dbError } = await supabase.from("user").upsert(
     {
-      oauth_id: user.id,
+      id: user.id,
       email: user.email!,
       name: name,
       nickname,
@@ -176,7 +176,7 @@ export async function completeSignupAction(data: CompleteSignupInput): Promise<A
       photo_url: null,
       linked_providers: ["email"],
     },
-    { onConflict: "oauth_id" },
+    { onConflict: "id" },
   );
 
   if (dbError) {
@@ -283,7 +283,7 @@ export async function completeOAuthProfileAction(
 
   const { error: dbError } = await supabase.from("user").upsert(
     {
-      oauth_id: user.id,
+      id: user.id,
       email: user.email!,
       name,
       nickname,
@@ -293,7 +293,7 @@ export async function completeOAuthProfileAction(
       photo_url: (user.user_metadata?.avatar_url as string) ?? null,
       ...(linkedProviders.length > 0 ? { linked_providers: linkedProviders } : {}),
     },
-    { onConflict: "oauth_id" },
+    { onConflict: "id" },
   );
 
   if (dbError) {
@@ -345,7 +345,7 @@ export async function unLinkOAuthAction(provider: OAuthProvider): Promise<Action
   const { data: dbUser, error: dbUserError } = await supabase
     .from("user")
     .select("linked_providers")
-    .eq("oauth_id", user.id)
+    .eq("id", user.id)
     .single();
 
   if (!dbUser || dbUserError) {
@@ -361,7 +361,7 @@ export async function unLinkOAuthAction(provider: OAuthProvider): Promise<Action
   const { error: updateError } = await supabase
     .from("user")
     .update({ linked_providers: updatedProviders })
-    .eq("oauth_id", user.id);
+    .eq("id", user.id);
 
   if (updateError) {
     return {
@@ -460,7 +460,7 @@ export async function updateProfileAction(formData: FormData): Promise<ActionRes
       nickname,
       photo_url: photoUrl,
     })
-    .eq("oauth_id", user.id);
+    .eq("id", user.id);
 
   if (updateError) {
     return {

--- a/src/actions/chat-room.ts
+++ b/src/actions/chat-room.ts
@@ -15,22 +15,12 @@ export const createChatRoomAction = async (formData: CreateChatRoomInput) => {
     return { error: "인증 정보가 없습니다." };
   }
 
-  const { data: dbUser, error: userError } = await supabase
-    .from("user")
-    .select("id")
-    .eq("oauth_id", user.id)
-    .single();
-
-  if (userError || !dbUser) {
-    return { error: "사용자 정보를 찾을 수 없습니다." };
-  }
-
   const { data: room, error: roomError } = await supabase
     .from("chat_room")
     .insert({
       title: formData.title,
       max_capacity: formData.capacity,
-      owner_id: dbUser.id,
+      owner_id: user.id,
       description: formData.description ?? null,
     })
     .select("id")
@@ -42,7 +32,7 @@ export const createChatRoomAction = async (formData: CreateChatRoomInput) => {
 
   const { error: memberError } = await supabase.from("chat_room_member").insert({
     chat_room_id: room.id,
-    user_id: dbUser.id,
+    user_id: user.id,
   });
 
   if (memberError) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
       const { data: existingUser } = await supabase
         .from("user")
         .select("id, linked_providers, photo_url")
-        .eq("oauth_id", user.id)
+        .eq("id", user.id)
         .single();
 
       if (!existingUser) {
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest) {
       }
 
       if (Object.keys(updatePayload).length > 0) {
-        await supabase.from("user").update(updatePayload).eq("oauth_id", user.id);
+        await supabase.from("user").update(updatePayload).eq("id", user.id);
       }
 
       return NextResponse.redirect(

--- a/src/app/auth/complete-profile/page.tsx
+++ b/src/app/auth/complete-profile/page.tsx
@@ -18,7 +18,7 @@ export default async function Page() {
   const { data: profile } = await supabase
     .from("user")
     .select("nickname")
-    .eq("oauth_id", user.id)
+    .eq("id", user.id)
     .single();
 
   if (profile?.nickname) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@
 }
 
 :root {
-  --app-content-height: calc(100vh - 145px);
+  --app-content-height: calc(100vh - 146px);
 
   --brand: #46c6a9;
   --brand-foreground: #ffffff;

--- a/src/components/auth/auth-listener.tsx
+++ b/src/components/auth/auth-listener.tsx
@@ -57,7 +57,7 @@ export default function AuthListener() {
       const { data, error } = await supabase
         .from("user")
         .select("linked_providers")
-        .eq("oauth_id", user.id)
+        .eq("id", user.id)
         .maybeSingle();
 
       if (error) {

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -14,11 +14,7 @@ export default async function Header() {
 
   let hasProfile = false;
   if (user) {
-    const { data: profile } = await supabase
-      .from("user")
-      .select("id")
-      .eq("oauth_id", user.id)
-      .single();
+    const { data: profile } = await supabase.from("user").select("id").eq("id", user.id).single();
 
     hasProfile = !!profile;
   }

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -11,5 +11,8 @@ export const QUERY_KEYS = {
     all: ["chat"] as const,
     rooms: (userId?: string, tabType?: string) =>
       [...QUERY_KEYS.chat.all, "rooms", userId, tabType].filter(Boolean),
+    room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
+    messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),
+    members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter(Boolean),
   },
 } as const;

--- a/src/hooks/use-chat-room.ts
+++ b/src/hooks/use-chat-room.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import { QUERY_KEYS } from "@/constants/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import { ChatRoom } from "@/types/chat-room";
 
@@ -9,7 +10,7 @@ export function useRoom(roomId: string) {
   const supabase = createClient();
 
   return useQuery<ChatRoom>({
-    queryKey: ["room", roomId],
+    queryKey: QUERY_KEYS.chat.room(roomId),
     enabled: !!roomId,
     queryFn: async () => {
       const { data, error } = await supabase

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 
 import { useInfiniteQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 
+import { QUERY_KEYS } from "@/constants/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { Message } from "@/types/message";
 import { MESSAGE_PAGE_SIZE } from "@/constants/message";
@@ -13,14 +14,12 @@ interface MessagesPage {
   nextCursor?: string;
 }
 
-const queryKeyByChatRoomId = (chatRoomId: string) => ["messages", chatRoomId] as const;
-
 export default function useMessages(chatRoomId: string) {
   const supabase = createClient();
   const queryClient = useQueryClient();
 
   const query = useInfiniteQuery({
-    queryKey: queryKeyByChatRoomId(chatRoomId),
+    queryKey: QUERY_KEYS.chat.messages(chatRoomId),
     initialPageParam: undefined as string | undefined,
     enabled: !!chatRoomId,
     staleTime: 1000 * 60,
@@ -76,7 +75,7 @@ export default function useMessages(chatRoomId: string) {
           if (!messageId) return;
 
           queryClient.setQueryData<InfiniteData<MessagesPage>>(
-            queryKeyByChatRoomId(chatRoomId),
+            QUERY_KEYS.chat.messages(chatRoomId),
             (previous) => {
               if (!previous) return previous;
 

--- a/src/hooks/use-profile.ts
+++ b/src/hooks/use-profile.ts
@@ -33,7 +33,7 @@ export function useUser() {
       const { data, error } = await supabase
         .from("user")
         .select("*")
-        .eq("oauth_id", authUser.id)
+        .eq("id", authUser.id)
         .maybeSingle();
       if (error) throw error;
       return data;

--- a/src/hooks/use-room-members.ts
+++ b/src/hooks/use-room-members.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { QUERY_KEYS } from "@/constants/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { RoomMemberQuery } from "@/types/chat-room-member";
 
@@ -7,7 +8,7 @@ export function useRoomMembers(roomId: string) {
   const supabase = createClient();
 
   return useQuery<RoomMemberQuery[]>({
-    queryKey: ["room-members", roomId],
+    queryKey: QUERY_KEYS.chat.members(roomId),
     enabled: !!roomId,
     queryFn: async () => {
       const { data, error } = await supabase

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -51,7 +51,7 @@ export async function updateSession(request: NextRequest) {
     const { data: profile } = await supabase
       .from("user")
       .select("nickname")
-      .eq("oauth_id", user.sub)
+      .eq("id", user.sub)
       .single();
 
     // 닉네임(display_name)이 없다면 프로필 설정 페이지로 강제 이동

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -94,21 +94,6 @@ export type Database = {
           },
         ];
       };
-      kv_store_55ce40ce: {
-        Row: {
-          key: string;
-          value: Json;
-        };
-        Insert: {
-          key: string;
-          value: Json;
-        };
-        Update: {
-          key?: string;
-          value?: Json;
-        };
-        Relationships: [];
-      };
       message: {
         Row: {
           chat_room_id: string;
@@ -162,7 +147,6 @@ export type Database = {
           modified_at: string;
           name: string;
           nickname: string;
-          oauth_id: string;
           phone: string;
           photo_url: string | null;
         };
@@ -171,12 +155,11 @@ export type Database = {
           created_at?: string;
           email: string;
           gender: Database["public"]["Enums"]["gender"];
-          id?: string;
+          id: string;
           linked_providers?: Database["public"]["Enums"]["oauth_provider"][];
           modified_at?: string;
           name: string;
           nickname: string;
-          oauth_id: string;
           phone: string;
           photo_url?: string | null;
         };
@@ -190,7 +173,6 @@ export type Database = {
           modified_at?: string;
           name?: string;
           nickname?: string;
-          oauth_id?: string;
           phone?: string;
           photo_url?: string | null;
         };


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/rls/#29 -> dev

### ✅ 작업 내용 `기능 개선`,  `리팩토링`

- `public.user.id`를 Supabase Auth User ID 기준으로 통합했습니다.
- `oauth_id` 기준 조회 코드를 `id` 기준으로 정리했습니다.
- `user`, `chat_room`, `chat_room_member`, `message` 테이블의 RLS를 활성화하고 1차 정책을 적용했습니다.
- 로그인 유저는 채팅방 메타데이터를 조회할 수 있고, 방 생성자만 채팅방 수정과 삭제가 가능하도록 제한했습니다.
- 활성 참여자만 메시지를 조회하고 생성할 수 있으며, 작성자만 메시지를 수정하고 삭제할 수 있도록 제한했습니다.
- `chat_room_member.last_joined_at` 기본값과 `update_member_count()` 트리거 함수 권한을 정리했습니다.
- `get_rooms_by_tab`의 `JOINED`, `NOT_JOINED` 기준을 `is_banned`, `last_joined_at` 기준으로 보강했습니다.
- Supabase Security Advisor 경고 중 트리거 전용 함수 직접 실행 권한과 함수 `search_path` 경고를 정리했습니다.
- 이메일 로그인 테스트 계정 `test@test.com`을 생성하고 Auth ID와 DB User ID 일치를 확인했습니다.
- 채팅방 상세의 room, messages, members query key를 `QUERY_KEYS.chat` 기준으로 통합합니다.

### 🎯 단독 테스트 결과

- `npm run types` 정상 완료.
- `npm run build` 정상 완료.
- SQL Editor 기준 RLS 정책 테스트 완료.
- 비로그인 유저의 `chat_room`, `message` 조회와 방 생성 차단을 확인했습니다.
- 로그인 유저의 `public.user` 조회, 본인 프로필 수정, 타인 프로필 수정 차단을 확인했습니다.
- 채팅방 생성, 수정, 삭제 정책이 owner 기준으로 동작하는지 확인했습니다.
- 메시지 조회, 생성, 수정, 삭제 정책이 활성 참여자와 작성자 기준으로 동작하는지 확인했습니다.
- `get_rooms_by_tab`의 `JOINED`, `NOT_JOINED`, `OWNED` 반환 기준을 테스트 더미 데이터로 확인했습니다.
- 회원가입 전 이메일 중복 체크와 닉네임 중복 체크 정상 동작을 확인했습니다.
- 프로필 수정 닉네임 중복 체크 정상 동작을 확인했습니다.
- Auth 유저 삭제 시 `public.user` row 삭제 트리거 정상 동작을 확인했습니다.
- query key 통합 후 빌드와 사용자 수동 테스트를 진행합니다.

### 🚨 연관 이슈

closes #29