### PR TITLE
Feat/chat/message zod/#51 메시지 길이 제한

### DIFF
--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -7,8 +7,10 @@ import { toast } from "sonner";
 import ChatEmojiPicker from "@/components/chat/chat-emoji-picker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MESSAGE_CONTENT_MAX_LENGTH } from "@/constants/message";
 import { ERROR_MESSAGES } from "@/constants/errors";
 import { createClient } from "@/lib/supabase/client";
+import { messageContentSchema } from "@/lib/zod/message";
 
 interface Props {
   roomId: string;
@@ -23,17 +25,25 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   const sendMessageLockRef = useRef(false);
 
   const handleSend = async () => {
-    const trimmed = draft.trim();
-    if (!trimmed || sendMessageLockRef.current || !currentUserId || !roomId) {
+    if (sendMessageLockRef.current || !currentUserId || !roomId) {
       return;
     }
+
+    const parsed = messageContentSchema.safeParse(draft);
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      toast.error(first?.message ?? "입력값을 확인해주세요.");
+      return;
+    }
+
+    const content = parsed.data;
 
     sendMessageLockRef.current = true;
 
     const { error } = await supabase.from("message").insert({
       chat_room_id: roomId,
       user_id: currentUserId,
-      content: trimmed,
+      content,
     });
 
     if (error) {
@@ -54,13 +64,18 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
     <div className="border-border bg-background/95 flex shrink-0 gap-2 border-t p-2 backdrop-blur-sm">
       <ChatEmojiPicker
         disabled={disabled}
-        onEmojiSelect={(emoji) => setDraft((prev) => prev + emoji)}
+        onEmojiSelect={(emoji) =>
+          setDraft((prev) => (prev + emoji).slice(0, MESSAGE_CONTENT_MAX_LENGTH))
+        }
       />
       <Input
         value={draft}
         disabled={disabled}
+        maxLength={MESSAGE_CONTENT_MAX_LENGTH}
         title={disabled ? disabledHint : undefined}
-        onChange={(e) => setDraft(e.target.value)}
+        onChange={(e) =>
+          setDraft(e.target.value.slice(0, MESSAGE_CONTENT_MAX_LENGTH))
+        }
         onKeyDown={(e) => {
           if (disabled) return;
           if (e.key === "Enter" && !e.shiftKey) {

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,1 +1,4 @@
+/** DB `message.content` 제약과 일치하는지 필요 시 확인한다. */
+export const MESSAGE_CONTENT_MAX_LENGTH = 2000;
+
 export const MESSAGE_PAGE_SIZE = 20;

--- a/src/lib/zod/message.ts
+++ b/src/lib/zod/message.ts
@@ -1,0 +1,13 @@
+// 채팅 메시지 본문(content) 입력 검증 스키마를 정의한다.
+import { z } from "zod";
+
+import { MESSAGE_CONTENT_MAX_LENGTH } from "@/constants/message";
+
+export const messageContentSchema = z
+  .string()
+  .trim()
+  .min(1, "메시지를 입력해주세요.")
+  .max(
+    MESSAGE_CONTENT_MAX_LENGTH,
+    `메시지는 ${MESSAGE_CONTENT_MAX_LENGTH}자 이하로 입력해주세요.`,
+  );


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/chat/message zod/#51 -> dev

### ✅ 작업 내용 `기능 추가`


- 빈 메시지 보낼시 toast 알림
- 2000자 이상 길이의 문자 제한

### 🎯 단독 테스트 결과


- 2000자 이상의 메시지는 처음 2000자만 적용 
- 빈 메시지는 toast로 알림이 뜸

### 🚨 연관 이슈

closes #51 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 메시지 입력 최대 길이가 2,000자로 제한되었습니다.
  * 입력 필드에서 문자 길이를 자동으로 제한하여 범위를 초과한 입력을 방지합니다.
  * 유효하지 않은 메시지는 전송되지 않으며, 오류 메시지가 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->