### PR TITLE
feat/search/(#36): 채팅방 검색 기능 추가

### DIFF
--- a/.agents/supabase-convention/SKILLS.md
+++ b/.agents/supabase-convention/SKILLS.md
@@ -1,0 +1,24 @@
+# Supabase Convention
+
+이 문서는 PixelPlay 프로젝트에서 Supabase를 다룰 때 준수해야 하는 규칙입니다.
+
+## 1. 데이터베이스 타입 동기화
+
+데이터베이스 스키마 변경이 발생하면 반드시 로컬의 TypeScript 타입을 업데이트해야 합니다.
+
+- **명령어**: `npm run types`
+- **설명**: `package.json`에 정의된 스크립트를 사용하여 Supabase 프로젝트로부터 최신 타입을 가져옵니다.
+- **주기**: 테이블 추가, 컬럼 수정, 함수(RPC) 생성 등 스키마 변화가 있을 때마다 즉시 실행하십시오.
+
+## 2. 데이터베이스 변경 (Migrations vs SQL Editor)
+
+프로젝트의 복잡도를 낮추고 신속한 개발을 위해 CLI 기반의 Migration 대신 Supabase 대시보드를 활용합니다.
+
+- **원칙**: Supabase migrations(CLI) 기능을 사용하지 않습니다.
+- **방법**: Supabase 대시보드의 **SQL Editor**를 사용하여 테이블 생성, 수정, RPC 함수 정의 등을 수행하십시오.
+
+## 3. RPC 및 로직 위치
+
+- 비즈니스 로직이 데이터베이스 계층에서 처리되는 것이 효율적일 경우(예: 복잡한 필터링, 트랜잭션 처리) PostgreSQL 함수(RPC)를 적극 활용하십시오.
+- 동시성 문제가 발생될 것 같은 부분은 사용자에게 상의후에 적용할지 말지 결정하십시오.
+- `src/lib/supabase/client.ts` 및 `server.ts`를 통해 생성된 클라이언트를 사용하여 데이터에 접근하십시오.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - 아키텍처/SRP 컨벤션: [.agents/code-convention/SRP_CONVENTION.md](./.agents/code-convention/SRP_CONVENTION.md)
 - 디자인/CSS/cn 규칙: [.agents/design-convention/SKILLS.md](./.agents/design-convention/SKILLS.md)
 - 커밋/브랜치 컨벤션: [.agents/git-convention/SKILLS.md](./.agents/git-convention/SKILLS.md)
+- Supabase/DB 컨벤션: [.agents/supabase-convention/SKILLS.md](./.agents/supabase-convention/SKILLS.md)
 
 ---
 

--- a/src/app/search/chat/page.tsx
+++ b/src/app/search/chat/page.tsx
@@ -1,0 +1,29 @@
+// 채팅방 검색 결과 페이지를 렌더링합니다.
+import ChatSearchResults from "@/components/search/chat-search-results";
+import { Separator } from "@/components/ui/separator";
+
+interface Props {
+  searchParams: Promise<{
+    query?: string;
+  }>;
+}
+
+export default async function ChatSearchPage({ searchParams }: Props) {
+  const { query = "" } = await searchParams;
+  const trimmedQuery = query.trim();
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-6 sm:px-5 md:px-6 md:py-8">
+      {trimmedQuery && (
+        <div className="flex flex-col gap-1 px-1">
+          <p className="text-muted-foreground text-sm">채팅방 검색 결과</p>
+          <h1 className="text-foreground text-xl font-bold">
+            <span className="text-brand">&quot;{trimmedQuery}&quot;</span>으로 검색한 결과입니다.
+          </h1>
+        </div>
+      )}
+      <Separator />
+      <ChatSearchResults query={query} />
+    </div>
+  );
+}

--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -1,17 +1,8 @@
 import { cn } from "@/lib/utils";
+import type { ChatRoomCardData } from "@/types/chat-room";
 import { formatCapacity, formatRoomDate } from "@/utils/chat-room";
 import { Clock, MessageCircle, Users } from "lucide-react";
 import Link from "next/link";
