### PR TITLE
feat(#59): 채팅방 참여 Dialog 및 정원 마감 UX 

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,7 +38,7 @@ reviews:
 knowledge_base:
   code_guidelines:
     enabled: true
-    file_patterns:
+    filePatterns:
       - "AGENTS.md"
       - ".agents/code-convention/*.md"
       - ".agents/design-convention/*.md"
@@ -51,4 +51,5 @@ chat:
   auto_reply: true
 
 issue_enrichment:
-  enabled: true
+  auto_enrich:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,13 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: "ko-KR"
-enable_beta_features: false
 
 reviews:
   profile: "assertive"
   request_changes_workflow: false
   high_level_summary: true
   poem: false
-  
+
   # 폴더별 SRP(단일 책임 원칙) 컨벤션 적용
   path_instructions:
     - path: "src/actions/**/*.ts"
@@ -50,12 +49,6 @@ knowledge_base:
 
 chat:
   auto_reply: true
-
-tools:
-  shellcheck:
-    enabled: true
-  ast-grep:
-    enabled: true
 
 issue_enrichment:
   enabled: true

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": ["--yes", "@playwright/mcp@latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=ftvoynnfpfzmblgrntqj"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,14 +1,6 @@
-import SettingSidebar from "@/components/setting/setting-sidebar";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { SettingsShell } from "@/components/setting/settings-shell";
 import { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return (
-    <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
-      <SettingSidebar />
-      <SidebarInset className="min-w-0 overflow-hidden">
-        <div className="h-full min-w-0 overflow-auto p-6 md:p-10">{children}</div>
-      </SidebarInset>
-    </SidebarProvider>
-  );
+  return <SettingsShell>{children}</SettingsShell>;
 }

--- a/src/app/(settings)/layout.tsx
+++ b/src/app/(settings)/layout.tsx
@@ -1,6 +1,6 @@
-import { SettingsShell } from "@/components/setting/settings-shell";
+import { SettingShell } from "@/components/setting/setting-shell";
 import { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return <SettingsShell>{children}</SettingsShell>;
+  return <SettingShell>{children}</SettingShell>;
 }

--- a/src/app/auth/complete-profile/page.tsx
+++ b/src/app/auth/complete-profile/page.tsx
@@ -29,7 +29,7 @@ export default async function Page() {
     <div className="container m-auto">
       <div className="border-brand/20 bg-card/80 m-auto max-w-md rounded-2xl border-2 p-8 shadow-[0_0_30px_#46c6a90a] backdrop-blur-sm dark:shadow-[0_0_60px_#46c6a918]">
         <div className="mb-6 flex flex-col items-center gap-4">
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <div className="flex flex-col items-center gap-1 text-center">
             <p className="text-xs tracking-widest uppercase">추가 정보 입력</p>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
         )}
       >
         <div className="mb-4 flex flex-col items-center gap-3 sm:mb-6 sm:gap-4">
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <p className="text-xs tracking-widest uppercase">로그인</p>
         </div>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
         )}
       >
         <div className={cn("mb-4 flex flex-col items-center gap-3", "sm:mb-6 sm:gap-4")}>
-          <Logo className="dark:text-foreground text-[#1e1d37]" />
+          <Logo className="text-foreground" />
           <Separator className="bg-brand/40" />
           <p className="text-xs tracking-widest uppercase">회원가입</p>
         </div>

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -7,7 +7,7 @@ export default function ChatLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex h-[calc(100dvh-11rem)] max-h-[calc(100dvh-11rem)] min-h-0 w-full flex-col overflow-hidden md:h-[calc(100dvh-12rem)] md:max-h-[calc(100dvh-12rem)]">
+    <div className="h-app-content min-h-0 w-full overflow-hidden">
       {children}
     </div>
   );

--- a/src/components/auth/auth-listener.tsx
+++ b/src/components/auth/auth-listener.tsx
@@ -8,6 +8,7 @@ import { QUERY_KEYS } from "@/constants/query-keys";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { toastAppError } from "@/utils/toast-message";
 import type { LoginProvider } from "@/types/auth";
+import { toast } from "sonner";
 
 /**
  * 앱 루트에서 1회 마운트되어 Supabase Auth 상태를 Zustand store(AuthUser)에 동기화.

--- a/src/components/auth/complete-profile/complete-profile-abandon-alert.tsx
+++ b/src/components/auth/complete-profile/complete-profile-abandon-alert.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { LogOut } from "lucide-react";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
 import { useAuthStore } from "@/stores/auth";

--- a/src/components/chat/chat-emoji-picker.tsx
+++ b/src/components/chat/chat-emoji-picker.tsx
@@ -45,12 +45,13 @@ export default function ChatEmojiPicker({ onEmojiSelect, disabled = false }: Pro
           <Button
             {...props}
             type="button"
-            size="icon-sm"
-            variant="secondary"
+            size="icon-lg"
+            variant="ghost"
             aria-label="이모지 선택"
             disabled={disabled}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
           >
-            <Smile className="size-4" />
+            <Smile className="size-5" />
           </Button>
         )}
       />

--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -43,14 +43,14 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
           <span
             className={cn(
               "text-muted-foreground shrink-0 font-medium tracking-tight",
-              "text-[11px]",
+              "text-xs",
             )}
           >
             @{chatRoom.owner_nickname}
           </span>
         </div>
         {chatRoom.description && (
-          <p className={cn("text-muted-foreground line-clamp-1 leading-relaxed", "text-[11px]")}>
+          <p className={cn("text-muted-foreground line-clamp-1 leading-relaxed", "text-xs")}>
             {chatRoom.description}
           </p>
         )}
@@ -74,7 +74,7 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
             <Users className="text-muted-foreground h-3 w-3" />
             <span
               className={cn(
-                "font-mono text-[11px] font-semibold",
+                "font-mono text-xs font-semibold",
                 isFull ? "text-live" : "text-brand",
               )}
             >
@@ -101,7 +101,7 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
         </div>
         <div className="flex items-center gap-1">
           <Clock className="text-muted-foreground/50 h-2.5 w-2.5" />
-          <span className="text-muted-foreground/70 text-[11px] whitespace-nowrap">
+          <span className="text-muted-foreground/70 whitespace-nowrap text-xs">
             생성일 {formatRoomDate(chatRoom.created_at)}
           </span>
         </div>

--- a/src/components/chat/chat-room-leave-alert-dialog.tsx
+++ b/src/components/chat/chat-room-leave-alert-dialog.tsx
@@ -2,6 +2,8 @@
 
 // 채팅방 나가기 확인용 AlertDialog
 
+import { DoorOpen, LogOut } from "lucide-react";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,8 +12,10 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogMedia,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
 
 interface Props {
   open: boolean;
@@ -20,12 +24,7 @@ interface Props {
   onConfirmLeave: () => void;
 }
 
-export function ChatRoomLeaveAlertDialog({
-  open,
-  onOpenChange,
-  isPending,
-  onConfirmLeave,
-}: Props) {
+export function ChatRoomLeaveAlertDialog({ open, onOpenChange, isPending, onConfirmLeave }: Props) {
   return (
     <AlertDialog
       open={open}
@@ -33,23 +32,45 @@ export function ChatRoomLeaveAlertDialog({
         if (!isPending) onOpenChange(next);
       }}
     >
-      <AlertDialogContent size="sm">
-        <AlertDialogHeader>
-          <AlertDialogTitle>채팅방 나가기</AlertDialogTitle>
-          <AlertDialogDescription>
-            이 채팅방에서 나가면 참여 목록에서 제거됩니다. 다시 들어오려면 해당 채팅방에 다시
-            참여해야 합니다.
-          </AlertDialogDescription>
+      <AlertDialogContent
+        showCloseButton={false}
+        className="border-destructive/20 shadow-destructive/10 overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md"
+      >
+        <AlertDialogHeader className="bg-destructive/5 border-destructive/10 flex items-center gap-4 border-b px-5 pt-5 pb-4 text-left">
+          <AlertDialogMedia className="bg-destructive/10 text-destructive ring-destructive/20 mb-0 shrink-0 rounded-xl ring-1">
+            <LogOut />
+          </AlertDialogMedia>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <AlertDialogTitle className="text-lg leading-tight font-bold">
+              채팅방 나가기
+            </AlertDialogTitle>
+            <AlertDialogDescription className="leading-snug whitespace-pre-line text-pretty">
+              {"채팅방에서 나가시겠습니까?\n언제든 다시 참여하실 수 있습니다."}
+            </AlertDialogDescription>
+          </div>
         </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>취소</AlertDialogCancel>
+        <AlertDialogFooter className="m-0 flex-row justify-end gap-2 border-0 bg-transparent px-5 pt-4 pb-5">
+          <AlertDialogCancel
+            disabled={isPending}
+            className="border-border bg-background text-foreground hover:bg-muted h-10 min-w-24 rounded-xl px-4 font-semibold"
+          >
+            돌아가기
+          </AlertDialogCancel>
           <AlertDialogAction
             variant="destructive"
             disabled={isPending}
             type="button"
             onClick={onConfirmLeave}
+            className="shadow-destructive/10 h-10 min-w-24 rounded-xl px-4 font-bold shadow-sm"
           >
-            {isPending ? "나가는 중…" : "나가기"}
+            {isPending ? (
+              <Spinner className="size-4" />
+            ) : (
+              <>
+                <DoorOpen className="size-4" />
+                나가기
+              </>
+            )}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/chat/chat-room-menu.tsx
+++ b/src/components/chat/chat-room-menu.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from "react";
 
-import { DoorOpen, MoreVertical } from "lucide-react";
+import { Ellipsis } from "lucide-react";
 
 import { ChatRoomLeaveAlertDialog } from "@/components/chat/chat-room-leave-alert-dialog";
 import { Button } from "@/components/ui/button";
@@ -69,11 +69,11 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
               {...props}
               type="button"
               variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground hover:text-foreground shrink-0"
+              size="icon-lg"
+              className="hover:text-foreground shrink-0"
               aria-label="채팅방 메뉴"
             >
-              <MoreVertical data-icon="inline-start" />
+              <Ellipsis data-icon="inline-start" />
             </Button>
           )}
         />
@@ -108,7 +108,6 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
         isPending={isPending}
         onConfirmLeave={handleLeave}
       />
-      
     </>
   );
 }

--- a/src/components/chat/chat-room-menu.tsx
+++ b/src/components/chat/chat-room-menu.tsx
@@ -69,7 +69,7 @@ export function ChatRoomMenu({ roomId, ownerId, currentMember, currentUserId }: 
               {...props}
               type="button"
               variant="ghost"
-              size="icon-xs"
+              size="icon-sm"
               className="text-muted-foreground hover:text-foreground shrink-0"
               aria-label="채팅방 메뉴"
             >

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -98,7 +98,7 @@ export function ChatRoom({ roomId }: Props) {
       </div>
 
       <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
-        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2.5">
+        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -45,7 +45,10 @@ export function ChatRoom({ roomId }: Props) {
   const currentUserId = profile?.id ?? "";
 
   const roomQuery = useRoom(roomId);
-  const { isKicked, isJoined, membershipFetched } = useChatRoomMemberRealtime({ roomId, currentUserId });
+  const { isKicked, isJoined, membershipFetched } = useChatRoomMemberRealtime({
+    roomId,
+    currentUserId,
+  });
 
   const { messages, hasMorePrevious, isLoadingPrevious, fetchPreviousPage, isLoadingInitial } =
     useMessages(roomId, isJoined);
@@ -54,7 +57,7 @@ export function ChatRoom({ roomId }: Props) {
   const [membersSheetOpen, setMembersSheetOpen] = useState(false);
 
   const isFull =
-    (roomQuery.data?.current_member ?? 0) >= (roomQuery.data?.max_capacity ?? 0);
+    roomQuery.data != null && roomQuery.data.current_member >= roomQuery.data.max_capacity;
 
   const shouldShowJoinDialog =
     membershipFetched && roomQuery.isFetched && roomQuery.data != null && !isJoined && !isKicked;

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -10,11 +10,7 @@ import { KickedRoomAlertDialog } from "@/components/member/kicked-room-alert-dia
 import { MessageInput } from "@/components/message/message-input";
 import { MessageList } from "@/components/message/message-list";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
@@ -98,6 +94,7 @@ export function ChatRoom({ roomId }: Props) {
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+      {/* PC: 좌측 고정 사이드바 */}
       <div className="hidden shrink-0 md:flex">
         <MemberList
           roomId={roomId}
