### PR TITLE
style(#57): 반응형 QA 및 Tailwind 컨벤션 정리

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,7 +38,7 @@ reviews:
 knowledge_base:
   code_guidelines:
     enabled: true
-    file_patterns:
+    filePatterns:
       - "AGENTS.md"
       - ".agents/code-convention/*.md"
       - ".agents/design-convention/*.md"
@@ -51,4 +51,5 @@ chat:
   auto_reply: true
 
 issue_enrichment:
-  enabled: true
+  auto_enrich:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,13 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: "ko-KR"
-enable_beta_features: false
 
 reviews:
   profile: "assertive"
   request_changes_workflow: false
   high_level_summary: true
   poem: false
-  
+
   # 폴더별 SRP(단일 책임 원칙) 컨벤션 적용
   path_instructions:
     - path: "src/actions/**/*.ts"
@@ -50,12 +49,6 @@ knowledge_base:
 
 chat:
   auto_reply: true
-
-tools:
-  shellcheck:
-    enabled: true
-  ast-grep:
-    enabled: true
 
 issue_enrichment:
   enabled: true

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=ftvoynnfpfzmblgrntqj"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,3 +1,5 @@
+// 설정 페이지 레이아웃 - SettingsShell로 사이드바와 콘텐츠 영역 구성
+
 import { SettingShell } from "@/components/setting/setting-shell";
 import { ReactNode } from "react";
 

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,14 +1,6 @@
-import SettingSidebar from "@/components/setting/setting-sidebar";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { SettingsShell } from "@/components/setting/settings-shell";
 import { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return (
-    <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
-      <SettingSidebar />
-      <SidebarInset className="min-w-0 overflow-hidden">
-        <div className="h-full min-w-0 overflow-auto p-6 md:p-10">{children}</div>
-      </SidebarInset>
-    </SidebarProvider>
-  );
+  return <SettingsShell>{children}</SettingsShell>;
 }

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,6 +1,6 @@
-import { SettingsShell } from "@/components/setting/settings-shell";
+import { SettingShell } from "@/components/setting/setting-shell";
 import { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return <SettingsShell>{children}</SettingsShell>;
+  return <SettingShell>{children}</SettingShell>;
 }

--- a/src/app/auth/complete-profile/page.tsx
+++ b/src/app/auth/complete-profile/page.tsx
@@ -29,7 +29,7 @@ export default async function Page() {
     <div className="container m-auto">
       <div className="border-brand/20 bg-card/80 m-auto max-w-md rounded-2xl border-2 p-8 shadow-[0_0_30px_#46c6a90a] backdrop-blur-sm dark:shadow-[0_0_60px_#46c6a918]">
         <div className="mb-6 flex flex-col items-center gap-4">
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <div className="flex flex-col items-center gap-1 text-center">
             <p className="text-xs tracking-widest uppercase">추가 정보 입력</p>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
         )}
       >
         <div className="mb-4 flex flex-col items-center gap-3 sm:mb-6 sm:gap-4">
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <p className="text-xs tracking-widest uppercase">로그인</p>
         </div>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
         )}
       >
         <div className={cn("mb-4 flex flex-col items-center gap-3", "sm:mb-6 sm:gap-4")}>
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <p className="text-xs tracking-widest uppercase">회원가입</p>
         </div>

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -7,7 +7,7 @@ export default function ChatLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex h-[calc(100dvh-11rem)] max-h-[calc(100dvh-11rem)] min-h-0 w-full flex-col overflow-hidden md:h-[calc(100dvh-12rem)] md:max-h-[calc(100dvh-12rem)]">
+    <div className="h-app-content min-h-0 w-full overflow-hidden">
       {children}
     </div>
   );

--- a/src/components/auth/auth-listener.tsx
+++ b/src/components/auth/auth-listener.tsx
@@ -8,6 +8,7 @@ import { QUERY_KEYS } from "@/constants/query-keys";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { toastAppError } from "@/utils/toast-message";
 import type { LoginProvider } from "@/types/auth";