-
-interface ChatRoomCardData {
-  id: string;
-  title: string;
-  description: string | null;
-  owner_nickname: string;
-  current_member: number;
-  max_capacity: number;
-  created_at: string;
-}
 
 interface Props {
   chatRoom: ChatRoomCardData;

--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -1,11 +1,20 @@
 import { cn } from "@/lib/utils";
-import type { ChatRoomByTab } from "@/types/chat-room";
 import { formatCapacity, formatRoomDate } from "@/utils/chat-room";
 import { Clock, MessageCircle, Users } from "lucide-react";
 import Link from "next/link";
 
+interface ChatRoomCardData {
+  id: string;
+  title: string;
+  description: string | null;
+  owner_nickname: string;
+  current_member: number;
+  max_capacity: number;
+  created_at: string;
+}
+
 interface Props {
-  chatRoom: ChatRoomByTab;
+  chatRoom: ChatRoomCardData;
   unreadMessageCount?: number;
 }
 
@@ -102,7 +111,7 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
         <div className="flex items-center gap-1">
           <Clock className="text-muted-foreground/50 h-2.5 w-2.5" />
           <span className="text-muted-foreground/70 text-[11px] whitespace-nowrap">
-            개설 {formatRoomDate(chatRoom.created_at)}
+            생성일 {formatRoomDate(chatRoom.created_at)}
           </span>
         </div>
       </div>

--- a/src/components/chat/chat-room-list-header.tsx
+++ b/src/components/chat/chat-room-list-header.tsx
@@ -1,7 +1,7 @@
 import CreateChatRoomDialog from "@/components/chat/create-chat-room-dialog";
 import ChatRoomTabs from "@/components/chat/chat-room-tabs";
-import type { ChatRoomCounts } from "@/hooks/use-chat-room-counts";
 import { cn } from "@/lib/utils";
+import type { ChatRoomCounts } from "@/types/chat-room";
 
 interface Props {
   roomCount: number;

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -2,9 +2,8 @@
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CHAT_ROOM_TABS, ROOM_TAB_LABELS } from "@/constants/chat-room";
-import type { ChatRoomCounts } from "@/hooks/use-chat-room-counts";
 import { useChatRoomStore } from "@/stores/chat-room";
-import type { ChatRoomTab } from "@/types/chat-room";
+import type { ChatRoomCounts, ChatRoomTab } from "@/types/chat-room";
 import { cn } from "@/lib/utils";
 
 interface Props {

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,6 +1,7 @@
 import LoginButton from "@/components/auth/login-button";
 import Logo from "@/components/common/logo";
 import ThemeToggleButton from "@/components/common/theme-toggle-button";
+import HeaderSearchForm from "@/components/search/header-search-form";
 import HeaderProfileBadge from "@/components/setting/profile/header-profile-badge";
 import { createClient } from "@/lib/supabase/server";
 import { cn } from "@/lib/utils";
@@ -27,12 +28,13 @@ export default async function Header() {
         "dark:border-border dark:bg-muted/60", // 다크 모드 톤다운 조합
       )}
     >
-      <div className="flex items-center justify-between px-3 py-2 sm:px-5">
+      <div className="flex flex-wrap items-center justify-between px-3 py-2 sm:flex-nowrap sm:px-5">
         <Link href="/" className="h-10 w-32 sm:w-40">
           <Logo className="dark:text-foreground h-full w-full text-[#1e1d37]" />
         </Link>
 
         <div className="flex items-center gap-3 sm:gap-5">
+          <HeaderSearchForm />
           <ThemeToggleButton />
           {user && hasProfile && <HeaderProfileBadge />}
           {!user && <LoginButton />}

--- a/src/components/common/main-menu-sidebar.tsx
+++ b/src/components/common/main-menu-sidebar.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
 import ChatRoomList from "@/components/chat/chat-room-list";
 import MainMenuSidebarItemRenderer from "@/components/common/main-menu-sidebar-item";
 import LiveList from "@/components/live/live-list";
 import { MAIN_MENU_SIDEBAR_ITEMS } from "@/constants/main-menu-sidebar";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
 import {
   Sidebar,
@@ -49,7 +49,8 @@ function Items({ activeMenu, setActiveMenu }: Props) {
 }
 
 export default function MainMenuSidebar() {
-  const [activeMenu, setActiveMenu] = useState<MainMenuSidebarKey>("chat");
+  const activeMenu = useMainMenuStore((state) => state.activeMenu);
+  const setActiveMenu = useMainMenuStore((state) => state.setActiveMenu);
   const isMobile = useIsMobile();
 
   return (

--- a/src/components/search/chat-search-results.tsx
+++ b/src/components/search/chat-search-results.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+// 채팅방 검색 결과를 조회하고 제목/방장 섹션으로 나눠 표시합니다.
+import ChatRoomListSkeleton from "@/components/chat/chat-room-list-skeleton";
+import ChatSearchSection from "@/components/search/chat-search-section";
+import { useChatRoomSearch } from "@/hooks/use-chat-room-search";
+import type { ChatSearchResult } from "@/types/search";
+import { Search } from "lucide-react";
+
+interface Props {
+  query: string;
+}
+
+function flattenPages(pages?: ChatSearchResult[][]) {
+  return pages?.flat() ?? [];
+}
+
+export default function ChatSearchResults({ query }: Props) {
+  const trimmedQuery = query.trim();
+  const titleSearch = useChatRoomSearch(trimmedQuery, "title");
+  const ownerSearch = useChatRoomSearch(trimmedQuery, "owner");
+
+  if (!trimmedQuery) {
+    return <EmptySearchResult message="검색어를 입력하면 채팅방 검색 결과가 표시됩니다." />;
+  }
+
+  if (titleSearch.isError || ownerSearch.isError) {
+    return <EmptySearchResult message="채팅방 검색 결과를 불러오지 못했습니다." />;
+  }
+
+  if (titleSearch.isLoading || ownerSearch.isLoading) {
+    return <ChatRoomListSkeleton />;
+  }
+
+  const titleResults = flattenPages(titleSearch.data?.pages);
+  const ownerResults = flattenPages(ownerSearch.data?.pages);
+
+  return (
+    <div className="flex flex-col gap-8 md:gap-10">
+      {titleResults.length > 0 && (
+        <ChatSearchSection
+          title="제목"
+          description="채팅방 제목 검색 결과입니다."
+          results={titleResults}
+          hasMore={titleSearch.hasNextPage}
+          isFetchingMore={titleSearch.isFetchingNextPage}
+          onLoadMore={() => titleSearch.fetchNextPage()}
+        />
+      )}
+      {ownerResults.length > 0 && (
+        <ChatSearchSection
+          title="닉네임"
+          description="방을 생성한 사용자의 닉네임 검색 결과입니다."
+          results={ownerResults}
+          hasMore={ownerSearch.hasNextPage}
+          isFetchingMore={ownerSearch.isFetchingNextPage}
+          onLoadMore={() => ownerSearch.fetchNextPage()}
+        />
+      )}
+      {titleResults.length === 0 && ownerResults.length === 0 && (
+        <EmptySearchResult message="검색 결과가 없습니다." />
+      )}
+    </div>
+  );
+}
+
+function EmptySearchResult({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-120 w-full items-center justify-center px-4 py-12 text-center">
+      <div className="flex max-w-80 flex-col items-center">
+        <div className="bg-brand/10 ring-brand/20 dark:bg-brand/15 mb-4 flex h-16 w-16 items-center justify-center rounded-2xl ring-1">
+          <Search className="text-brand h-7 w-7" />
+        </div>
+        <h2 className="text-foreground text-base font-bold">채팅방을 찾지 못했습니다</h2>
+        <p className="text-muted-foreground mt-1.5 text-sm leading-relaxed">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/search/chat-search-section.tsx
+++ b/src/components/search/chat-search-section.tsx
@@ -1,0 +1,69 @@
+// 채팅 검색 결과를 섹션 단위로 렌더링합니다.
+import ChatRoomCard from "@/components/chat/chat-room-card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import type { ChatSearchResult } from "@/types/search";
+import { ChevronDown, Loader2 } from "lucide-react";
+
+interface Props {
+  title: string;
+  description: string;
+  results: ChatSearchResult[];
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  onLoadMore: () => void;
+}
+
+export default function ChatSearchSection({
+  title,
+  description,
+  results,
+  hasMore,
+  isFetchingMore,
+  onLoadMore,
+}: Props) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1 px-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-foreground text-xl font-bold">{title}</h2>
+          </div>
+          <p className="text-muted-foreground text-sm">{description}</p>
+        </div>
+      </div>
+
+      <div className={cn("grid grid-cols-1 gap-3", "sm:grid-cols-2 xl:grid-cols-4")}>
+        {results.map((room) => (
+          <ChatRoomCard key={`${room.section}-${room.id}`} chatRoom={room} />
+        ))}
+      </div>
+
+      {hasMore && (
+        <div className="flex items-center gap-4 pt-1">
+          <Separator className="flex-1" />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onLoadMore}
+            disabled={isFetchingMore}
+            className={cn(
+              "h-9 rounded-full border px-4 text-xs font-bold",
+              "border-border bg-background text-muted-foreground shadow-sm",
+              "hover:border-brand/40 hover:text-brand",
+            )}
+          >
+            {isFetchingMore ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+            더보기
+          </Button>
+          <Separator className="flex-1" />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+// Header에서 검색어를 입력받아 검색 페이지로 이동합니다.
+import SearchInput from "@/components/search/search-input";
+import { useMainMenuStore } from "@/stores/main-menu";
+import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
+  const searchParams = new URLSearchParams({ query });
+
+  if (activeMenu === "live") {
+    return `/search/live?${searchParams.toString()}`;
+  }
+
+  return `/search/chat?${searchParams.toString()}`;
+}
+
+export default function HeaderSearchForm() {
+  const router = useRouter();
+  const activeMenu = useMainMenuStore((state) => state.activeMenu);
+  const [query, setQuery] = useState("");
+  const isLiveSearchDisabled = activeMenu === "live";
+
+  const handleSearch = () => {
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery || isLiveSearchDisabled) {
+      return;
+    }
+
+    router.push(resolveSearchPath(activeMenu, trimmedQuery));
+    setQuery("");
+  };
+
+  return (
+    <SearchInput
+      value={query}
+      onChange={setQuery}
+      onSubmit={handleSearch}
+      placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
+      disabled={isLiveSearchDisabled}
+      className="order-3 mt-2 w-full basis-full sm:order-0 sm:mt-0 sm:w-48 sm:basis-auto md:w-64"
+    />
+  );
+}

--- a/src/components/search/search-input.tsx
+++ b/src/components/search/search-input.tsx
@@ -1,0 +1,52 @@
+// 검색어 입력에 사용하는 공통 입력 UI를 렌더링합니다.
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { Search } from "lucide-react";
+import type { FormEvent } from "react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+export default function SearchInput({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = "검색어를 입력하세요",
+  className,
+  disabled = false,
+}: Props) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={cn("relative w-full", className)}>
+      <Search
+        className={cn(
+          "text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2",
+          disabled && "opacity-50",
+        )}
+      />
+      <Input
+        type="search"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className={cn(
+          "h-9 rounded-full pr-3 pl-9 text-sm",
+          "bg-background/80 border-brand/20 focus-visible:border-brand/50 focus-visible:ring-brand/30",
+          "dark:border-border dark:bg-background/70",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+        )}
+      />
+    </form>
+  );
+}

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -15,5 +15,7 @@ export const QUERY_KEYS = {
     room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
     messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),
     members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter(Boolean),
+    search: (query?: string, section?: string) =>
+      [...QUERY_KEYS.chat.all, "search", query, section].filter(Boolean),
   },
 } as const;

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,0 +1,1 @@
+export const CHAT_SEARCH_RESULT_LIMIT = 8;