@@ -107,20 +104,22 @@ export function ChatRoom({ roomId }: Props) {
       </div>
 
       <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
+        {/* 헤더 — py-3으로 MemberList 헤더와 높이 맞춤 */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-3">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-0.5">
+          <div className="flex shrink-0 items-center gap-1">
+            {/* 모바일: Sheet 열기 / PC: 시각적 표시 */}
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+              className="h-9 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground md:pointer-events-none md:cursor-default"
               onClick={() => setMembersSheetOpen(true)}
               aria-label="참여자 목록"
             >
-              <Users className="size-3.5" />
-              <span className="text-xs font-medium">{members.length}</span>
+              <Users className="size-4" />
+              <span className="text-sm font-medium">{members.length}</span>
             </Button>
             {roomQuery.data ? (
               <ChatRoomMenu
@@ -156,6 +155,7 @@ export function ChatRoom({ roomId }: Props) {
         />
       </section>
 
+      {/* 모바일 전용 Sheet */}
       <Sheet open={membersSheetOpen} onOpenChange={setMembersSheetOpen}>
         <SheetContent side="right" className="flex w-80 flex-col gap-0 p-0">
           <SheetTitle className="sr-only">참여자 목록</SheetTitle>
@@ -163,7 +163,7 @@ export function ChatRoom({ roomId }: Props) {
             roomId={roomId}
             currentUserId={currentUserId}
             ownerId={roomQuery.data?.owner_id}
-            className="h-full max-h-none w-full border-r-0 md:h-full md:w-full md:border-r-0"
+            className="h-full max-h-none w-full border-r-0 md:w-full md:border-r-0"
           />
         </SheetContent>
       </Sheet>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -30,7 +30,7 @@ function ChatRoomError({ code }: { code: AppMessageCode }) {
   const message = getAppMessage(code);
 
   return (
-    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background px-4 text-center text-foreground">
+    <div className="bg-background text-foreground flex h-full min-h-0 flex-col items-center justify-center gap-3 px-4 text-center">
       <p className="text-sm">{message.title}</p>
       <Link href="/" className="text-sm underline">
         처음으로
@@ -74,7 +74,7 @@ export function ChatRoom({ roomId }: Props) {
 
   if (profilePending) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-background">
+      <div className="bg-background flex h-full w-full items-center justify-center">
         <Spinner className="text-muted-foreground size-8" />
       </div>
     );
@@ -93,7 +93,7 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+    <div className="bg-background text-foreground flex h-full min-h-0 w-full overflow-hidden md:flex-row">
       {/* PC: 좌측 고정 사이드바 */}
       <div className="hidden shrink-0 md:flex">
         <MemberList
@@ -103,18 +103,17 @@ export function ChatRoom({ roomId }: Props) {
         />
       </div>
 
-      <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-        {/* 헤더 — py-3으로 MemberList 헤더와 높이 맞춤 */}
-        <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-3">
+      <section className="bg-background flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="border-border/50 bg-muted/20 flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1.5">
             {/* 모바일: Sheet 열기 / PC: 시각적 표시 */}
             <Button
               variant="ghost"
-              size="sm"
-              className="h-9 gap-1.5 px-2.5 text-muted-foreground hover:text-foreground md:pointer-events-none md:cursor-default"
+              size={"icon-lg"}
+              className="gap-1.5 md:pointer-events-none md:cursor-default"
               onClick={() => setMembersSheetOpen(true)}
               aria-label="참여자 목록"
             >

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -26,7 +26,7 @@ function ChatRoomError({ code }: { code: AppMessageCode }) {
   const message = getAppMessage(code);
 
   return (
-    <div className="dark flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-zinc-950 px-4 text-center text-zinc-200">
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background px-4 text-center text-foreground">
       <p className="text-sm">{message.title}</p>
       <Link href="/" className="text-sm underline">
         처음으로
@@ -69,7 +69,7 @@ export function ChatRoom({ roomId }: Props) {
 
   if (profilePending) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-zinc-950">
+      <div className="flex h-full w-full items-center justify-center bg-background">
         <Spinner className="text-muted-foreground size-8" />
       </div>
     );
@@ -88,14 +88,14 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="dark text-foreground flex h-full min-h-0 w-full flex-col overflow-hidden bg-zinc-950 md:flex-row">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background text-foreground md:flex-row">
       <MemberList
         roomId={roomId}
         currentUserId={currentUserId}
         ownerId={roomQuery.data?.owner_id}
       />
 
-      <aside className="bg-background flex min-h-0 flex-1 flex-col border-white/10 md:w-[min(100%,380px)] md:shrink-0 md:border-l">
+      <aside className="flex min-h-0 flex-1 flex-col border-border bg-background md:w-[min(100%,380px)] md:shrink-0 md:border-l">
         <header className="border-border shrink-0 border-b px-3 py-2.5">
           <div className="flex items-start justify-between gap-2">
             <h1 className="line-clamp-2 flex-1 text-sm leading-tight font-semibold">
@@ -113,7 +113,7 @@ export function ChatRoom({ roomId }: Props) {
               ) : null}
             </div>
           </div>
-          <p className="text-muted-foreground mt-1 line-clamp-1 text-[11px]">
+          <p className="text-muted-foreground mt-1 line-clamp-1 text-xs">
             {roomQuery.data?.description ?? ""}
           </p>
         </header>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Users } from "lucide-react";
 
 import { ChatRoomMenu } from "@/components/chat/chat-room-menu";
+import { JoinChatRoomDialog } from "@/components/chat/join-chat-room-dialog";
 import { MemberList } from "@/components/member/member-list";
 import { KickedRoomAlertDialog } from "@/components/member/kicked-room-alert-dialog";
 import { MessageInput } from "@/components/message/message-input";
@@ -41,16 +42,22 @@ function ChatRoomError({ code }: { code: AppMessageCode }) {
 
 export function ChatRoom({ roomId }: Props) {
   const { data: profile, isPending: profilePending } = useUser();
-  const { messages, hasMorePrevious, isLoadingPrevious, fetchPreviousPage, isLoadingInitial } =
-    useMessages(roomId);
+  const currentUserId = profile?.id ?? "";
 
   const roomQuery = useRoom(roomId);
-  const { data: members = [] } = useRoomMembers(roomId);
+  const { isKicked, isJoined } = useChatRoomMemberRealtime({ roomId, currentUserId });
 
-  const currentUserId = profile?.id ?? "";
-  const { isKicked } = useChatRoomMemberRealtime({ roomId, currentUserId });
+  const { messages, hasMorePrevious, isLoadingPrevious, fetchPreviousPage, isLoadingInitial } =
+    useMessages(roomId, isJoined);
+  const { data: members = [] } = useRoomMembers(roomId, isJoined);
 
   const [membersSheetOpen, setMembersSheetOpen] = useState(false);
+
+  const isFull =
+    (roomQuery.data?.current_member ?? 0) >= (roomQuery.data?.max_capacity ?? 0);
+
+  const shouldShowJoinDialog =
+    roomQuery.isFetched && roomQuery.data != null && !isJoined && !isKicked;
 
   const markRoomReadEnabled =
     !!roomId &&
@@ -59,7 +66,8 @@ export function ChatRoom({ roomId }: Props) {
     roomQuery.isFetched &&
     roomQuery.data != null &&
     roomQuery.error == null &&
-    !isKicked;
+    !isKicked &&
+    isJoined;
 
   useMarkRoomReadLifecycle({ roomId, enabled: markRoomReadEnabled });
 
@@ -90,7 +98,7 @@ export function ChatRoom({ roomId }: Props) {
     return <ChatRoomError code={APP_MESSAGE_CODE.error.chatRoom.notFoundOrLoadFailed} />;
   }
 
-  const inputLocked = profilePending || !currentUserId;
+  const inputLocked = profilePending || !currentUserId || !isJoined;
 
   return (
     <div className="bg-background text-foreground flex h-full min-h-0 w-full overflow-hidden md:flex-row">
@@ -168,6 +176,13 @@ export function ChatRoom({ roomId }: Props) {
       </Sheet>
 
       <KickedRoomAlertDialog open={isKicked} />
+
+      <JoinChatRoomDialog
+        open={shouldShowJoinDialog}
+        roomId={roomId}
+        roomTitle={roomQuery.data?.title ?? ""}
+        isFull={isFull}
+      />
     </div>
   );
 }

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -97,7 +97,7 @@ export function ChatRoom({ roomId }: Props) {
         />
       </div>
 
-      <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
         <div className="flex shrink-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-4 py-2.5">
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -45,7 +45,7 @@ export function ChatRoom({ roomId }: Props) {
   const currentUserId = profile?.id ?? "";
 
   const roomQuery = useRoom(roomId);
-  const { isKicked, isJoined } = useChatRoomMemberRealtime({ roomId, currentUserId });
+  const { isKicked, isJoined, membershipFetched } = useChatRoomMemberRealtime({ roomId, currentUserId });
 
   const { messages, hasMorePrevious, isLoadingPrevious, fetchPreviousPage, isLoadingInitial } =
     useMessages(roomId, isJoined);
@@ -57,7 +57,7 @@ export function ChatRoom({ roomId }: Props) {
     (roomQuery.data?.current_member ?? 0) >= (roomQuery.data?.max_capacity ?? 0);
 
   const shouldShowJoinDialog =
-    roomQuery.isFetched && roomQuery.data != null && !isJoined && !isKicked;
+    membershipFetched && roomQuery.isFetched && roomQuery.data != null && !isJoined && !isKicked;
 
   const markRoomReadEnabled =
     !!roomId &&

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -88,35 +88,32 @@ export function ChatRoom({ roomId }: Props) {
   const inputLocked = profilePending || !currentUserId;
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background text-foreground md:flex-row">
-      <MemberList
-        roomId={roomId}
-        currentUserId={currentUserId}
-        ownerId={roomQuery.data?.owner_id}
-      />
+    <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
+      <div className="hidden md:flex">
+        <MemberList
+          roomId={roomId}
+          currentUserId={currentUserId}
+          ownerId={roomQuery.data?.owner_id}
+        />
+      </div>
 
-      <aside className="flex min-h-0 flex-1 flex-col border-border bg-background md:w-[min(100%,380px)] md:shrink-0 md:border-l">
-        <header className="border-border shrink-0 border-b px-3 py-2.5">
-          <div className="flex items-start justify-between gap-2">
-            <h1 className="line-clamp-2 flex-1 text-sm leading-tight font-semibold">
-              {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
-            </h1>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-muted-foreground text-xs">{members.length}명</span>
-              {roomQuery.data ? (
-                <ChatRoomMenu
-                  roomId={roomId}
-                  ownerId={roomQuery.data.owner_id}
-                  currentMember={roomQuery.data.current_member}
-                  currentUserId={currentUserId}
-                />
-              ) : null}
-            </div>
+      <section className="flex min-h-0 w-full flex-1 flex-col bg-background md:border-l md:border-border">
+        <div className="border-border flex shrink-0 items-center gap-2 border-b px-3 py-2.5">
+          <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
+            {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
+          </h1>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span className="text-muted-foreground text-xs">{members.length}명</span>
+            {roomQuery.data ? (
+              <ChatRoomMenu
+                roomId={roomId}
+                ownerId={roomQuery.data.owner_id}
+                currentMember={roomQuery.data.current_member}
+                currentUserId={currentUserId}
+              />
+            ) : null}
           </div>
-          <p className="text-muted-foreground mt-1 line-clamp-1 text-xs">
-            {roomQuery.data?.description ?? ""}
-          </p>
-        </header>
+        </div>
 
         <MessageList
           key={roomId}
@@ -139,7 +136,7 @@ export function ChatRoom({ roomId }: Props) {
             ).title
           }
         />
-      </aside>
+      </section>
 
       <KickedRoomAlertDialog open={isKicked} />
     </div>

--- a/src/components/chat/chat-room.tsx
+++ b/src/components/chat/chat-room.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
+import { Users } from "lucide-react";
 
 import { ChatRoomMenu } from "@/components/chat/chat-room-menu";
 import { MemberList } from "@/components/member/member-list";
 import { KickedRoomAlertDialog } from "@/components/member/kicked-room-alert-dialog";
 import { MessageInput } from "@/components/message/message-input";
 import { MessageList } from "@/components/message/message-list";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import type { AppMessageCode } from "@/constants/app-message-code";
@@ -41,11 +49,12 @@ export function ChatRoom({ roomId }: Props) {
     useMessages(roomId);
 
   const roomQuery = useRoom(roomId);
-
   const { data: members = [] } = useRoomMembers(roomId);
 
   const currentUserId = profile?.id ?? "";
   const { isKicked } = useChatRoomMemberRealtime({ roomId, currentUserId });
+
+  const [membersSheetOpen, setMembersSheetOpen] = useState(false);
 
   const markRoomReadEnabled =
     !!roomId &&
@@ -89,7 +98,7 @@ export function ChatRoom({ roomId }: Props) {
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground md:flex-row">
-      <div className="hidden md:flex">
+      <div className="hidden shrink-0 md:flex">
         <MemberList
           roomId={roomId}
           currentUserId={currentUserId}
@@ -102,8 +111,17 @@ export function ChatRoom({ roomId }: Props) {
           <h1 className="min-w-0 flex-1 truncate text-sm font-semibold">
             {roomQuery.isPending ? "불러오는 중…" : (roomQuery.data?.title ?? "채팅방")}
           </h1>
-          <div className="flex shrink-0 items-center gap-1.5">
-            <span className="text-muted-foreground text-xs">{members.length}명</span>
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+              onClick={() => setMembersSheetOpen(true)}
+              aria-label="참여자 목록"
+            >
+              <Users className="size-3.5" />
+              <span className="text-xs font-medium">{members.length}</span>
+            </Button>
             {roomQuery.data ? (
               <ChatRoomMenu
                 roomId={roomId}
@@ -137,6 +155,18 @@ export function ChatRoom({ roomId }: Props) {
           }
         />
       </section>
+
+      <Sheet open={membersSheetOpen} onOpenChange={setMembersSheetOpen}>
+        <SheetContent side="right" className="flex w-80 flex-col gap-0 p-0">
+          <SheetTitle className="sr-only">참여자 목록</SheetTitle>
+          <MemberList
+            roomId={roomId}
+            currentUserId={currentUserId}
+            ownerId={roomQuery.data?.owner_id}
+            className="h-full max-h-none w-full border-r-0 md:h-full md:w-full md:border-r-0"
+          />
+        </SheetContent>
+      </Sheet>
 
       <KickedRoomAlertDialog open={isKicked} />
     </div>

--- a/src/components/chat/create-chat-room-dialog.tsx
+++ b/src/components/chat/create-chat-room-dialog.tsx
@@ -71,7 +71,13 @@ export default function CreateChatRoomDialog() {
         <Plus className="h-4 w-4" />
         채팅방 만들기
       </DialogTrigger>
-      <DialogContent className="border-brand/20 shadow-brand/10 dark:border-brand/10 max-w-md gap-0 overflow-hidden rounded-2xl p-0 shadow-xl">
+      <DialogContent
+        className={cn(
+          "max-w-md gap-0 overflow-hidden rounded-2xl p-0 shadow-xl",
+          "border-brand/20 shadow-brand/10",
+          "dark:border-brand/10",
+        )}
+      >
         <DialogHeader className="bg-brand/5 border-brand/10 border-b px-5 pt-5 pb-4">
           <div className="flex items-center gap-3">
             <span className="bg-brand/10 text-brand ring-brand/20 flex size-10 shrink-0 items-center justify-center rounded-xl ring-1">

--- a/src/components/chat/join-chat-room-dialog.tsx
+++ b/src/components/chat/join-chat-room-dialog.tsx
@@ -69,7 +69,7 @@ export function JoinChatRoomDialog({ open, roomId, roomTitle, isFull }: Props) {
         </AlertDialogHeader>
         <AlertDialogFooter className="m-0 flex-row justify-end gap-2 border-0 bg-transparent px-5 pt-4 pb-5">
           <AlertDialogCancel
-            onClick={() => router.replace("/")}
+            onClick={() => router.back()}
             className="border-border bg-background text-foreground hover:bg-muted h-10 min-w-24 rounded-xl px-4 font-semibold"
           >
             돌아가기

--- a/src/components/chat/join-chat-room-dialog.tsx
+++ b/src/components/chat/join-chat-room-dialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+// 미참여 유저에게 채팅방 참여 여부를 묻는 Dialog (정원 마감 시 안내만 표시)
+
+import { useRouter } from "next/navigation";
+import { DoorOpen, Users } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useJoinChatRoom } from "@/hooks/use-join-chat-room";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  roomId: string;
+  roomTitle: string;
+  isFull: boolean;
+}
+
+export function JoinChatRoomDialog({ open, roomId, roomTitle, isFull }: Props) {
+  const router = useRouter();
+  const { mutate, isPending } = useJoinChatRoom();
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent
+        showCloseButton={false}
+        className={cn(
+          "overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md",
+          isFull
+            ? "border-destructive/20 shadow-destructive/10"
+            : "border-brand/20 shadow-brand/10",
+        )}
+      >
+        <AlertDialogHeader
+          className={cn(
+            "flex items-center gap-4 border-b px-5 pt-5 pb-4 text-left",
+            isFull ? "bg-destructive/5 border-destructive/10" : "bg-brand/5 border-brand/10",
+          )}
+        >
+          <AlertDialogMedia
+            className={cn(
+              "mb-0 shrink-0 rounded-xl ring-1",
+              isFull
+                ? "bg-destructive/10 text-destructive ring-destructive/20"
+                : "bg-brand/10 text-brand ring-brand/20",
+            )}
+          >
+            {isFull ? <Users /> : <DoorOpen />}
+          </AlertDialogMedia>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <AlertDialogTitle className="text-lg leading-tight font-bold">
+              {roomTitle}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="leading-snug text-pretty">
+              {isFull ? "정원이 가득 찬 채팅방입니다." : "채팅방에 참여하시겠습니까?"}
+            </AlertDialogDescription>
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="m-0 flex-row justify-end gap-2 border-0 bg-transparent px-5 pt-4 pb-5">
+          <AlertDialogCancel
+            onClick={() => router.replace("/")}
+            className="border-border bg-background text-foreground hover:bg-muted h-10 min-w-24 rounded-xl px-4 font-semibold"
+          >
+            돌아가기
+          </AlertDialogCancel>
+          {!isFull && (
+            <AlertDialogAction
+              onClick={() => mutate(roomId)}
+              disabled={isPending}
+              className="bg-brand shadow-brand/20 hover:bg-brand/90 h-10 min-w-24 rounded-xl px-4 font-bold text-white shadow-sm"
+            >
+              {isPending ? <Spinner className="size-4" /> : "참여하기"}
+            </AlertDialogAction>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/chat/join-chat-room-dialog.tsx
+++ b/src/components/chat/join-chat-room-dialog.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 // 미참여 유저에게 채팅방 참여 여부를 묻는 Dialog (정원 마감 시 안내만 표시)
+"use client";
 
 import { useRouter } from "next/navigation";
 import { DoorOpen, Users } from "lucide-react";

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -30,7 +30,7 @@ export default async function Header() {
     >
       <div className="flex flex-wrap items-center justify-between px-3 py-2 sm:flex-nowrap sm:px-5">
         <Link href="/" className="h-10 w-32 sm:w-40">
-          <Logo className="dark:text-foreground h-full w-full text-[#1e1d37]" />
+          <Logo className="h-full w-full text-foreground" />
         </Link>
 
         <div className="flex items-center gap-3 sm:gap-5">

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -28,12 +28,12 @@ export default async function Header() {
         "dark:border-border dark:bg-muted/60", // 다크 모드 톤다운 조합
       )}
     >
-      <div className="flex flex-wrap items-center justify-between px-3 py-2 sm:flex-nowrap sm:px-5">
-        <Link href="/" className="h-10 w-32 sm:w-40">
+      <div className="flex h-14 items-center justify-between px-3 sm:px-5">
+        <Link href="/" className="h-9 w-28 shrink-0 sm:w-36">
           <Logo className="h-full w-full text-foreground" />
         </Link>
 
-        <div className="flex items-center gap-3 sm:gap-5">
+        <div className="flex items-center gap-2 sm:gap-3">
           {user && hasProfile && <HeaderSearchForm />}
           <ThemeToggleButton />
           {user && hasProfile && <HeaderProfileBadge />}

--- a/src/components/common/main-menu-sidebar.tsx
+++ b/src/components/common/main-menu-sidebar.tsx
@@ -57,11 +57,11 @@ export default function MainMenuSidebar() {
     <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
       <Sidebar
         collapsible={isMobile ? "offcanvas" : "none"}
-        className="bg-background h-full shrink-0 border-r border-zinc-200 dark:border-zinc-800/50"
+        className="h-full shrink-0 border-r border-border bg-background"
       >
         <SidebarContent>
           <SidebarGroup className="p-4 pt-5">
-            <SidebarGroupLabel className="mb-3 px-2 text-xs font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+            <SidebarGroupLabel className="mb-3 px-2 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
               메뉴
             </SidebarGroupLabel>
             <SidebarGroupContent>
@@ -73,7 +73,7 @@ export default function MainMenuSidebar() {
 
       <SidebarInset>
         {isMobile && (
-          <div className="flex shrink-0 items-center gap-3 border-b border-zinc-200 p-4 dark:border-zinc-800/50">
+          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
             <SidebarTrigger className="cursor-pointer" />
             <span className="text-foreground text-sm font-semibold">
               {MAIN_MENU_SIDEBAR_ITEMS.find((item) => item.key === activeMenu)?.label}

--- a/src/components/member/kicked-room-alert-dialog.tsx
+++ b/src/components/member/kicked-room-alert-dialog.tsx
@@ -32,15 +32,18 @@ export function KickedRoomAlertDialog({ open }: Props) {
         showCloseButton={false}
         className="border-destructive/20 shadow-destructive/10 overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md"
       >
-        <AlertDialogHeader className="bg-destructive/5 border-destructive/10 border-b px-5 pt-5 pb-4 text-left">
-          <AlertDialogMedia className="bg-destructive/10 text-destructive ring-destructive/20 mb-0 rounded-xl ring-1">
+        <AlertDialogHeader className="bg-destructive/5 border-destructive/10 flex items-center gap-4 border-b px-5 pt-5 pb-4 text-left">
+          <AlertDialogMedia className="bg-destructive/10 text-destructive ring-destructive/20 mb-0 shrink-0 rounded-xl ring-1">
             <UserX />
           </AlertDialogMedia>
-          <AlertDialogTitle className="text-lg font-bold">채팅방 강퇴</AlertDialogTitle>
-          <AlertDialogDescription className="leading-relaxed text-pretty">
-            방장에 의해 채팅방에서 제외되었습니다.
-            <br />더 이상 이 방에서 대화를 나눌 수 없습니다.
-          </AlertDialogDescription>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <AlertDialogTitle className="text-lg leading-tight font-bold">
+              채팅방 강퇴
+            </AlertDialogTitle>
+            <AlertDialogDescription className="leading-snug whitespace-pre-line text-pretty">
+              {"방장에 의해 채팅방에서 제외되었습니다.\n더 이상 대화에 참여할 수 없습니다."}
+            </AlertDialogDescription>
+          </div>
         </AlertDialogHeader>
         <AlertDialogFooter className="m-0 flex-row justify-end border-0 bg-transparent px-5 pt-4 pb-5">
           <AlertDialogAction

--- a/src/components/member/member-action-alert-dialog.tsx
+++ b/src/components/member/member-action-alert-dialog.tsx
@@ -75,11 +75,23 @@ export function MemberActionAlertDialog({
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger render={trigger} />
-      <AlertDialogContent className="border-brand/20 shadow-brand/10 dark:border-brand/10 overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md">
-        <AlertDialogHeader className="bg-brand/5 border-brand/10 border-b px-5 pt-5 pb-4 text-left">
+      <AlertDialogContent
+        className={cn(
+          "overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md",
+          isKick
+            ? "border-destructive/20 shadow-destructive/10"
+            : "border-brand/20 shadow-brand/10 dark:border-brand/10",
+        )}
+      >
+        <AlertDialogHeader
+          className={cn(
+            "flex items-center gap-4 border-b px-5 pt-5 pb-4 text-left",
+            isKick ? "bg-destructive/5 border-destructive/10" : "bg-brand/5 border-brand/10",
+          )}
+        >
           <AlertDialogMedia
             className={cn(
-              "mb-0 rounded-xl ring-1",
+              "mb-0 shrink-0 rounded-xl ring-1",
               isKick
                 ? "bg-destructive/10 text-destructive ring-destructive/20"
                 : "bg-brand/10 text-brand ring-brand/20",
@@ -87,11 +99,15 @@ export function MemberActionAlertDialog({
           >
             {isKick ? <UserX /> : <Crown />}
           </AlertDialogMedia>
-          <AlertDialogTitle className="text-lg font-bold">{copy.title}</AlertDialogTitle>
-          <AlertDialogDescription className="leading-relaxed text-pretty">
-            {targetNickname}
-            {copy.description}
-          </AlertDialogDescription>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <AlertDialogTitle className="text-lg leading-tight font-bold">
+              {copy.title}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="leading-snug text-pretty">
+              {targetNickname}
+              {copy.description}
+            </AlertDialogDescription>
+          </div>
         </AlertDialogHeader>
         <AlertDialogFooter className="m-0 flex-row justify-end gap-2 border-0 bg-transparent px-5 pt-4 pb-5">
           <AlertDialogCancel

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,7 +18,7 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/40">
+      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5">
         <Avatar size="sm" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,14 +18,12 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5">
-        <Avatar size="sm" className="shrink-0">
+      <div className="flex w-full items-center gap-3 rounded-md px-3 py-2">
+        <Avatar size="default" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>
         </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">
-          {nickname}
-        </span>
+        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
       </div>
     );
   }
@@ -34,15 +32,13 @@ export function MemberItem({ roomId, member, canManage }: Props) {
     <MemberActionPopover roomId={roomId} member={member}>
       <Button
         variant="ghost"
-        className="flex h-auto w-full items-center gap-2.5 justify-start rounded-md px-2 py-1.5 font-normal transition-colors"
+        className="flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors"
       >
-        <Avatar size="sm" className="shrink-0">
+        <Avatar size="default" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>
         </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">
-          {nickname}
-        </span>
+        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
       </Button>
     </MemberActionPopover>
   );

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -18,7 +18,7 @@ export function MemberItem({ roomId, member, canManage }: Props) {
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-2.5 px-2 py-1.5 text-left transition-colors">
+      <div className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/40">
         <Avatar size="sm" className="shrink-0">
           {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
           <AvatarFallback>{fallbackText}</AvatarFallback>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -13,7 +13,7 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
   const canManageMembers = !!currentUserId && currentUserId === ownerId;
 
   return (
-    <section className="bg-background flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-white/10 md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
+    <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
       <header className="border-border shrink-0 border-b px-3 py-2.5">
         <h2 className="text-sm leading-tight font-semibold">
           참여자 목록 {members.length.toLocaleString("ko-KR")}명

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -14,7 +14,7 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
 
   return (
     <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
-      <div className="border-border flex shrink-0 items-center border-b px-3 py-2.5">
+      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
         <span className="text-muted-foreground text-xs font-medium">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -1,4 +1,5 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import { MemberItem } from "./member-item";
 import { useRoomMembers } from "@/hooks/use-room-members";
 
@@ -6,16 +7,23 @@ interface Props {
   roomId: string;
   currentUserId: string;
   ownerId?: string;
+  className?: string;
 }
 
-export function MemberList({ roomId, currentUserId, ownerId }: Props) {
+export function MemberList({ roomId, currentUserId, ownerId, className }: Props) {
   const { data: members = [] } = useRoomMembers(roomId);
   const canManageMembers = !!currentUserId && currentUserId === ownerId;
 
   return (
-    <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
+    <section
+      className={cn(
+        "flex min-h-0 shrink-0 flex-col overflow-hidden bg-background",
+        "md:h-full md:w-80 md:shrink-0 md:border-r md:border-border",
+        className,
+      )}
+    >
       <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
-        <span className="text-muted-foreground text-xs font-medium">
+        <span className="text-xs font-medium text-muted-foreground">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>
       </div>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -14,11 +14,11 @@ export function MemberList({ roomId, currentUserId, ownerId }: Props) {
 
   return (
     <section className="flex max-h-[38dvh] min-h-0 shrink-0 flex-col overflow-hidden border-border bg-background md:h-full md:max-h-none md:w-[min(100%,260px)] md:shrink-0 md:border-r">
-      <header className="border-border shrink-0 border-b px-3 py-2.5">
-        <h2 className="text-sm leading-tight font-semibold">
-          참여자 목록 {members.length.toLocaleString("ko-KR")}명
-        </h2>
-      </header>
+      <div className="border-border flex shrink-0 items-center border-b px-3 py-2.5">
+        <span className="text-muted-foreground text-xs font-medium">
+          참여자 {members.length.toLocaleString("ko-KR")}명
+        </span>
+      </div>
 
       <ScrollArea className="min-h-0 flex-1">
         <ul className="py-1" role="list">

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -17,16 +17,13 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
   return (
     <section
       className={cn(
-        "flex min-h-0 shrink-0 flex-col overflow-hidden bg-background",
-        "md:h-full md:w-80 md:shrink-0 md:border-r md:border-border",
+        "bg-background flex min-h-0 shrink-0 flex-col overflow-hidden",
+        "md:border-border md:h-full md:w-80 md:shrink-0 md:border-r",
         className,
       )}
     >
-      {/* py-3 + text-sm → 채팅 섹션 헤더와 동일 높이 */}
-      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-3">
-        <span className="text-sm font-medium text-muted-foreground">
-          참여자 {members.length.toLocaleString("ko-KR")}명
-        </span>
+      <div className="border-border/50 bg-muted/20 flex h-14 shrink-0 items-center border-b px-4">
+        <span className="text-sm font-medium">채팅방 참여 인원</span>
       </div>
 
       <ScrollArea className="min-h-0 flex-1">

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -22,14 +22,15 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
         className,
       )}
     >
-      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-2.5">
-        <span className="text-xs font-medium text-muted-foreground">
+      {/* py-3 + text-sm → 채팅 섹션 헤더와 동일 높이 */}
+      <div className="flex shrink-0 items-center border-b border-border/50 bg-muted/20 px-4 py-3">
+        <span className="text-sm font-medium text-muted-foreground">
           참여자 {members.length.toLocaleString("ko-KR")}명
         </span>
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <ul className="py-1" role="list">
+        <ul className="py-1.5" role="list">
           {members.map((member) => (
             <li key={`${member.chat_room_id}-${member.user_id}`}>
               <MemberItem

--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -60,7 +60,7 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   };
 
   return (
-    <div className="border-border bg-background/95 flex shrink-0 gap-2 border-t p-2 backdrop-blur-sm">
+    <div className="border-border bg-background/95 flex shrink-0 items-center gap-2 border-t px-3 py-2 backdrop-blur-sm">
       <ChatEmojiPicker
         disabled={disabled}
         onEmojiSelect={(emoji) =>
@@ -85,19 +85,20 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
             ? (disabledHint ?? getAppMessageTitle(APP_MESSAGE_CODE.error.chatRoom.inputLocked))
             : "채팅하기"
         }
-        className="border-border/80 bg-muted/40 flex-1 text-sm"
+        className="h-9 flex-1 rounded-xl border-border/60 bg-muted/30 py-0 text-sm placeholder:text-muted-foreground/60"
         aria-label="메시지 입력"
       />
       <Button
         type="button"
-        size="icon-sm"
-        variant="secondary"
+        size="icon-lg"
+        variant="ghost"
         disabled={disabled}
         title={disabled ? disabledHint : undefined}
         onClick={() => void handleSend()}
         aria-label="전송"
+        className="shrink-0 text-brand hover:bg-brand/10 hover:text-brand"
       >
-        <SendHorizontal className="size-4" />
+        <SendHorizontal className="size-5" />
       </Button>
     </div>
   );

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -40,7 +40,7 @@ export function MessageItem({ message, isOwn }: Props) {
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
-        <div className="mb-0.5 text-xs font-medium text-[#94eaff]">{nickname}</div>
+        <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
         <div
           className={cn(
             "inline-block max-w-full rounded-md px-2 py-1 text-sm leading-snug",

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -20,11 +20,11 @@ export function MessageItem({ message, isOwn }: Props) {
 
   if (isOwn) {
     return (
-      <div className="flex justify-end px-2 py-0.5">
+      <div className="flex justify-end px-3 py-0.5">
         <div
           className={cn(
-            "max-w-[88%] rounded-lg px-2.5 py-1.5 text-sm leading-snug",
-            "bg-primary text-primary-foreground",
+            "max-w-[88%] rounded-2xl rounded-tr-sm px-3 py-1.5 text-sm leading-snug",
+            "bg-brand text-white",
           )}
         >
           <span className="wrap-break-word">{message.content}</span>
@@ -34,8 +34,8 @@ export function MessageItem({ message, isOwn }: Props) {
   }
 
   return (
-    <div className="flex gap-2 px-2 py-0.5">
-      <Avatar size="sm" className="mt-0.5">
+    <div className="flex gap-2 px-3 py-0.5">
+      <Avatar size="sm" className="mt-0.5 shrink-0">
         {photoUrl && <AvatarImage src={photoUrl} alt="" />}
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
@@ -43,7 +43,7 @@ export function MessageItem({ message, isOwn }: Props) {
         <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
         <div
           className={cn(
-            "inline-block max-w-full rounded-md px-2 py-1 text-sm leading-snug",
+            "inline-block max-w-full rounded-2xl rounded-tl-sm px-3 py-1.5 text-sm leading-snug",
             "bg-muted/60 text-foreground",
           )}
         >

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -35,19 +35,19 @@ export function MessageItem({ message, isOwn }: Props) {
 
   return (
     <div className="flex gap-2 px-3 py-0.5">
-      <Avatar size="sm" className="mt-0.5 shrink-0">
+      <Avatar size={"lg"} className="mt-0.5 shrink-0">
         {photoUrl && <AvatarImage src={photoUrl} alt="" />}
         <AvatarFallback>{fallbackText}</AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
-        <div className="mb-0.5 text-xs font-medium text-info">{nickname}</div>
+        <div className="mb-1.5 text-xs font-medium">{nickname}</div>
         <div
           className={cn(
             "inline-block max-w-full rounded-2xl rounded-tl-sm px-3 py-1.5 text-sm leading-snug",
             "bg-muted/60 text-foreground",
           )}
         >
-          <span className="wrap-break-word">{message.content}</span>
+          <span>{message.content}</span>
         </div>
       </div>
     </div>

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -47,7 +47,7 @@ export function MessageItem({ message, isOwn }: Props) {
             "bg-muted/60 text-foreground",
           )}
         >
-          <span>{message.content}</span>
+          <span className="wrap-break-word">{message.content}</span>
         </div>
       </div>
     </div>

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -4,6 +4,7 @@
 import SearchInput from "@/components/search/search-input";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
+import { Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -25,23 +26,32 @@ export default function HeaderSearchForm() {
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
-
-    if (!trimmedQuery || isLiveSearchDisabled) {
-      return;
-    }
-
+    if (!trimmedQuery || isLiveSearchDisabled) return;
     router.push(resolveSearchPath(activeMenu, trimmedQuery));
     setQuery("");
   };
 
   return (
-    <SearchInput
-      value={query}
-      onChange={setQuery}
-      onSubmit={handleSearch}
-      placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
-      disabled={isLiveSearchDisabled}
-      className="order-3 mt-2 w-full basis-full sm:order-0 sm:mt-0 sm:w-48 sm:basis-auto md:w-64"
-    />
+    <>
+      {/* 모바일: 검색 아이콘 버튼으로 검색 페이지 이동 */}
+      <button
+        className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
+        onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
+        disabled={isLiveSearchDisabled}
+        aria-label="채팅방 검색"
+      >
+        <Search className="size-5" />
+      </button>
+
+      {/* sm 이상: 검색 인풋 */}
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        onSubmit={handleSearch}
+        placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
+        disabled={isLiveSearchDisabled}
+        className="hidden sm:block sm:w-48 md:w-64"
+      />
+    </>
   );
 }

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -2,6 +2,7 @@
 
 // Header에서 검색어를 입력받아 검색 페이지로 이동합니다.
 import SearchInput from "@/components/search/search-input";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
@@ -49,26 +50,30 @@ export default function HeaderSearchForm() {
               disabled={isLiveSearchDisabled}
               className="w-44"
             />
-            <button
-              className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+            <Button
+              variant="ghost"
+              size="icon-sm"
               onClick={handleClose}
               aria-label="검색 닫기"
+              className="text-muted-foreground hover:text-foreground shrink-0"
             >
               <X className="size-4" />
-            </button>
+            </Button>
           </div>
         ) : (
-          <button
-            className={cn(
-              "text-muted-foreground hover:text-foreground p-1 transition-colors",
-              isLiveSearchDisabled && "cursor-not-allowed opacity-50",
-            )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={() => !isLiveSearchDisabled && setMobileOpen(true)}
             disabled={isLiveSearchDisabled}
             aria-label="채팅방 검색"
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              isLiveSearchDisabled && "cursor-not-allowed",
+            )}
           >
             <Search className="size-5" />
-          </button>
+          </Button>
         )}
       </div>
 

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -5,60 +5,81 @@ import SearchInput from "@/components/search/search-input";
 import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
-import { Search } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
   const searchParams = new URLSearchParams({ query });
-
-  if (activeMenu === "live") {
-    return `/search/live?${searchParams.toString()}`;
-  }
-
+  if (activeMenu === "live") return `/search/live?${searchParams.toString()}`;
   return `/search/chat?${searchParams.toString()}`;
 }
 
 export default function HeaderSearchForm() {
   const router = useRouter();
-  const pathname = usePathname();
   const activeMenu = useMainMenuStore((state) => state.activeMenu);
   const [query, setQuery] = useState("");
+  const [mobileOpen, setMobileOpen] = useState(false);
   const isLiveSearchDisabled = activeMenu === "live";
-  const isOnSearchPage = pathname.startsWith("/search/");
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
     if (!trimmedQuery || isLiveSearchDisabled) return;
     router.push(resolveSearchPath(activeMenu, trimmedQuery));
     setQuery("");
+    setMobileOpen(false);
+  };
+
+  const handleClose = () => {
+    setMobileOpen(false);
+    setQuery("");
   };
 
   return (
     <>
-      {/* 모바일 전용 아이콘 버튼 — 검색 페이지가 아닐 때만 표시 */}
-      {!isOnSearchPage && (
-        <button
-          className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
-          onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
-          disabled={isLiveSearchDisabled}
-          aria-label="채팅방 검색"
-        >
-          <Search className="size-5" />
-        </button>
-      )}
+      {/* 모바일: 아이콘 토글 → 검색창 인라인 표시 */}
+      <div className="sm:hidden">
+        {mobileOpen ? (
+          <div className="flex items-center gap-1">
+            <SearchInput
+              value={query}
+              onChange={setQuery}
+              onSubmit={handleSearch}
+              placeholder="채팅방 검색"
+              disabled={isLiveSearchDisabled}
+              className="w-44"
+            />
+            <button
+              className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+              onClick={handleClose}
+              aria-label="검색 닫기"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        ) : (
+          <button
+            className={cn(
+              "text-muted-foreground hover:text-foreground p-1 transition-colors",
+              isLiveSearchDisabled && "cursor-not-allowed opacity-50",
+            )}
+            onClick={() => !isLiveSearchDisabled && setMobileOpen(true)}
+            disabled={isLiveSearchDisabled}
+            aria-label="채팅방 검색"
+          >
+            <Search className="size-5" />
+          </button>
+        )}
+      </div>
 
-      {/* 검색 입력창 — sm 이상 항상, 모바일은 검색 페이지에서만 표시 */}
+      {/* sm 이상: 항상 검색 인풋 */}
       <SearchInput
         value={query}
         onChange={setQuery}
         onSubmit={handleSearch}
         placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
         disabled={isLiveSearchDisabled}
-        className={cn(
-          "sm:block sm:w-48 md:w-64",
-          isOnSearchPage ? "block w-40" : "hidden",
-        )}
+        className="hidden sm:block sm:w-48 md:w-64"
       />
     </>
   );

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -2,10 +2,11 @@
 
 // Header에서 검색어를 입력받아 검색 페이지로 이동합니다.
 import SearchInput from "@/components/search/search-input";
+import { cn } from "@/lib/utils";
 import { useMainMenuStore } from "@/stores/main-menu";
 import type { MainMenuSidebarKey } from "@/types/main-menu-sidebar";
 import { Search } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
@@ -20,9 +21,11 @@ function resolveSearchPath(activeMenu: MainMenuSidebarKey, query: string) {
 
 export default function HeaderSearchForm() {
   const router = useRouter();
+  const pathname = usePathname();
   const activeMenu = useMainMenuStore((state) => state.activeMenu);
   const [query, setQuery] = useState("");
   const isLiveSearchDisabled = activeMenu === "live";
+  const isOnSearchPage = pathname.startsWith("/search/");
 
   const handleSearch = () => {
     const trimmedQuery = query.trim();
@@ -33,24 +36,29 @@ export default function HeaderSearchForm() {
 
   return (
     <>
-      {/* 모바일: 검색 아이콘 버튼으로 검색 페이지 이동 */}
-      <button
-        className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
-        onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
-        disabled={isLiveSearchDisabled}
-        aria-label="채팅방 검색"
-      >
-        <Search className="size-5" />
-      </button>
+      {/* 모바일 전용 아이콘 버튼 — 검색 페이지가 아닐 때만 표시 */}
+      {!isOnSearchPage && (
+        <button
+          className="text-muted-foreground hover:text-foreground p-1 transition-colors sm:hidden"
+          onClick={() => !isLiveSearchDisabled && router.push("/search/chat")}
+          disabled={isLiveSearchDisabled}
+          aria-label="채팅방 검색"
+        >
+          <Search className="size-5" />
+        </button>
+      )}
 
-      {/* sm 이상: 검색 인풋 */}
+      {/* 검색 입력창 — sm 이상 항상, 모바일은 검색 페이지에서만 표시 */}
       <SearchInput
         value={query}
         onChange={setQuery}
         onSubmit={handleSearch}
         placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
         disabled={isLiveSearchDisabled}
-        className="hidden sm:block sm:w-48 md:w-64"
+        className={cn(
+          "sm:block sm:w-48 md:w-64",
+          isOnSearchPage ? "block w-40" : "hidden",
+        )}
       />
     </>
   );

--- a/src/components/setting/profile/linked-oauth-alert-dialog.tsx
+++ b/src/components/setting/profile/linked-oauth-alert-dialog.tsx
@@ -46,7 +46,6 @@ export default function LinkedOAuthAlertDialog({
   const [isLoading, setIsLoading] = useState(false);
 
   const linkOAuthAction = async (provider: OAuthProvider) => {
-    setIsLoading(true);
     const supabase = createClient();
 
     const { error } = await supabase.auth.signInWithOAuth({
@@ -59,9 +58,8 @@ export default function LinkedOAuthAlertDialog({
     if (error) {
       console.error("linkOAuthAction signInWithOAuth error", error);
       toastAppError(APP_MESSAGE_CODE.error.oauth.linkFailed);
+      setIsLoading(false);
     }
-
-    setIsLoading(false);
   };
 
   const handleToggle = async (provider: OAuthProvider) => {
@@ -78,27 +76,30 @@ export default function LinkedOAuthAlertDialog({
             `${OAUTH_PROVIDER_META[provider].name} 연동이 해제되었습니다.`,
           );
           await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.auth.all });
+          setOpen(false);
         } else {
           toastAppError(result.code ?? APP_MESSAGE_CODE.error.oauth.unlinkFailed);
         }
+        setIsLoading(false);
       } else {
-        // 연동 로직
         await linkOAuthAction(provider);
-        return;
       }
     } catch (error) {
       console.error("LinkedOAuthAlertDialog toggle error", error);
       toastAppError(APP_MESSAGE_CODE.error.oauth.actionFailed);
-    } finally {
       setIsLoading(false);
-      setOpen(false);
     }
   };
 
   const { logo, name: providerName } = OAUTH_PROVIDER_META[provider];
 
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isLoading) setOpen(next);
+      }}
+    >
       <AlertDialogTrigger
         render={
           <Button
@@ -125,36 +126,55 @@ export default function LinkedOAuthAlertDialog({
           </Button>
         }
       />
-      <AlertDialogContent className="border-brand/20 shadow-brand/10 dark:border-brand/10 overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md">
-        <AlertDialogHeader className="bg-brand/5 border-brand/10 border-b px-5 pt-5 pb-4 text-left">
-          <div className="flex items-center gap-3">
-            <span className="bg-background ring-brand/20 flex size-10 shrink-0 items-center justify-center rounded-xl ring-1">
-              <Image
-                src={logo}
-                alt={providerName}
-                width={20}
-                height={20}
-                className={provider === "github" ? "dark:invert" : undefined}
-              />
-            </span>
-            <div className="min-w-0">
-              <AlertDialogTitle className="text-lg font-bold">
-                {isLinked ? `${providerName} 계정 연동 해제` : `${providerName} 계정 연동`}
-              </AlertDialogTitle>
-              <AlertDialogDescription className="mt-1 leading-relaxed text-pretty">
-                {isLinked
-                  ? `${providerName} 계정 연결을 해제합니다. 이메일 계정 또는 다른 소셜 계정이 남아 있어야 합니다.`
-                  : `${providerName} 계정을 현재 프로필에 연결합니다.`}
-              </AlertDialogDescription>
-            </div>
+      <AlertDialogContent
+        className={cn(
+          "overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md",
+          isLinked
+            ? "border-destructive/20 shadow-destructive/10"
+            : "border-brand/20 shadow-brand/10 dark:border-brand/10",
+        )}
+      >
+        <AlertDialogHeader
+          className={cn(
+            "flex items-center gap-4 border-b px-5 pt-5 pb-4 text-left",
+            isLinked ? "bg-destructive/5 border-destructive/10" : "bg-brand/5 border-brand/10",
+          )}
+        >
+          <span
+            className={cn(
+              "bg-background flex size-10 shrink-0 items-center justify-center rounded-xl ring-1",
+              isLinked ? "ring-destructive/20" : "ring-brand/20",
+            )}
+          >
+            <Image
+              src={logo}
+              alt={providerName}
+              width={20}
+              height={20}
+              className={provider === "github" ? "dark:invert" : undefined}
+            />
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <AlertDialogTitle className="text-lg leading-tight font-bold">
+              {isLinked ? `${providerName} 계정 연동 해제` : `${providerName} 계정 연동`}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="leading-snug text-pretty whitespace-pre-line">
+              {isLinked
+                ? `${providerName} 계정 연결을 해제합니다.`
+                : `${providerName} 계정을 현재 프로필에 연결합니다.`}
+            </AlertDialogDescription>
           </div>
         </AlertDialogHeader>
         <AlertDialogFooter className="m-0 flex-row justify-end gap-2 border-0 bg-transparent px-5 pt-4 pb-5">
-          <AlertDialogCancel className="border-border bg-background text-foreground hover:bg-muted h-10 min-w-24 rounded-xl px-4 font-semibold">
+          <AlertDialogCancel
+            disabled={isLoading}
+            className="border-border bg-background text-foreground hover:bg-muted h-10 min-w-24 rounded-xl px-4 font-semibold"
+          >
             돌아가기
           </AlertDialogCancel>
           <AlertDialogAction
             variant={isLinked ? "destructive" : "default"}
+            disabled={isLoading}
             className={cn(
               "h-10 min-w-24 rounded-xl px-4 font-bold shadow-sm",
               isLinked

--- a/src/components/setting/profile/profile-avatar-upload.tsx
+++ b/src/components/setting/profile/profile-avatar-upload.tsx
@@ -75,11 +75,11 @@ export default function ProfileAvatarUpload({
         <div
           className={cn(
             "pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-full text-white transition-opacity",
-            isHovering || isDragging ? "bg-black/55 opacity-100" : "opacity-0",
+            isHovering || isDragging ? "bg-black/55 opacity-100 dark:bg-black/70" : "opacity-0",
           )}
         >
           <Camera className="size-6" />
-          <span className="text-[11px] font-medium tracking-wider uppercase">
+          <span className="text-xs font-medium tracking-wider uppercase">
             {isDragging ? "Drop" : "변경"}
           </span>
         </div>

--- a/src/components/setting/setting-shell.tsx
+++ b/src/components/setting/setting-shell.tsx
@@ -6,7 +6,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/s
 import { useIsMobile } from "@/hooks/use-mobile";
 import { ReactNode } from "react";
 
-export function SettingsShell({ children }: { children: ReactNode }) {
+export function SettingShell({ children }: { children: ReactNode }) {
   const isMobile = useIsMobile();
 
   return (
@@ -14,7 +14,7 @@ export function SettingsShell({ children }: { children: ReactNode }) {
       <SettingSidebar isMobile={isMobile} />
       <SidebarInset className="min-w-0 overflow-hidden">
         {isMobile && (
-          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
+          <div className="border-border flex shrink-0 items-center gap-3 border-b p-4">
             <SidebarTrigger className="cursor-pointer" />
             <span className="text-foreground text-sm font-semibold">설정</span>
           </div>

--- a/src/components/setting/setting-sidebar.tsx
+++ b/src/components/setting/setting-sidebar.tsx
@@ -19,7 +19,7 @@ import { useAuthStore } from "@/stores/auth";
 import { LogOut } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
-export default function SettingSidebar() {
+export default function SettingSidebar({ isMobile }: { isMobile?: boolean }) {
   const router = useRouter();
   const pathname = usePathname();
   const supabase = createClient();
@@ -35,7 +35,7 @@ export default function SettingSidebar() {
 
   return (
     <Sidebar
-      collapsible="none"
+      collapsible={isMobile ? "offcanvas" : "none"}
       className="bg-background h-full shrink-0 border-r"
     >
       <SidebarContent>

--- a/src/components/setting/settings-shell.tsx
+++ b/src/components/setting/settings-shell.tsx
@@ -1,0 +1,26 @@
+// 설정 레이아웃 전체를 감싸는 클라이언트 쉘 — 모바일 offcanvas sidebar 처리
+"use client";
+
+import SettingSidebar from "@/components/setting/setting-sidebar";
+import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { ReactNode } from "react";
+
+export function SettingsShell({ children }: { children: ReactNode }) {
+  const isMobile = useIsMobile();
+
+  return (
+    <SidebarProvider className="h-app-content min-h-0 overflow-hidden">
+      <SettingSidebar isMobile={isMobile} />
+      <SidebarInset className="min-w-0 overflow-hidden">
+        {isMobile && (
+          <div className="flex shrink-0 items-center gap-3 border-b border-border p-4">
+            <SidebarTrigger className="cursor-pointer" />
+            <span className="text-foreground text-sm font-semibold">설정</span>
+          </div>
+        )}
+        <div className="h-full min-w-0 overflow-auto p-6 md:p-10">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/hooks/use-chat-room-member-realtime.ts
+++ b/src/hooks/use-chat-room-member-realtime.ts
@@ -21,7 +21,7 @@ export function useChatRoomMemberRealtime({
   const queryClient = useQueryClient();
   const supabase = createClient();
 
-  const { data: membership } = useQuery({
+  const { data: membership, isFetched: membershipFetched } = useQuery({
     queryKey: [...QUERY_KEYS.chat.members(roomId), currentUserId],
     enabled: !!roomId && !!currentUserId,
     queryFn: async () => {
@@ -83,5 +83,5 @@ export function useChatRoomMemberRealtime({
     };
   }, [supabase, queryClient, roomId, currentUserId]);
 
-  return { isKicked, isJoined };
+  return { isKicked, isJoined, membershipFetched };
 }

--- a/src/hooks/use-chat-room-member-realtime.ts
+++ b/src/hooks/use-chat-room-member-realtime.ts
@@ -1,13 +1,13 @@
 "use client";
 
-// 채팅방 멤버 상태 변경 Realtime 이벤트를 관리하는 훅
-import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+// 채팅방 멤버 상태(참여/강퇴)를 본인 row 단건 조회 + Realtime 구독으로 관리하는 훅
+
+import { useEffect } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { QUERY_KEYS } from "@/constants/query-keys";
 import { createClient } from "@/lib/supabase/client";
-import type { RoomMember } from "@/types/chat-room-member";
 
 interface UseChatRoomMemberRealtimeParams {
   roomId: string;
@@ -19,53 +19,34 @@ export function useChatRoomMemberRealtime({
   currentUserId,
 }: UseChatRoomMemberRealtimeParams) {
   const queryClient = useQueryClient();
-  const [isKicked, setIsKicked] = useState(false);
+  const supabase = createClient();
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsKicked(false);
-
-    if (!roomId || !currentUserId) return;
-
-    let ignore = false;
-
-    const supabase = createClient();
-
-    const checkInitialStatus = async () => {
+  const { data: membership } = useQuery({
+    queryKey: [...QUERY_KEYS.chat.members(roomId), currentUserId],
+    enabled: !!roomId && !!currentUserId,
+    queryFn: async () => {
       const { data, error } = await supabase
         .from("chat_room_member")
-        .select("is_banned")
+        .select("is_banned, last_joined_at")
         .eq("chat_room_id", roomId)
         .eq("user_id", currentUserId)
         .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
 
-      if (!ignore && !error && data?.is_banned) {
-        setIsKicked(true);
-      }
-    };
+  const isKicked = membership?.is_banned ?? false;
+  const isJoined = !!membership?.last_joined_at && !membership.is_banned;
 
-    checkInitialStatus();
+  useEffect(() => {
+    if (!roomId || !currentUserId) return;
 
     const invalidateChatRoomQueries = () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.members(roomId) });
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.room(roomId) });
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.rooms() });
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.counts() });
-    };
-
-    const handleMemberChange = (payload: RealtimePostgresChangesPayload<RoomMember>) => {
-      invalidateChatRoomQueries();
-
-      if (payload.eventType !== "UPDATE") return;
-
-      const previous = payload.old as Partial<RoomMember>;
-      const next = payload.new as RoomMember;
-      const wasKicked =
-        previous.is_banned === false && next.is_banned === true && next.user_id === currentUserId;
-
-      if (wasKicked) {
-        setIsKicked(true);
-      }
     };
 
     const channel = supabase
@@ -78,7 +59,9 @@ export function useChatRoomMemberRealtime({
           table: "chat_room_member",
           filter: `chat_room_id=eq.${roomId}`,
         },
-        handleMemberChange,
+        () => {
+          invalidateChatRoomQueries();
+        },
       )
       .on(
         "postgres_changes",
@@ -89,16 +72,16 @@ export function useChatRoomMemberRealtime({
           filter: `id=eq.${roomId}`,
         },
         () => {
-          invalidateChatRoomQueries();
+          void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.room(roomId) });
+          void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.rooms() });
         },
       )
       .subscribe();
 
     return () => {
-      ignore = true;
       void channel.unsubscribe();
     };
-  }, [currentUserId, queryClient, roomId]);
+  }, [supabase, queryClient, roomId, currentUserId]);
 
-  return { isKicked };
+  return { isKicked, isJoined };
 }

--- a/src/hooks/use-chat-room-member-realtime.ts
+++ b/src/hooks/use-chat-room-member-realtime.ts
@@ -19,6 +19,8 @@ export function useChatRoomMemberRealtime({
   currentUserId,
 }: UseChatRoomMemberRealtimeParams) {
   const queryClient = useQueryClient();
+
+  // supabase는 공식문서에도 나와있음 이렇게 사용하면 싱글톤 패턴으로 등록됨 전혀 고려할 문제없음
   const supabase = createClient();
 
   const { data: membership, isFetched: membershipFetched } = useQuery({

--- a/src/hooks/use-join-chat-room.ts
+++ b/src/hooks/use-join-chat-room.ts
@@ -1,0 +1,24 @@
+"use client";
+
+// join_chat_room RPC 호출 후 채팅방 멤버·룸 관련 쿼리를 무효화하는 mutation 훅
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { QUERY_KEYS } from "@/constants/query-keys";
+import { createClient } from "@/lib/supabase/client";
+
+export function useJoinChatRoom() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (roomId: string) => {
+      const supabase = createClient();
+      const { error } = await supabase.rpc("join_chat_room", { p_room_id: roomId });
+      if (error) throw error;
+    },
+    onSuccess: (_, roomId) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.members(roomId) });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.room(roomId) });
+    },
+  });
+}

--- a/src/hooks/use-join-chat-room.ts
+++ b/src/hooks/use-join-chat-room.ts
@@ -1,6 +1,5 @@
-"use client";
-
 // join_chat_room RPC 호출 후 채팅방 멤버·룸 관련 쿼리를 무효화하는 mutation 훅
+"use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -14,14 +14,14 @@ interface MessagesPage {
   nextCursor?: string;
 }
 
-export default function useMessages(chatRoomId: string) {
+export default function useMessages(chatRoomId: string, enabled = true) {
   const supabase = createClient();
   const queryClient = useQueryClient();
 
   const query = useInfiniteQuery({
     queryKey: QUERY_KEYS.chat.messages(chatRoomId),
     initialPageParam: undefined as string | undefined,
-    enabled: !!chatRoomId,
+    enabled: enabled && !!chatRoomId,
     staleTime: 1000 * 60,
     queryFn: async ({ pageParam }): Promise<MessagesPage> => {
       let request = supabase
@@ -55,7 +55,7 @@ export default function useMessages(chatRoomId: string) {
   });
 
   useEffect(() => {
-    if (!chatRoomId) return;
+    if (!enabled || !chatRoomId) return;
 
     const channel = supabase
       .channel(`room-message-${chatRoomId}`)
@@ -108,7 +108,7 @@ export default function useMessages(chatRoomId: string) {
     return () => {
       void channel.unsubscribe();
     };
-  }, [queryClient, chatRoomId, supabase]);
+  }, [queryClient, chatRoomId, supabase, enabled]);
 
   const messages = query.data ?? [];
 

--- a/src/hooks/use-room-members.ts
+++ b/src/hooks/use-room-members.ts
@@ -4,12 +4,12 @@ import { QUERY_KEYS } from "@/constants/query-keys";
 import { createClient } from "@/lib/supabase/client";
 import type { RoomMemberQuery } from "@/types/chat-room-member";
 
-export function useRoomMembers(roomId: string) {
+export function useRoomMembers(roomId: string, enabled = true) {
   const supabase = createClient();
 
   return useQuery<RoomMemberQuery[]>({
     queryKey: QUERY_KEYS.chat.members(roomId),
-    enabled: !!roomId,
+    enabled: enabled && !!roomId,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("chat_room_member")

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -225,7 +225,7 @@ export type Database = {
           unread_count: number
         }[]
       }
-      join_chat_room: { Args: { p_chat_room_id: string }; Returns: string }
+      join_chat_room: { Args: { p_room_id: string }; Returns: undefined }
       kick_chat_room_member: {
         Args: { p_room_id: string; p_target_user_id: string }
         Returns: undefined

--- a/supabase/migrations/20260514030000_replace_join_chat_room_rpc.sql
+++ b/supabase/migrations/20260514030000_replace_join_chat_room_rpc.sql
@@ -1,0 +1,44 @@
+-- 기존 join_chat_room RPC 폐기 (status 5종 반환하던 복잡한 버전)
+drop function if exists public.join_chat_room(uuid);
+
+-- 신규 join_chat_room: 단순 upsert (security invoker로 RLS 위임)
+create or replace function public.join_chat_room(p_room_id uuid)
+returns void
+language sql
+security invoker
+set search_path = public, auth
+as $$
+  insert into public.chat_room_member (chat_room_id, user_id, last_joined_at)
+  values (p_room_id, auth.uid(), now())
+  on conflict (chat_room_id, user_id)
+  do update set last_joined_at = now();
+$$;
+
+-- 재참여(last_joined_at NULL → 값) 시 정원 초과 차단 트리거
+create or replace function public.check_chat_room_capacity_on_rejoin()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_current_member smallint;
+  v_max_capacity smallint;
+begin
+  if old.last_joined_at is null and new.last_joined_at is not null then
+    select current_member, max_capacity
+    into v_current_member, v_max_capacity
+    from public.chat_room
+    where id = new.chat_room_id;
+
+    if v_current_member >= v_max_capacity then
+      raise exception 'chat room is full';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trigger_check_capacity_on_rejoin on public.chat_room_member;
+create trigger trigger_check_capacity_on_rejoin
+before update on public.chat_room_member
+for each row execute function public.check_chat_room_capacity_on_rejoin();


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/chat/join-room/#59 -> dev

### ✅ 작업 내용 `기능 추가`, `기능 개선`, `리팩토링`

- 기존 `join_chat_room` RPC를 단순 upsert로 교체하고 재참여 정원 검사 BEFORE UPDATE 트리거 추가 (검증 책임을 RLS·트리거로 위임)
- `useChatRoomMemberRealtime`을 `useQuery` + `useEffect` 분리 구조로 리팩토링, `{ isKicked, isJoined }` 반환
- `useMessages`, `useRoomMembers`에 `enabled` 파라미터 추가 → 미참여 상태일 때 메시지/멤버 쿼리 발사 차단
- `/chat/[room-id]` 진입 시 미참여 유저에게 참여 확인 Dialog 노출, 정원 마감 상태에서는 안내 + 돌아가기만 표시
- 프로젝트 내 모든 AlertDialog 공통 flex 레이아웃(media + title/description)으로 통일
- `isFull` · `isKick` · `isLinked` 상태별 destructive/brand 베이스 색상 분기
- 미적용 상태였던 채팅방 나가기 Dialog에 프로젝트 dialog 틀 신규 적용
- OAuth 연동 Dialog: redirect 진행 중에도 spinner가 유지되도록 `handleToggle` 로직 보정, 로딩 중 close 차단

### 🎯 단독 테스트 결과

- 신규 참여: 한 번도 참여하지 않은 방 진입 → Dialog 표시 → "참여하기" 클릭 → realtime INSERT 수신 → Dialog 자동 닫힘, 메시지/멤버 쿼리 활성화
- 재참여: 이전에 나간 방(`last_joined_at IS NULL`) 진입 → Dialog 표시 → 참여 후 정상 진입
- 정원 마감: 정원 가득 찬 방 진입 → "정원이 가득 찬 채팅방입니다." 안내 + 돌아가기만 노출
- 강퇴 사용자: `KickedRoomAlertDialog`가 우선 노출되어 join dialog가 표시되지 않음
- 네트워크 패널: 미참여 상태에서 `message`, `chat_room_member` 리스트 쿼리가 발사되지 않는 것을 확인
- 모든 dialog의 헤더 레이아웃(아이콘 + 텍스트 그룹) 및 색상 베이스 일관성 확인
- OAuth 연동 클릭 시 redirect 진행 중 spinner가 유지되는 것을 확인

### 🚨 연관 이슈

closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일에서 검색창을 열고 닫을 수 있는 토글형 검색 UI 추가
  * 채팅방 참여 확인/참여 흐름을 안내하는 대화창 추가
  * 설정 화면 레이아웃을 감싸는 새 설정 쉘 추가

* **개선 사항**
  * 채팅방, 메시지, 멤버 목록, 헤더 등 레이아웃·간격·스타일 정돈
  * 로고 및 주요 UI 색상·토큰 통일, 버튼·입력·이모지 스타일 개선

* **오류 수정**
  * OAuth 동기화 실패 시 알림 표시 안정성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/60)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->