+import { toast } from "sonner";
 
 /**
  * 앱 루트에서 1회 마운트되어 Supabase Auth 상태를 Zustand store(AuthUser)에 동기화.

--- a/src/components/auth/complete-profile/complete-profile-abandon-alert.tsx
+++ b/src/components/auth/complete-profile/complete-profile-abandon-alert.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { LogOut } from "lucide-react";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
 import { useAuthStore } from "@/stores/auth";

--- a/src/components/chat/chat-emoji-picker.tsx
+++ b/src/components/chat/chat-emoji-picker.tsx
@@ -45,12 +45,13 @@ export default function ChatEmojiPicker({ onEmojiSelect, disabled = false }: Pro
           <Button
             {...props}
             type="button"
-            size="icon-sm"
-            variant="secondary"
+            size="icon-lg"
+            variant="ghost"
             aria-label="이모지 선택"
             disabled={disabled}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
           >
-            <Smile className="size-4" />
+            <Smile className="size-5" />
           </Button>
         )}
       />

--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -43,14 +43,14 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
           <span
             className={cn(
               "text-muted-foreground shrink-0 font-medium tracking-tight",
-              "text-[11px]",
+              "text-xs",
             )}
           >
             @{chatRoom.owner_nickname}
           </span>
         </div>
         {chatRoom.description && (
-          <p className={cn("text-muted-foreground line-clamp-1 leading-relaxed", "text-[11px]")}>
+          <p className={cn("text-muted-foreground line-clamp-1 leading-relaxed", "text-xs")}>
             {chatRoom.description}
           </p>
         )}
@@ -74,7 +74,7 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
             <Users className="text-muted-foreground h-3 w-3" />
             <span
               className={cn(
-                "font-mono text-[11px] font-semibold",
+                "font-mono text-xs font-semibold",
                 isFull ? "text-live" : "text-brand",
               )}
             >
@@ -101,7 +101,7 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
         </div>
         <div className="flex items-center gap-1">
           <Clock className="text-muted-foreground/50 h-2.5 w-2.5" />
-          <span className="text-muted-foreground/70 text-[11px] whitespace-nowrap">
+          <span className="text-muted-foreground/70 whitespace-nowrap text-xs">
             생성일 {formatRoomDate(chatRoom.created_at)}
           </span>
         </div>

--- a/src/components/chat/chat-room-menu.tsx
+++ b/src/components/chat/chat-room-menu.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from "react";
 
-import { DoorOpen, MoreVertical } from "lucide-react";
+import { Ellipsis } from "lucide-react";
 
 import { ChatRoomLeaveAlertDialog } from "@/components/chat/chat-room-leave-alert-dialog";
 import { Button } from "@/components/ui/button";
@@ -69,11 +69,11 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
               {...props}
               type="button"
               variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground hover:text-foreground shrink-0"
+              size="icon-lg"
+              className="hover:text-foreground shrink-0"
               aria-label="채팅방 메뉴"
             >
-              <MoreVertical data-icon="inline-start" />
+              <Ellipsis data-icon="inline-start" />
             </Button>
           )}
         />
@@ -108,7 +108,6 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
         isPending={isPending}
         onConfirmLeave={handleLeave}
       />
-      
     </>
   );
 }

--- a/src/components/chat/chat-room-menu.tsx
+++ b/src/components/chat/chat-room-menu.tsx
@@ -69,7 +69,7 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
               {...props}
               type="button"
               variant="ghost"
-              size="icon-xs"
+              size="icon-sm"
               className="text-muted-foreground hover:text-foreground shrink-0"
               aria-label="채팅방 메뉴"
             >

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -98,7 +98,7 @@ export function ChatRoom({ roomId }: Props) {
       </div>
 
       <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
-        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2.5">
+        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -10,11 +10,7 @@ import { KickedRoomAlertDialog } from "@/components/member/kicked-room-alert-dia
 import { MessageInput } from "@/components/message/message-input";
 import { MessageList } from "@/components/message/message-list";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
@@ -98,6 +94,7 @@ export function ChatRoom({ roomId }: Props) {
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+      {/* PC: 좌측 고정 사이드바 */}
       <div className="hidden shrink-0 md:flex">
         <MemberList
           roomId={roomId}