--- a/src/hooks/use-chat-room-search.ts
+++ b/src/hooks/use-chat-room-search.ts
@@ -1,0 +1,51 @@
+"use client";
+
+// 채팅방 검색 결과를 Supabase RPC로 조회합니다.
+import { QUERY_KEYS } from "@/constants/query-keys";
+import { CHAT_SEARCH_RESULT_LIMIT } from "@/constants/search";
+import { createClient } from "@/lib/supabase/client";
+import type { ChatSearchResult, ChatSearchSection } from "@/types/search";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+function isChatSearchSection(section: string): section is ChatSearchSection {
+  return section === "title" || section === "owner";
+}
+
+function isChatSearchResult(result: { section: string }): result is ChatSearchResult {
+  return isChatSearchSection(result.section);
+}
+
+async function fetchChatRoomSearchResults(
+  query: string,
+  section: ChatSearchSection,
+  offset: number,
+): Promise<ChatSearchResult[]> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase.rpc("search_chat_rooms", {
+    p_query: query,
+    p_limit: CHAT_SEARCH_RESULT_LIMIT,
+    p_section: section,
+    p_offset: offset,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).filter(isChatSearchResult);
+}
+
+export function useChatRoomSearch(query: string, section: ChatSearchSection) {
+  const trimmedQuery = query.trim();
+
+  return useInfiniteQuery<ChatSearchResult[]>({
+    queryKey: QUERY_KEYS.chat.search(trimmedQuery, section),
+    queryFn: ({ pageParam }) =>
+      fetchChatRoomSearchResults(trimmedQuery, section, Number(pageParam)),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.at(-1)?.has_more ? allPages.length * CHAT_SEARCH_RESULT_LIMIT : undefined,
+    enabled: trimmedQuery.length > 0,
+  });
+}

--- a/src/stores/main-menu.ts
+++ b/src/stores/main-menu.ts
@@ -1,0 +1,22 @@
+// 메인 메뉴의 활성 상태를 전역에서 공유합니다.
+import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface MainMenuState {
+  activeMenu: MainMenuSidebarKey;
+  setActiveMenu: (activeMenu: MainMenuSidebarKey) => void;
+}
+
+export const useMainMenuStore = create<MainMenuState>()(
+  devtools(
+    (set) => ({
+      activeMenu: "chat",
+      setActiveMenu: (activeMenu) => set({ activeMenu }, false, "mainMenu/setActiveMenu"),
+    }),
+    {
+      name: "MainMenuStore",
+      enabled: process.env.NODE_ENV !== "production",
+    },
+  ),
+);

--- a/src/types/chat-room.ts
+++ b/src/types/chat-room.ts
@@ -6,5 +6,10 @@ export type ChatRoomTab = "JOINED" | "NOT_JOINED" | "OWNED";
 
 export type ChatRoom = GenericTables<"chat_room">;
 
+export type ChatRoomCardData = Pick<
+  ChatRoomByTab,
+  "id" | "title" | "description" | "owner_nickname" | "current_member" | "max_capacity" | "created_at"
+>;
+
 // 모든 탭 키가 항상 존재하는 타입 (로딩 중 여부는 쿼리 반환값 자체가 undefined인지로 판단)
 export type ChatRoomCounts = Record<ChatRoomTab, number>;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -215,6 +215,28 @@ export type Database = {
           title: string
         }[]
       }