@@ -107,20 +104,22 @@ export function ChatRoom({ roomId }: Props) {
       </div>
 
       <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
+        {/* 헤더 — py-3으로 MemberList 헤더와 높이 맞춤 */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-3">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-0.5">
+          <div className="flex shrink-0 items-center gap-1">
+            {/* 모바일: Sheet 열기 / PC: 시각적 표시 */}
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+              className="h-9 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground md:pointer-events-none md:cursor-default"
               onClick={() => setMembersSheetOpen(true)}
               aria-label="참여자 목록"
             >
-              <Users className="size-3.5" />
-              <span className="text-xs font-medium">{members.length}</span>
+              <Users className="size-4" />
+              <span className="text-sm font-medium">{members.length}</span>
             </Button>
             {roomQuery.data ? (
               <ChatRoomMenu
@@ -156,6 +155,7 @@ export function ChatRoom({ roomId }: Props) {
         />
       </section>
 
+      {/* 모바일 전용 Sheet */}
       <Sheet open={membersSheetOpen} onOpenChange={setMembersSheetOpen}>
         <SheetContent side="right" className="flex w-80 flex-col gap-0 p-0">
           <SheetTitle className="sr-only">참여자 목록</SheetTitle>
@@ -163,7 +163,7 @@ export function ChatRoom({ roomId }: Props) {
             roomId={roomId}
             currentUserId={currentUserId}
             ownerId={roomQuery.data?.owner_id}
-            className="h-full max-h-none w-full border-r-0 md:h-full md:w-full md:border-r-0"
+            className="h-full max-h-none w-full border-r-0 md:w-full md:border-r-0"
           />
         </SheetContent>
       </Sheet>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -30,7 +30,7 @@ function ChatRoomError({ code }: { code: AppMessageCode }) {
   const message = getAppMessage(code);
 
   return (
-    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background px-4 text-center text-foreground">
+    <div className="bg-background text-foreground flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 text-center">
       <p className="text-sm">{message.title}</p>
       <Link href="/" className="text-sm underline">
         처음으로
@@ -74,7 +74,7 @@ export function ChatRoom({ roomId }: Props) {
 
   if (profilePending) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-background">
+      <div className="bg-background flex h-full w-full items-center justify-center">
         <Spinner className="text-muted-foreground size-8" />
       </div>
     );
@@ -93,7 +93,7 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+    <div className="bg-background text-foreground flex h-full min-h-0 w-full overflow-hidden md:flex-row">
       {/* PC: 좌측 고정 사이드바 */}
       <div className="hidden shrink-0 md:flex">
         <MemberList
@@ -103,18 +103,17 @@ export function ChatRoom({ roomId }: Props) {
         />
       </div>
 
-      <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-        {/* 헤더 — py-3으로 MemberList 헤더와 높이 맞춤 */}
-        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-3">
+      <section className="bg-background flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="border-border/50 bg-muted/20 flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1.5">
             {/* 모바일: Sheet 열기 / PC: 시각적 표시 */}
             <Button
               variant="ghost"
-              size="sm"
-              className="h-9 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground md:pointer-events-none md:cursor-default"
+              size={"icon-lg"}
+              className="gap-1.5 md:pointer-events-none md:cursor-default"
               onClick={() => setMembersSheetOpen(true)}
               aria-label="참여자 목록"
             >

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -26,7 +26,7 @@ function ChatRoomError({ code }: { code: AppMessageCode }) {
   const message = getAppMessage(code);
 
   return (
-    <div className="dark flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-zinc-950 px-4 text-center text-zinc-200">
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background px-4 text-center text-foreground">
       <p className="text-sm">{message.title}</p>
       <Link href="/" className="text-sm underline">
         처음으로
@@ -69,7 +69,7 @@ export function ChatRoom({ roomId }: Props) {
 
   if (profilePending) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-zinc-950">
+      <div className="flex h-full w-full items-center justify-center bg-background">
         <Spinner className="text-muted-foreground size-8" />
       </div>
     );
@@ -88,14 +88,14 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="dark text-foreground flex h-full min-h-0 w-full flex-col overflow-hidden bg-zinc-950 md:flex-row">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background text-foreground md:flex-row">
       <MemberList
         roomId={roomId}
         currentUserId={currentUserId}
         ownerId={roomQuery.data?.owner_id}
       />
 
-      <aside className="bg-background flex min-h-0 flex-1 flex-col border-white/10 md:w-[min(100%,380px)] md:shrink-0 md:border-l">
+      <aside className="flex min-h-0 flex-1 flex-col border-border bg-background md:w-[min(100%,380px)] md:shrink-0 md:border-l">
         <header className="border-border shrink-0 border-b px-3 py-2.5">
           <div className="flex items-start justify-between gap-2">
             <h1 className="line-clamp-2 flex-1 text-sm leading-tight font-semibold">
@@ -113,7 +113,7 @@ export function ChatRoom({ roomId }: Props) {
               ) : null}
             </div>
           </div>
-          <p className="text-muted-foreground mt-1 line-clamp-1 text-[11px]">
+          <p className="text-muted-foreground mt-1 line-clamp-1 text-xs">
             {roomQuery.data?.description ?? ""}
           </p>
         </header>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -97,7 +97,7 @@ export function ChatRoom({ roomId }: Props) {
         />
       </div>
 
-      <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
         <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -88,35 +88,32 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background text-foreground md:flex-row">
-      <MemberList
-        roomId={roomId}
-        currentUserId={currentUserId}
-        ownerId={roomQuery.data?.owner_id}
-      />
+    <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+      <div className="hidden md:flex">
+        <MemberList
+          roomId={roomId}
+          currentUserId={currentUserId}
+          ownerId={roomQuery.data?.owner_id}
+        />
+      </div>
 
-      <aside className="flex min-h-0 flex-1 flex-col border-border bg-background md:w-[min(100%,380px)] md:shrink-0 md:border-l">
-        <header className="border-border shrink-0 border-b px-3 py-2.5">
-          <div className="flex items-start justify-between gap-2">
-            <h1 className="line-clamp-2 flex-1 text-sm leading-tight font-semibold">
-              {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
-            </h1>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-muted-foreground text-xs">{members.length}명</span>
-              {roomQuery.data ? (
-                <ChatRoomMenu
-                  roomId={roomId}
-                  ownerId={roomQuery.data.owner_id}
-                  currentMember={roomQuery.data.current_member}
-                  currentUserId={currentUserId}
-                />
-              ) : null}
-            </div>
+      <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
+        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2.5">
+          <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
+            {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
+          </h1>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span className="text-muted-foreground text-xs">{members.length}명</span>
+            {roomQuery.data ? (
+              <ChatRoomMenu
+                roomId={roomId}
+                ownerId={roomQuery.data.owner_id}
+                currentMember={roomQuery.data.current_member}
+                currentUserId={currentUserId}
+              />
+            ) : null}
           </div>
-          <p className="text-muted-foreground mt-1 line-clamp-1 text-xs">
-            {roomQuery.data?.description ?? ""}
-          </p>
-        </header>
+        </div>
 
         <MessageList
           key={roomId}
@@ -139,7 +136,7 @@ export function ChatRoom({ roomId }: Props) {
             ).title
           }
         />
-      </aside>
+      </section>
 
       <KickedRoomAlertDialog open={isKicked} />
     </div>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
+import { Users } from "lucide-react";
 
 import { ChatRoomMenu } from "@/components/chat/chat-room-menu";
 import { MemberList } from "@/components/member/member-list";
 import { KickedRoomAlertDialog } from "@/components/member/kicked-room-alert-dialog";
 import { MessageInput } from "@/components/message/message-input";
 import { MessageList } from "@/components/message/message-list";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
@@ -41,11 +49,12 @@ export function ChatRoom({ roomId }: Props) {
     useMessages(roomId);
 
   const roomQuery = useRoom(roomId);
-
   const { data: members = [] } = useRoomMembers(roomId);
 
   const currentUserId = profile?.id ?? "";
   const { isKicked } = useChatRoomMemberRealtime({ roomId, currentUserId });
+
+  const [membersSheetOpen, setMembersSheetOpen] = useState(false);
 
   const markRoomReadEnabled =
     !!roomId &&
@@ -89,7 +98,7 @@ export function ChatRoom({ roomId }: Props) {
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
-      <div className="hidden md:flex">
+      <div className="hidden shrink-0 md:flex">
         <MemberList
           roomId={roomId}
           currentUserId={currentUserId}
@@ -102,8 +111,17 @@ export function ChatRoom({ roomId }: Props) {
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-1.5">
-            <span className="text-muted-foreground text-xs">{members.length}명</span>
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+              onClick={() => setMembersSheetOpen(true)}
+              aria-label="참여자 목록"
+            >
+              <Users className="size-3.5" />
+              <span className="text-xs font-medium">{members.length}</span>
+            </Button>
             {roomQuery.data ? (
               <ChatRoomMenu
                 roomId={roomId}
@@ -137,6 +155,18 @@ export function ChatRoom({ roomId }: Props) {
           }
         />
       </section>
+
+      <Sheet open={membersSheetOpen} onOpenChange={setMembersSheetOpen}>
+        <SheetContent side="right" className="flex w-80 flex-col gap-0 p-0">
+          <SheetTitle className="sr-only">참여자 목록</SheetTitle>
+          <MemberList
+            roomId={roomId}
+            currentUserId={currentUserId}
+            ownerId={roomQuery.data?.owner_id}
+            className="h-full max-h-none w-full border-r-0 md:h-full md:w-full md:border-r-0"
+          />
+        </SheetContent>
+      </Sheet>
 
       <KickedRoomAlertDialog open={isKicked} />
     </div>

--- a/src/components/chat/create-chat-room-dialog.tsx
+++ b/src/components/chat/create-chat-room-dialog.tsx
@@ -71,7 +71,13 @@ export default function CreateChatRoomDialog() {
         <Plus className="h-4 w-4" />
         채팅방 만들기
       </DialogTrigger>
-      <DialogContent className="border-brand/20 shadow-brand/10 dark:border-brand/10 max-w-md gap-0 overflow-hidden rounded-2xl p-0 shadow-xl">
+      <DialogContent
+        className={cn(
+          "max-w-md gap-0 overflow-hidden rounded-2xl p-0 shadow-xl",
+          "border-brand/20 shadow-brand/10",
+          "dark:border-brand/10",
+        )}
+      >
         <DialogHeader className="bg-brand/5 border-brand/10 border-b px-5 pt-5 pb-4">
           <div className="flex items-center gap-3">
             <span className="bg-brand/10 text-brand ring-brand/20 flex size-10 shrink-0 items-center justify-center rounded-xl ring-1">

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -30,7 +30,7 @@ export default async function Header() {
     >
       <div className="flex flex-wrap items-center justify-between px-3 py-2 sm:flex-nowrap sm:px-5">
         <Link href="/" className="h-10 w-32 sm:w-40">
-          <Logo className="dark:text-foreground h-full w-full text-[#1e1d37]" />
+          <Logo className="h-full w-full text-foreground" />
         </Link>
 
         <div className="flex items-center gap-3 sm:gap-5">

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -28,12 +28,12 @@ export default async function Header() {
         "dark:border-border dark:bg-muted/60", // 다크 모드 톤다운 조합
       )}
     >
-      <div className="flex flex-wrap items-center justify-between px-3 py-2 sm:flex-nowrap sm:px-5">
-        <Link href="/" className="h-10 w-32 sm:w-40">
+      <div className="flex h-14 items-center justify-between px-3 sm:px-5">
+        <Link href="/" className="h-9 w-28 shrink-0 sm:w-36">
           <Logo className="h-full w-full text-foreground" />
         </Link>
 
-        <div className="flex items-center gap-3 sm:gap-5">
+        <div className="flex items-center gap-2 sm:gap-3">
           {user && hasProfile && <HeaderSearchForm />}
           <ThemeToggleButton />
           {user && hasProfile && <HeaderProfileBadge />}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,3 +1,5 @@
+// 애플리케이션 헤더 - 로고, 검색, 테마 전환, 프로필 배지 표시
+
 import LoginButton from "@/components/auth/login-button";
 import Logo from "@/components/common/logo";
 import ThemeToggleButton from "@/components/common/theme-toggle-button";
@@ -30,7 +32,7 @@ export default async function Header() {
     >
       <div className="flex h-14 items-center justify-between px-3 sm:px-5">
         <Link href="/" className="h-9 w-28 shrink-0 sm:w-36">
-          <Logo className="h-full w-full text-foreground" />
+          <Logo className="text-foreground h-full w-full" />
         </Link>
 
         <div className="flex items-center gap-2 sm:gap-3">

--- a/src/components/common/main-menu-sidebar.tsx
+++ b/src/components/common/main-menu-sidebar.tsx
@@ -57,11 +57,11 @@ export default function MainMenuSidebar() {
     <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
       <Sidebar
         collapsible={isMobile ? "offcanvas" : "none"}
-        className="bg-background h-full shrink-0 border-r border-zinc-200 dark:border-zinc-800/50"
+        className="h-full shrink-0 border-r border-border bg-background"
       >
         <SidebarContent>
           <SidebarGroup className="p-4 pt-5">
-            <SidebarGroupLabel className="mb-3 px-2 text-xs font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+            <SidebarGroupLabel className="mb-3 px-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
               메뉴
             </SidebarGroupLabel>
             <SidebarGroupContent>
@@ -73,7 +73,7 @@ export default function MainMenuSidebar() {
 
       <SidebarInset>
         {isMobile && (
-          <div className="flex shrink-0 items-center gap-3 border-b border-zinc-200 p-4 dark:border-zinc-800/50">
+          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
             <SidebarTrigger className="cursor-pointer" />
             <span className="text-foreground text-sm font-semibold">
               {MAIN_MENU_SIDEBAR_ITEMS.find((item) => item.key === activeMenu)?.label}

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,7 +18,7 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/40">
+      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5">
         <Avatar size="sm" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,14 +18,12 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5">
-        <Avatar size="sm" className="shrink-0">
+      <div className="flex w-full items-center gap-3 rounded-md px-3 py-2">
+        <Avatar size="default" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>
         </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">
-          {nickname}
-        </span>
+        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
       </div>
     );
   }
@@ -34,15 +32,13 @@ export function MemberItem({ roomId, member, canManage }: Props) {
     <MemberActionPopover roomId={roomId} member={member}>
       <Button
         variant="ghost"
-        className="flex h-auto w-full items-center gap-2.5 justify-start rounded-md px-2 py-1.5 font-normal transition-colors"
+        className="flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors"
       >
-        <Avatar size="sm" className="shrink-0">
+        <Avatar size="default" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>
         </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">
-          {nickname}
-        </span>
+        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
       </Button>
     </MemberActionPopover>
   );

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,7 +18,7 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 px-2 py-1.5 text-left transition-colors">
+      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/40">
         <Avatar size="sm" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -13,7 +13,7 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
   const canManageMembers = !!currentUserId && currentUserId === ownerId;
 
   return (
-    <section className="bg-background flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-white/10 md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
+    <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
       <header className="border-border shrink-0 border-b px-3 py-2.5">
         <h2 className="text-sm leading-tight font-semibold">
           참여자 목록 {members.length.toLocaleString("ko-KR")}명

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -14,7 +14,7 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
 
   return (
     <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
-      <div className="border-border flex shrink-0 items-center border-b px-3 py-2.5">
+      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
         <span className="text-muted-foreground text-xs font-medium">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -1,4 +1,5 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import { MemberItem } from "./member-item";
 import { useRoomMembers } from "@/hooks/use-room-members";
 
@@ -6,16 +7,23 @@ interface Props {
   roomId: string;
   currentUserId: string;
   ownerId?: string;
+  className?: string;
 }
 
-export function MemberList({ roomId, currentUserId, ownerId }: Props) {
+export function MemberList({ roomId, currentUserId, ownerId, className }: Props) {
   const { data: members = [] } = useRoomMembers(roomId);
   const canManageMembers = !!currentUserId && currentUserId === ownerId;
 
   return (
-    <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
+    <section
+      className={cn(
+        "flex min-h-0 shrink-0 flex-col overflow-hidden bg-background",
+        "md:h-full md:w-80 md:shrink-0 md:border-r md:border-border",
+        className,
+      )}
+    >
       <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
-        <span className="text-muted-foreground text-xs font-medium">
+        <span className="text-xs font-medium text-muted-foreground">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>
       </div>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -14,11 +14,11 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
 
   return (
     <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
-      <header className="border-border shrink-0 border-b px-3 py-2.5">
-        <h2 className="text-sm leading-tight font-semibold">
-          참여자 목록 {members.length.toLocaleString("ko-KR")}명
-        </h2>
-      </header>
+      <div className="border-border flex shrink-0 items-center border-b px-3 py-2.5">
+        <span className="text-muted-foreground text-xs font-medium">
+          참여자 {members.length.toLocaleString("ko-KR")}명
+        </span>
+      </div>
 
       <ScrollArea className="min-h-0 flex-1">
         <ul className="py-1" role="list">

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -17,16 +17,13 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
   return (
     <section
       className={cn(
-        "flex min-h-0 shrink-0 flex-col overflow-hidden bg-background",
-        "md:h-full md:w-80 md:shrink-0 md:border-r md:border-border",
+        "bg-background flex min-h-0 shrink-0 flex-col overflow-hidden",
+        "md:border-border md:h-full md:w-80 md:shrink-0 md:border-r",
         className,
       )}
     >
-      {/* py-3 + text-sm → 채팅 섹션 헤더와 동일 높이 */}
-      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-3">
-        <span className="text-sm font-medium text-muted-foreground">
-          참여자 {members.length.toLocaleString("ko-KR")}명
-        </span>
+      <div className="border-border/50 bg-muted/20 flex h-14 shrink-0 items-center border-b px-4">
+        <span className="text-sm font-medium">채팅방 참여 인원</span>
       </div>
 
       <ScrollArea className="min-h-0 flex-1">

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -22,14 +22,15 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
         className,
       )}
     >
-      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
-        <span className="text-xs font-medium text-muted-foreground">
+      {/* py-3 + text-sm → 채팅 섹션 헤더와 동일 높이 */}
+      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-3">
+        <span className="text-sm font-medium text-muted-foreground">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <ul className="py-1" role="list">
+        <ul className="py-1.5" role="list">
           {members.map((member) => (
             <li key={`${member.chat_room_id}-${member.user_id}`}>
               <MemberItem

--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -60,7 +60,7 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   };
 
   return (
-    <div className="border-border bg-background/95 flex shrink-0 gap-2 border-t p-2 backdrop-blur-sm">
+    <div className="border-border bg-background/95 flex shrink-0 items-center gap-2 border-t px-3 py-2 backdrop-blur-sm">
       <ChatEmojiPicker
         disabled={disabled}
         onEmojiSelect={(emoji) =>
@@ -85,19 +85,20 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
             ? (disabledHint ?? getAppMessageTitle(APP_MESSAGE_CODE.error.chatRoom.inputLocked))
             : "채팅하기"
         }
-        className="border-border/80 bg-muted/40 flex-1 text-sm"
+        className="h-9 flex-1 rounded-xl border-border/60 bg-muted/30 py-0 text-sm placeholder:text-muted-foreground/60"
         aria-label="메시지 입력"
       />
       <Button
         type="button"
-        size="icon-sm"
-        variant="secondary"
+        size="icon-lg"
+        variant="ghost"
         disabled={disabled}
         title={disabled ? disabledHint : undefined}
         onClick={() => void handleSend()}
         aria-label="전송"
+        className="shrink-0 text-brand hover:bg-brand/10 hover:text-brand"
       >
-        <SendHorizontal className="size-4" />
+        <SendHorizontal className="size-5" />
       </Button>
     </div>
   );

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -40,7 +40,7 @@ export function MessageItem({ message, isOwn }: Props) {
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
-        <div className="mb-0.5 text-xs font-medium text-[#94eaff]">{nickname}</div>
+        <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
         <div
           className={cn(
             "inline-block max-w-full rounded-md px-2 py-1 text-sm leading-snug",

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -20,11 +20,11 @@ export function MessageItem({ message, isOwn }: Props) {
 
   if (isOwn) {
     return (
-      <div className="flex justify-end px-2 py-0.5">
+      <div className="flex justify-end px-3 py-0.5">
         <div
           className={cn(
-            "max-w-[88%] rounded-lg px-2.5 py-1.5 text-sm leading-snug",
-            "bg-primary text-primary-foreground",
+            "max-w-[88%] rounded-2xl rounded-tr-sm px-3 py-1.5 text-sm leading-snug",
+            "bg-brand text-white",
           )}
         >
           <span className="wrap-break-word">{message.content}</span>
@@ -34,8 +34,8 @@ export function MessageItem({ message, isOwn }: Props) {
   }
 
   return (
-    <div className="flex gap-2 px-2 py-0.5">
-      <Avatar size="sm" className="mt-0.5">
+    <div className="flex gap-2 px-3 py-0.5">
+      <Avatar size="sm" className="mt-0.5 shrink-0">
         {photoUrl && <AvatarImage src={photoUrl} alt="" />}
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
@@ -43,7 +43,7 @@ export function MessageItem({ message, isOwn }: Props) {
         <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
         <div
           className={cn(
-            "inline-block max-w-full rounded-md px-2 py-1 text-sm leading-snug",
+            "inline-block max-w-full rounded-2xl rounded-tl-sm px-3 py-1.5 text-sm leading-snug",
             "bg-muted/60 text-foreground",
           )}
         >

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -35,19 +35,19 @@ export function MessageItem({ message, isOwn }: Props) {
 
   return (
     <div className="flex gap-2 px-3 py-0.5">
-      <Avatar size="sm" className="mt-0.5 shrink-0">
+      <Avatar size={"lg"} className="mt-0.5 shrink-0">
         {photoUrl && <AvatarImage src={photoUrl} alt="" />}
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
-        <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
+        <div className="mb-1.5 text-xs font-medium">{nickname}</div>
         <div
           className={cn(
             "inline-block max-w-full rounded-2xl rounded-tl-sm px-3 py-1.5 text-sm leading-snug",
             "bg-muted/60 text-foreground",
           )}
         >
-          <span className="wrap-break-word">{message.content}</span>
+          <span>{message.content}</span>
         </div>
       </div>
     </div>

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -4,6 +4,7 @@
 import SearchInput from "@/components/search/search-input";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
+import { Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -25,23 +26,32 @@ export default function HeaderSearchForm() {
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
-
-    if (!trimmedQuery || isLiveSearchDisabled) {
-      return;
-    }
-
+    if (!trimmedQuery || isLiveSearchDisabled) return;
     router.push(resolveSearchPath(activeMenu, trimmedQuery));
     setQuery("");
   };
 
   return (
-    <SearchInput
-      value={query}
-      onChange={setQuery}
-      onSubmit={handleSearch}
-      placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
-      disabled={isLiveSearchDisabled}
-      className="order-3 mt-2 w-full basis-full sm:order-0 sm:mt-0 sm:w-48 sm:basis-auto md:w-64"
-    />
+    <>
+      {/* 모바일: 검색 아이콘 버튼으로 검색 페이지 이동 */}
+      <button
+        className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
+        onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
+        disabled={isLiveSearchDisabled}
+        aria-label="채팅방 검색"
+      >
+        <Search className="size-5" />
+      </button>
+
+      {/* sm 이상: 검색 인풋 */}
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        onSubmit={handleSearch}
+        placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
+        disabled={isLiveSearchDisabled}
+        className="hidden sm:block sm:w-48 md:w-64"
+      />
+    </>
   );
 }

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -2,6 +2,7 @@
 
 // Header에서 검색어를 입력받아 검색 페이지로 이동합니다.
 import SearchInput from "@/components/search/search-input";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
@@ -49,26 +50,30 @@ export default function HeaderSearchForm() {
               disabled={isLiveSearchDisabled}
               className="w-44"
             />
-            <button
-              className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+            <Button
+              variant="ghost"
+              size="icon-sm"
               onClick={handleClose}
               aria-label="검색 닫기"
+              className="text-muted-foreground hover:text-foreground shrink-0"
             >
               <X className="size-4" />
-            </button>
+            </Button>
           </div>
         ) : (
-          <button
-            className={cn(
-              "text-muted-foreground hover:text-foreground p-1 transition-colors",
-              isLiveSearchDisabled && "cursor-not-allowed opacity-50",
-            )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={() => !isLiveSearchDisabled && setMobileOpen(true)}
             disabled={isLiveSearchDisabled}
             aria-label="채팅방 검색"
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              isLiveSearchDisabled && "cursor-not-allowed",
+            )}
           >
             <Search className="size-5" />
-          </button>
+          </Button>
         )}
       </div>
 

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -5,60 +5,81 @@ import SearchInput from "@/components/search/search-input";
 import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
-import { Search } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
   const searchParams = new URLSearchParams({ query });
-
-  if (activeMenu === "live") {
-    return `/search/live?${searchParams.toString()}`;
-  }
-
+  if (activeMenu === "live") return `/search/live?${searchParams.toString()}`;
   return `/search/chat?${searchParams.toString()}`;
 }
 
 export default function HeaderSearchForm() {
   const router = useRouter();
-  const pathname = usePathname();
   const activeMenu = useMainMenuStore((state) => state.activeMenu);
   const [query, setQuery] = useState("");
+  const [mobileOpen, setMobileOpen] = useState(false);
   const isLiveSearchDisabled = activeMenu === "live";
-  const isOnSearchPage = pathname.startsWith("/search/");
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
     if (!trimmedQuery || isLiveSearchDisabled) return;
     router.push(resolveSearchPath(activeMenu, trimmedQuery));
     setQuery("");
+    setMobileOpen(false);
+  };
+
+  const handleClose = () => {
+    setMobileOpen(false);
+    setQuery("");
   };
 
   return (
     <>
-      {/* 모바일 전용 아이콘 버튼 — 검색 페이지가 아닐 때만 표시 */}
-      {!isOnSearchPage && (
-        <button
-          className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
-          onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
-          disabled={isLiveSearchDisabled}
-          aria-label="채팅방 검색"
-        >
-          <Search className="size-5" />
-        </button>
-      )}
+      {/* 모바일: 아이콘 토글 → 검색창 인라인 표시 */}
+      <div className="sm:hidden">
+        {mobileOpen ? (
+          <div className="flex items-center gap-1">
+            <SearchInput
+              value={query}
+              onChange={setQuery}
+              onSubmit={handleSearch}
+              placeholder="채팅방 검색"
+              disabled={isLiveSearchDisabled}
+              className="w-44"
+            />
+            <button
+              className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+              onClick={handleClose}
+              aria-label="검색 닫기"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        ) : (
+          <button
+            className={cn(
+              "text-muted-foreground hover:text-foreground p-1 transition-colors",
+              isLiveSearchDisabled && "cursor-not-allowed opacity-50",
+            )}
+            onClick={() => !isLiveSearchDisabled && setMobileOpen(true)}
+            disabled={isLiveSearchDisabled}
+            aria-label="채팅방 검색"
+          >
+            <Search className="size-5" />
+          </button>
+        )}
+      </div>
 
-      {/* 검색 입력창 — sm 이상 항상, 모바일은 검색 페이지에서만 표시 */}
+      {/* sm 이상: 항상 검색 인풋 */}
       <SearchInput
         value={query}
         onChange={setQuery}
         onSubmit={handleSearch}
         placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
         disabled={isLiveSearchDisabled}
-        className={cn(
-          "sm:block sm:w-48 md:w-64",
-          isOnSearchPage ? "block w-40" : "hidden",
-        )}
+        className="hidden sm:block sm:w-48 md:w-64"
       />
     </>
   );

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -2,10 +2,11 @@
 
 // Header에서 검색어를 입력받아 검색 페이지로 이동합니다.
 import SearchInput from "@/components/search/search-input";
+import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
 import { Search } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
@@ -20,9 +21,11 @@ function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
 
 export default function HeaderSearchForm() {
   const router = useRouter();
+  const pathname = usePathname();
   const activeMenu = useMainMenuStore((state) => state.activeMenu);
   const [query, setQuery] = useState("");
   const isLiveSearchDisabled = activeMenu === "live";
+  const isOnSearchPage = pathname.startsWith("/search/");
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
@@ -33,24 +36,29 @@ export default function HeaderSearchForm() {
 
   return (
     <>
-      {/* 모바일: 검색 아이콘 버튼으로 검색 페이지 이동 */}
-      <button
-        className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
-        onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
-        disabled={isLiveSearchDisabled}
-        aria-label="채팅방 검색"
-      >
-        <Search className="size-5" />
-      </button>
+      {/* 모바일 전용 아이콘 버튼 — 검색 페이지가 아닐 때만 표시 */}
+      {!isOnSearchPage && (
+        <button
+          className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
+          onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
+          disabled={isLiveSearchDisabled}
+          aria-label="채팅방 검색"
+        >
+          <Search className="size-5" />
+        </button>
+      )}
 
-      {/* sm 이상: 검색 인풋 */}
+      {/* 검색 입력창 — sm 이상 항상, 모바일은 검색 페이지에서만 표시 */}
       <SearchInput
         value={query}
         onChange={setQuery}
         onSubmit={handleSearch}
         placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
         disabled={isLiveSearchDisabled}
-        className="hidden sm:block sm:w-48 md:w-64"
+        className={cn(
+          "sm:block sm:w-48 md:w-64",
+          isOnSearchPage ? "block w-40" : "hidden",
+        )}
       />
     </>
   );

--- a/src/components/setting/profile/profile-avatar-upload.tsx
+++ b/src/components/setting/profile/profile-avatar-upload.tsx
@@ -75,11 +75,11 @@ export default function ProfileAvatarUpload({
         <div
           className={cn(
             "pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full text-white transition-opacity",
-            isHovering || isDragging ? "bg-black/55 opacity-100" : "opacity-0",
+            isHovering || isDragging ? "bg-black/55 opacity-100 dark:bg-black/70" : "opacity-0",
           )}
         >
           <Camera className="size-6" />
-          <span className="text-[11px] font-medium tracking-wider uppercase">
+          <span className="text-xs font-medium tracking-wider uppercase">
             {isDragging ? "Drop" : "변경"}
           </span>
         </div>

--- a/src/components/setting/setting-shell.tsx
+++ b/src/components/setting/setting-shell.tsx
@@ -6,7 +6,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/s
 import { useIsMobile } from "@/hooks/use-mobile";
 import { ReactNode } from "react";
 
-export function SettingsShell({ children }: { children: ReactNode }) {
+export function SettingShell({ children }: { children: ReactNode }) {
   const isMobile = useIsMobile();
 
   return (
@@ -14,7 +14,7 @@ export function SettingsShell({ children }: { children: ReactNode }) {
       <SettingSidebar isMobile={isMobile} />
       <SidebarInset className="min-w-0 overflow-hidden">
         {isMobile && (
-          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
+          <div className="border-border flex shrink-0 items-center gap-3 border-b p-4">
             <SidebarTrigger className="cursor-pointer" />
             <span className="text-foreground text-sm font-semibold">설정</span>
           </div>

--- a/src/components/setting/setting-sidebar.tsx
+++ b/src/components/setting/setting-sidebar.tsx
@@ -19,7 +19,7 @@ import { useAuthStore } from "@/stores/auth";
 import { LogOut } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
-export default function SettingSidebar() {
+export default function SettingSidebar({ isMobile }: { isMobile?: boolean }) {
   const router = useRouter();
   const pathname = usePathname();
   const supabase = createClient();
@@ -35,7 +35,7 @@ export default function SettingSidebar() {
 
   return (
     <Sidebar
-      collapsible="none"
+      collapsible={isMobile ? "offcanvas" : "none"}
       className="bg-background h-full shrink-0 border-r"
     >
       <SidebarContent>

--- a/src/components/setting/settings-shell.tsx
+++ b/src/components/setting/settings-shell.tsx
@@ -1,0 +1,26 @@
+// 설정 레이아웃 전체를 감싸는 클라이언트 쉘 — 모바일 offcanvas sidebar 처리
+"use client";
+
+import SettingSidebar from "@/components/setting/setting-sidebar";
+import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { ReactNode } from "react";
+
+export function SettingsShell({ children }: { children: ReactNode }) {
+  const isMobile = useIsMobile();
+
+  return (
+    <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
+      <SettingSidebar isMobile={isMobile} />
+      <SidebarInset className="min-w-0 overflow-hidden">
+        {isMobile && (
+          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
+            <SidebarTrigger className="cursor-pointer" />
+            <span className="text-foreground text-sm font-semibold">설정</span>
+          </div>
+        )}
+        <div className="h-full min-w-0 overflow-auto p-6 md:p-10">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}


### PR DESCRIPTION
### 📌 반영 브랜치

#### style/ui/#57 -> dev

### ✅ 작업 내용 `기능 개선`, `버그 수정`, `리팩토링`

**반응형 대응**
- 설정 페이지 사이드바 모바일 offcanvas 지원 (`SettingsShell` 클라이언트 컴포넌트 추출)
- 헤더 모바일 검색 인라인 토글 (페이지 이동 없이 SearchInput 표시/숨김)
- 채팅방 참여자 목록 모바일 Sheet 지원 (참여인원 버튼 클릭 → 우측 슬라이드)

**라이트/다크 모드 수정**
- `chat-room` 강제 `dark` 클래스 제거 → `bg-background`, `text-foreground` 토큰 적용
- `text-[#94eaff]` → `text-info`, `text-[#1e1d37]` → `text-foreground` 등 하드코딩 색상 제거
- `border-white/10`, `bg-zinc-950`, zinc 계열 하드코딩 → `border-border`, `bg-background`로 통일

**Tailwind 컨벤션 정리**
- `text-[11px]` → `text-xs`, `button` 날 HTML 태그 → `Button` 컴포넌트 교체
- `h-[calc(100dvh-11rem)]` → `h-app-content` (전 페이지 공통 CSS 변수 통일)
- `main-menu-sidebar`, `chat-room-card`, `create-chat-room-dialog` cn() 그룹화 적용

**채팅방 UI 개선**
- 메시지 입력창 높이 통일: 이모지/전송 버튼과 Input 높이 36px(h-9)로 맞춤
- 말풍선: `rounded-2xl rounded-tr/tl-sm`, 내 메시지 `bg-brand text-white` 적용
- MemberList/채팅 섹션 헤더 고정 높이 `h-14` 통일 (py 방식 → 명시적 height)
- MemberList 너비 260px → 320px(`w-80`), 아바타 `size-sm` → `size-default`
- 헤더 참여인원 `Users` 아이콘 버튼, 메뉴 `icon-lg` 사이즈로 가시성 향상
- PC 사이드바 유지 + 모바일은 Sheet로 참여자 확인

### 🎯 단독 테스트 결과

- `npm run build` 통과, TypeScript 오류 없음
- 모바일 뷰: 헤더 검색 토글, 설정 offcanvas, 채팅방 참여자 Sheet 정상 동작
- 라이트/다크 모드 전환 시 채팅방 전 컴포넌트 색상 정상 적용
- 데스크톱 뷰: MemberList 사이드바 + 채팅 섹션 헤더 수평 정렬 확인

### 🚨 연관 이슈

closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일에서 응답형 검색 UI 추가
  * 채팅방의 모바일 참여자 보기(시트) 도입
  * 설정 페이지에 모바일 친화적 레이아웃(설정 셸) 추가

* **개선 사항**
  * 헤더·사이드바 및 전반적 색상·타이포 일관성 개선
  * 메시지 버블, 멤버 목록, 아바타 업로드, 이모지 버튼 등 채팅 UI 정비
  * 검색 입력 토글 및 모바일 검색 동작 개선

* **버그 수정**
  * 알림/토스트 표시 안정성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->