+      leave_chat_room: { Args: { p_room_id: string }; Returns: undefined }
+      mark_room_read: { Args: { p_room_id: string }; Returns: undefined }
+      search_chat_rooms: {
+        Args: {
+          p_limit?: number
+          p_offset?: number
+          p_query: string
+          p_section?: string
+        }
+        Returns: {
+          created_at: string
+          current_member: number
+          description: string
+          has_more: boolean
+          id: string
+          max_capacity: number
+          owner_id: string
+          owner_nickname: string
+          section: string
+          title: string
+        }[]
+      }
     }
     Enums: {
       gender: "male" | "female" | "none"

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,11 @@
+// 검색 화면과 검색 결과 타입을 정의합니다.
+import type { Database } from "@/types/database.types";
+
+export type SearchScope = "chat" | "live";
+export type ChatSearchSection = "title" | "owner";
+
+type ChatSearchRow = Database["public"]["Functions"]["search_chat_rooms"]["Returns"][number];
+
+export type ChatSearchResult = Omit<ChatSearchRow, "section"> & {
+  section: ChatSearchSection;
+};


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/search/#36 -> dev

### ✅ 작업 내용 `기능 추가`

- Header 검색 입력 컴포넌트와 /search/chat?query= 검색 결과 페이지를 추가했습니다.
- 채팅방 제목과 방장 닉네임 기준 검색 결과를 섹션별로 표시하도록 구성했습니다.
- 검색 결과는 섹션별 8개씩 조회하고 더보기로 추가 로드되도록 구현했습니다.
- 메인 메뉴 active 상태를 Zustand로 분리해 Header 검색 분기에서 사용할 수 있게 했습니다.
- Supabase RPC search_chat_rooms를 추가하고 타입을 갱신했습니다.

### 🎯 단독 테스트 결과

- npm run build 통과.
- Supabase RPC 직접 호출로 검색 결과 조회와 더보기 offset 중복 없음 확인.
- QA용 검색 제목 테스트 01부터 검색 제목 테스트 30 채팅방 생성 후 /search/chat?query=테스트에서 더보기 테스트 완료

### 🚨 연관 이슈

closes #36