### PR TITLE
refactor(#61): 채팅방 목록 InfiniteQuery → Pagination 전환

### DIFF
--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { ChatRoomCardData } from "@/types/chat-room";
 import { formatCapacity, formatRoomDate } from "@/utils/chat-room";
-import { Clock, MessageCircle, Users } from "lucide-react";
+import { Clock, Crown, MessageCircle, Users } from "lucide-react";
 import Link from "next/link";
 
 interface Props {
@@ -42,11 +42,13 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
           </h3>
           <span
             className={cn(
-              "text-muted-foreground shrink-0 font-medium tracking-tight",
-              "text-xs",
+              "inline-flex w-fit shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5",
+              "bg-brand/10 text-brand dark:bg-brand/15",
+              "text-xs font-semibold tracking-tight",
             )}
           >
-            @{chatRoom.owner_nickname}
+            <Crown className="size-3" aria-hidden />
+            <span className="max-w-24 truncate">{chatRoom.owner_nickname}</span>
           </span>
         </div>
         {chatRoom.description && (

--- a/src/components/chat/chat-room-list-header.tsx
+++ b/src/components/chat/chat-room-list-header.tsx
@@ -6,9 +6,10 @@ import type { ChatRoomCounts } from "@/types/chat-room";
 
 interface Props {
   counts?: ChatRoomCounts;
+  isFetching?: boolean;
 }
 
-export default function ChatRoomListHeader({ counts }: Props) {
+export default function ChatRoomListHeader({ counts, isFetching = false }: Props) {
   return (
     <div
       className={cn(
@@ -16,7 +17,7 @@ export default function ChatRoomListHeader({ counts }: Props) {
         "lg:flex-row lg:items-center lg:justify-between",
       )}
     >
-      <ChatRoomTabs counts={counts} />
+      <ChatRoomTabs counts={counts} isFetching={isFetching} />
       <div
         className={cn("flex w-full items-center justify-between gap-3", "lg:w-auto lg:justify-end")}
       >

--- a/src/components/chat/chat-room-list.tsx
+++ b/src/components/chat/chat-room-list.tsx
@@ -4,15 +4,15 @@ import ChatRoomCard from "@/components/chat/chat-room-card";
 import ChatRoomEmptyState from "@/components/chat/chat-room-empty-state";
 import ChatRoomListHeader from "@/components/chat/chat-room-list-header";
 import ChatRoomListSkeleton from "@/components/chat/chat-room-list-skeleton";
+import ChatRoomPagination from "@/components/chat/chat-room-pagination";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
-import { Spinner } from "@/components/ui/spinner";
 import { useChatRoomCounts } from "@/hooks/use-chat-room-counts";
 import {
+  CHAT_ROOM_PAGE_SIZE,
   CHAT_ROOM_SORT_OPTIONS_BY_TAB,
   DEFAULT_CHAT_ROOM_SORT_OPTION,
 } from "@/constants/chat-room";
 import { useChatRooms } from "@/hooks/use-chat-rooms";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useUser } from "@/hooks/use-profile";
 import { useChatRoomStore } from "@/stores/chat-room";
 import { getAppMessage } from "@/utils/app-message";
@@ -20,24 +20,22 @@ import { getAppMessage } from "@/utils/app-message";
 export default function ChatRoomList() {
   const tabType = useChatRoomStore((state) => state.tabType);
   const sortOption = useChatRoomStore((state) => state.sortOption);
+  const currentPage = useChatRoomStore((state) => state.currentPage);
+  const setCurrentPage = useChatRoomStore((state) => state.setCurrentPage);
   const { isFetched: isUserFetched } = useUser();
 
   const selectedSortOption = CHAT_ROOM_SORT_OPTIONS_BY_TAB[tabType].includes(sortOption)
     ? sortOption
     : DEFAULT_CHAT_ROOM_SORT_OPTION;
-  const query = useChatRooms(tabType, selectedSortOption);
+  const query = useChatRooms(tabType, selectedSortOption, currentPage);
   const { data: counts } = useChatRoomCounts();
 
-  const chatRooms = query.data?.pages.flatMap((page) => page) ?? [];
-
-  const sentinelRef = useIntersectionObserver(() => {
-    if (query.hasNextPage && !query.isFetchingNextPage) {
-      void query.fetchNextPage();
-    }
-  });
+  const chatRooms = query.data ?? [];
+  const totalPages = Math.ceil((counts?.[tabType] ?? 0) / CHAT_ROOM_PAGE_SIZE);
 
   const isInitialLoading = !isUserFetched || query.isLoading;
   const isEmpty = isUserFetched && !query.isLoading && chatRooms.length === 0;
+  const isPageFetching = query.isFetching && query.isPlaceholderData;
 
   if (query.isError) {
     const message = getAppMessage(APP_MESSAGE_CODE.error.chatRoomList.loadFailed);
@@ -47,15 +45,15 @@ export default function ChatRoomList() {
   }
 
   return (
-    <div className="flex flex-col gap-5">
-      <ChatRoomListHeader counts={counts} />
+    <div className="flex min-h-full flex-col gap-5">
+      <ChatRoomListHeader counts={counts} isFetching={isPageFetching} />
 
-      {isInitialLoading ? (
-        <ChatRoomListSkeleton />
-      ) : isEmpty ? (
-        <ChatRoomEmptyState tabType={tabType} />
-      ) : (
-        <>
+      <div className="flex flex-1 flex-col">
+        {isInitialLoading ? (
+          <ChatRoomListSkeleton />
+        ) : isEmpty ? (
+          <ChatRoomEmptyState tabType={tabType} />
+        ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {chatRooms.map((chatRoom) => (
               <ChatRoomCard
@@ -65,17 +63,15 @@ export default function ChatRoomList() {
               />
             ))}
           </div>
-          {query.isFetchingNextPage && (
-            <div className="flex justify-center py-4">
-              <Spinner className="text-muted-foreground size-5" />
-            </div>
-          )}
-          <div ref={sentinelRef} aria-hidden="true" />
-          {!query.hasNextPage && !query.isLoading && chatRooms.length > 0 && (
-            <p className="text-muted-foreground text-center text-sm">모든 채팅방을 불러왔습니다.</p>
-          )}
-        </>
-      )}
+        )}
+      </div>
+
+      <ChatRoomPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        isFetching={isPageFetching}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 }

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -21,12 +21,6 @@ interface Props {
   onPageChange: (page: number) => void;
 }
 
-const activePageButtonClass = cn(
-  "bg-brand text-white shadow-sm shadow-brand/20 rounded-xl font-bold",
-  "hover:bg-brand/90 hover:text-white",
-  "dark:hover:bg-brand/90",
-);
-
 export default function ChatRoomPagination({
   currentPage,
   totalPages,

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -1,0 +1,151 @@
+// 채팅방 목록 페이지네이션 (shadcn Pagination wrapper)
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+} from "@/components/ui/pagination";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { getPageItems } from "@/utils/pagination";
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  isFetching: boolean;
+  onPageChange: (page: number) => void;
+}
+
+const activePageButtonClass = cn(
+  "bg-brand text-white shadow-sm shadow-brand/20 rounded-xl font-bold",
+  "hover:bg-brand/90 hover:text-white",
+  "dark:hover:bg-brand/90",
+);
+
+export default function ChatRoomPagination({
+  currentPage,
+  totalPages,
+  isFetching,
+  onPageChange,
+}: Props) {
+  if (totalPages <= 1) return null;
+
+  const items = getPageItems(currentPage, totalPages);
+  const isFirstPage = currentPage <= 1;
+
+  const handlePageClick = (e: React.MouseEvent, page: number) => {
+    e.preventDefault();
+    if (isFetching) return;
+    if (page < 1 || page > totalPages || page === currentPage) return;
+    onPageChange(page);
+  };
+
+  const handlePrevious = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isFetching || isFirstPage) return;
+    onPageChange(currentPage - 1);
+  };
+
+  // 마지막 페이지에서 "다음" 클릭 시 page=1로 순환
+  const handleNext = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isFetching) return;
+    if (currentPage >= totalPages) {
+      onPageChange(1);
+      return;
+    }
+    onPageChange(currentPage + 1);
+  };
+
+  const isPrevDisabled = isFirstPage || isFetching;
+
+  return (
+    <Pagination className="pt-2">
+      <PaginationContent className="gap-1">
+        <PaginationItem>
+          <PaginationLink
+            href="#"
+            onClick={handlePrevious}
+            aria-disabled={isPrevDisabled}
+            aria-label="Go to previous page"
+            size="default"
+            className={cn(
+              "pl-1.5!",
+              "border-border/60 bg-background text-muted-foreground rounded-xl border font-semibold",
+              "hover:border-brand/40 hover:bg-brand/10 hover:text-brand",
+              "dark:border-border/30 dark:hover:bg-brand/15 dark:bg-zinc-900/50",
+              isPrevDisabled && "pointer-events-none opacity-50",
+            )}
+          >
+            {isFetching ? (
+              <Spinner data-icon="inline-start" className="size-4" />
+            ) : (
+              <ChevronLeftIcon data-icon="inline-start" />
+            )}
+            <span className="hidden sm:block">이전</span>
+          </PaginationLink>
+        </PaginationItem>
+        {items.map((item) =>
+          typeof item === "number" ? (
+            <PaginationItem key={item}>
+              <PaginationLink
+                href="#"
+                isActive={item === currentPage}
+                aria-disabled={isFetching}
+                onClick={(e) => handlePageClick(e, item)}
+                className={cn(
+                  item === currentPage
+                    ? cn(
+                        "bg-brand shadow-brand/20 rounded-xl font-bold text-white shadow-sm",
+                        "hover:bg-brand/90 hover:text-white",
+                        "dark:hover:bg-brand/90",
+                      )
+                    : cn(
+                        "text-muted-foreground rounded-xl font-semibold",
+                        "hover:bg-brand/10 hover:text-brand",
+                        "dark:hover:bg-brand/15",
+                      ),
+                  isFetching && "pointer-events-none opacity-50",
+                )}
+              >
+                {item}
+              </PaginationLink>
+            </PaginationItem>
+          ) : (
+            <PaginationItem key={item}>
+              <PaginationEllipsis className="text-muted-foreground/70" />
+            </PaginationItem>
+          ),
+        )}
+        <PaginationItem>
+          <PaginationLink
+            href="#"
+            onClick={handleNext}
+            aria-disabled={isFetching}
+            aria-label="Go to next page"
+            size="default"
+            className={cn(
+              "pr-1.5!",
+              "border-border/60 bg-background text-muted-foreground rounded-xl border font-semibold",
+              "hover:border-brand/40 hover:bg-brand/10 hover:text-brand",
+              "dark:border-border/30 dark:hover:bg-brand/15 dark:bg-zinc-900/50",
+              isFetching && "pointer-events-none opacity-50",
+            )}
+          >
+            <span className="hidden sm:block">다음</span>
+            {isFetching ? (
+              <Spinner data-icon="inline-end" className="size-4" />
+            ) : (
+              <ChevronRightIcon data-icon="inline-end" />
+            )}
+          </PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -36,7 +36,6 @@ export default function ChatRoomPagination({
   if (totalPages <= 1) return null;
 
   const items = getPageItems(currentPage, totalPages);
-  const isFirstPage = currentPage <= 1;
 
   const handlePageClick = (e: React.MouseEvent, page: number) => {
     e.preventDefault();
@@ -47,7 +46,11 @@ export default function ChatRoomPagination({
 
   const handlePrevious = (e: React.MouseEvent) => {
     e.preventDefault();
-    if (isFetching || isFirstPage) return;
+    if (isFetching) return;
+    if (currentPage <= 1) {
+      onPageChange(totalPages);
+      return;
+    }
     onPageChange(currentPage - 1);
   };
 
@@ -62,7 +65,7 @@ export default function ChatRoomPagination({
     onPageChange(currentPage + 1);
   };
 
-  const isPrevDisabled = isFirstPage || isFetching;
+  const isPrevDisabled = isFetching;
 
   return (
     <Pagination className="pt-2">

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -19,7 +19,7 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TooltipProvider delay={300}>
+      <TooltipProvider delay={0}>
         <TabsList
           className={cn(
             "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CHAT_ROOM_TABS, ROOM_TAB_LABELS } from "@/constants/chat-room";
 import { useChatRoomStore } from "@/stores/chat-room";
@@ -8,9 +9,10 @@ import { cn } from "@/lib/utils";
 
 interface Props {
   counts?: ChatRoomCounts;
+  isFetching?: boolean;
 }
 
-export default function ChatRoomTabs({ counts }: Props) {
+export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
   const tabType = useChatRoomStore((state) => state.tabType);
   const setTabType = useChatRoomStore((state) => state.setTabType);
 
@@ -50,7 +52,13 @@ export default function ChatRoomTabs({ counts }: Props) {
                       : "bg-muted-foreground/20 text-muted-foreground",
                 )}
               >
-                {count === undefined ? null : count > 99 ? "99+" : count}
+                {isFetching && tabType === tab ? (
+                  <Spinner className="size-3 text-white" />
+                ) : count === undefined ? null : count > 99 ? (
+                  "99+"
+                ) : (
+                  count
+                )}
               </span>
             </TabsTrigger>
           );

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -19,7 +19,7 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TooltipProvider delay={500}>
+      <TooltipProvider delay={300}>
         <TabsList
           className={cn(
             "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -51,11 +51,13 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
                 <span
                   className={cn(
                     "flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-xs leading-none font-black",
-                    count === undefined
-                      ? "invisible"
-                      : isActive
-                        ? "bg-brand text-white"
-                        : "bg-muted-foreground/20 text-muted-foreground",
+                    showSpinner
+                      ? "bg-brand text-white"
+                      : count === undefined
+                        ? "invisible"
+                        : isActive
+                          ? "bg-brand text-white"
+                          : "bg-muted-foreground/20 text-muted-foreground",
                   )}
                 >
                   {showSpinner ? (

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { CHAT_ROOM_TABS, ROOM_TAB_LABELS } from "@/constants/chat-room";
 import { useChatRoomStore } from "@/stores/chat-room";
 import type { ChatRoomCounts, ChatRoomTab } from "@/types/chat-room";
@@ -18,52 +19,76 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TabsList
-        className={cn(
-          "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",
-          "bg-muted/50 rounded-xl dark:bg-zinc-800/40",
-          "lg:w-150",
-        )}
-      >
-        {CHAT_ROOM_TABS.map((tab) => {
-          const count = counts?.[tab];
+      <TooltipProvider delay={500}>
+        <TabsList
+          className={cn(
+            "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",
+            "bg-muted/50 rounded-xl dark:bg-zinc-800/40",
+            "lg:w-150",
+          )}
+        >
+          {CHAT_ROOM_TABS.map((tab) => {
+            const count = counts?.[tab];
+            const isActive = tabType === tab;
+            const showSpinner = isFetching && isActive;
+            // 정확한 개수를 보여줄 수 있을 때만 Tooltip 활성화 (Spinner 중에는 비활성)
+            const hasOverflowCount = typeof count === "number" && count > 99 && !showSpinner;
 
-          return (
-            <TabsTrigger
-              key={tab}
-              value={tab}
-              className={({ active }) =>
-                cn(
-                  "relative flex h-auto min-w-0 cursor-pointer items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-semibold transition-all duration-200 lg:gap-1.5 lg:px-4",
-                  active
-                    ? "text-brand shadow-brand/10 bg-white shadow-sm dark:bg-zinc-900 dark:shadow-none"
-                    : "text-muted-foreground hover:text-foreground hover:bg-white/50 dark:hover:bg-zinc-700/40",
-                )
-              }
-            >
-              {ROOM_TAB_LABELS[tab]}
-              <span
-                className={cn(
-                  "flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-xs leading-none font-black",
-                  count === undefined
-                    ? "invisible"
-                    : tabType === tab
-                      ? "bg-brand text-white"
-                      : "bg-muted-foreground/20 text-muted-foreground",
-                )}
+            const trigger = (
+              <TabsTrigger
+                key={tab}
+                value={tab}
+                className={({ active }) =>
+                  cn(
+                    "relative flex h-auto min-w-0 cursor-pointer items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-semibold transition-all duration-200 lg:gap-1.5 lg:px-4",
+                    active
+                      ? "text-brand shadow-brand/10 bg-white shadow-sm dark:bg-zinc-900 dark:shadow-none"
+                      : "text-muted-foreground hover:text-foreground hover:bg-white/50 dark:hover:bg-zinc-700/40",
+                  )
+                }
               >
-                {isFetching && tabType === tab ? (
-                  <Spinner className="size-3 text-white" />
-                ) : count === undefined ? null : count > 99 ? (
-                  "99+"
-                ) : (
-                  count
-                )}
-              </span>
-            </TabsTrigger>
-          );
-        })}
-      </TabsList>
+                {ROOM_TAB_LABELS[tab]}
+                <span
+                  className={cn(
+                    "flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-xs leading-none font-black",
+                    count === undefined
+                      ? "invisible"
+                      : isActive
+                        ? "bg-brand text-white"
+                        : "bg-muted-foreground/20 text-muted-foreground",
+                  )}
+                >
+                  {showSpinner ? (
+                    <Spinner className="size-3 text-white" />
+                  ) : count === undefined ? null : count > 99 ? (
+                    "99+"
+                  ) : (
+                    count
+                  )}
+                </span>
+              </TabsTrigger>
+            );
+
+            if (!hasOverflowCount) return trigger;
+
+            return (
+              <Tooltip key={tab}>
+                <TooltipTrigger render={trigger} />
+                <TooltipContent
+                  className={cn(
+                    "bg-brand text-white",
+                    "shadow-brand/30 shadow-md",
+                    // TooltipContent 내부 자식(Arrow)에도 브랜드 컬러를 강제 적용
+                    "*:bg-brand! *:fill-brand!",
+                  )}
+                >
+                  {ROOM_TAB_LABELS[tab]} {count.toLocaleString()}개
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </TabsList>
+      </TooltipProvider>
     </Tabs>
   );
 }

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -2,28 +2,92 @@
 import { MemberActionPopover } from "@/components/member/member-action-popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import type { RoomMemberQuery } from "@/types/chat-room-member";
 import { getAvatarFallbackText } from "@/utils/avatar";
+import { Crown } from "lucide-react";
 
 interface Props {
   roomId: string;
   member: RoomMemberQuery;
+  isOwner: boolean;
   canManage: boolean;
 }
 
-export function MemberItem({ roomId, member, canManage }: Props) {
+function OwnerBadge() {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5",
+        "bg-brand/10 text-brand dark:bg-brand/15",
+        "text-[10px] leading-none font-black tracking-tight",
+      )}
+    >
+      <Crown className="size-2.5" aria-hidden />
+      방장
+    </span>
+  );
+}
+
+function MemberContent({
+  photoUrl,
+  fallbackText,
+  nickname,
+  isOwner,
+}: {
+  photoUrl: string | null;
+  fallbackText: string;
+  nickname: string;
+  isOwner: boolean;
+}) {
+  return (
+    <>
+      <div className="relative shrink-0">
+        <Avatar size="default">
+          {photoUrl ? <AvatarImage src={photoUrl} alt={`${nickname}의 프로필 사진`} /> : null}
+          <AvatarFallback>{fallbackText}</AvatarFallback>
+        </Avatar>
+        {isOwner && (
+          <span
+            aria-hidden
+            className="border-background bg-brand absolute -right-0.5 -bottom-0.5 h-3 w-3 rounded-full border-2"
+          />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span
+          className={cn(
+            "text-foreground min-w-0 truncate text-sm",
+            isOwner ? "font-semibold" : "font-normal",
+          )}
+        >
+          {nickname}
+        </span>
+        {isOwner && <OwnerBadge />}
+      </div>
+    </>
+  );
+}
+
+export function MemberItem({ roomId, member, isOwner, canManage }: Props) {
   const nickname = member.user.nickname;
   const photoUrl = member.user.photo_url;
   const fallbackText = getAvatarFallbackText(nickname);
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-3 rounded-md px-3 py-2">
-        <Avatar size="default" className="shrink-0">
-          {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-          <AvatarFallback>{fallbackText}</AvatarFallback>
-        </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
+      <div
+        className={cn(
+          "flex w-full items-center gap-3 rounded-md px-3 py-2",
+          isOwner && "bg-brand/5 dark:bg-brand/10",
+        )}
+      >
+        <MemberContent
+          photoUrl={photoUrl}
+          fallbackText={fallbackText}
+          nickname={nickname}
+          isOwner={isOwner}
+        />
       </div>
     );
   }
@@ -32,13 +96,17 @@ export function MemberItem({ roomId, member, canManage }: Props) {
     <MemberActionPopover roomId={roomId} member={member}>
       <Button
         variant="ghost"
-        className="flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors"
+        className={cn(
+          "flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors",
+          isOwner && "bg-brand/5 hover:bg-brand/10 dark:bg-brand/10 dark:hover:bg-brand/15",
+        )}
       >
-        <Avatar size="default" className="shrink-0">
-          {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-          <AvatarFallback>{fallbackText}</AvatarFallback>
-        </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
+        <MemberContent
+          photoUrl={photoUrl}
+          fallbackText={fallbackText}
+          nickname={nickname}
+          isOwner={isOwner}
+        />
       </Button>
     </MemberActionPopover>
   );

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -20,7 +20,7 @@ function OwnerBadge() {
       className={cn(
         "inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5",
         "bg-brand/10 text-brand dark:bg-brand/15",
-        "text-[10px] leading-none font-black tracking-tight",
+        "text-xs leading-none font-black tracking-tight",
       )}
     >
       <Crown className="size-2.5" aria-hidden />

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -27,16 +27,23 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <ul className="py-1.5" role="list">
-          {members.map((member) => (
-            <li key={`${member.chat_room_id}-${member.user_id}`}>
-              <MemberItem
-                roomId={roomId}
-                member={member}
-                canManage={canManageMembers && member.user_id !== currentUserId}
-              />
-            </li>
-          ))}
+        <ul className="flex flex-col gap-1 px-2 py-3">
+          {[...members]
+            .sort((a, b) => {
+              if (a.user_id === ownerId) return -1;
+              if (b.user_id === ownerId) return 1;
+              return 0;
+            })
+            .map((member) => (
+              <li key={`${member.chat_room_id}-${member.user_id}`}>
+                <MemberItem
+                  roomId={roomId}
+                  member={member}
+                  isOwner={member.user_id === ownerId}
+                  canManage={canManageMembers && member.user_id !== currentUserId}
+                />
+              </li>
+            ))}
         </ul>
       </ScrollArea>
     </section>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils/index";
+import { Button } from "@/components/ui/button";
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex items-center gap-0.5", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">;
+
+function PaginationLink({ className, isActive, size = "icon", ...props }: PaginationLinkProps) {
+  return (
+    <Button
+      variant={isActive ? "outline" : "ghost"}
+      size={size}
+      className={cn(className)}
+      nativeButton={false}
+      render={
+        <a
+          aria-current={isActive ? "page" : undefined}
+          data-slot="pagination-link"
+          data-active={isActive}
+          {...props}
+        />
+      }
+    />
+  );
+}
+
+function PaginationPrevious({
+  className,
+  text = "Previous",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("pl-1.5!", className)}
+      {...props}
+    >
+      <ChevronLeftIcon data-icon="inline-start" />
+      <span className="hidden sm:block">{text}</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({
+  className,
+  text = "Next",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("pr-1.5!", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">{text}</span>
+      <ChevronRightIcon data-icon="inline-end" />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn(
+        "flex size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/src/constants/chat-room.ts
+++ b/src/constants/chat-room.ts
@@ -2,7 +2,7 @@ import type { ChatRoomSortOption, ChatRoomTab } from "@/types/chat-room";
 
 export const CHAT_ROOM_MIN_CAPACITY = 2;
 export const CHAT_ROOM_MAX_CAPACITY = 50;
-export const CHAT_ROOM_PAGE_SIZE = 30;
+export const CHAT_ROOM_PAGE_SIZE = 16;
 
 export const CHAT_ROOM_TABS: ChatRoomTab[] = ["JOINED", "NOT_JOINED", "OWNED"];
 

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -17,12 +17,12 @@ export const QUERY_KEYS = {
   chat: {
     all: ["chat"] as const,
     rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number) =>
-      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter(Boolean),
-    counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter(Boolean),
-    room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
-    messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),
-    members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter(Boolean),
+      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter((v) => v !== undefined),
+    counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter((v) => v !== undefined),
+    room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter((v) => v !== undefined),
+    messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter((v) => v !== undefined),
+    members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter((v) => v !== undefined),
     search: (query?: string, section?: string) =>
-      [...QUERY_KEYS.chat.all, "search", query, section].filter(Boolean),
+      [...QUERY_KEYS.chat.all, "search", query, section].filter((v) => v !== undefined),
   },
 } as const;

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -16,8 +16,8 @@ export const QUERY_KEYS = {
   },
   chat: {
     all: ["chat"] as const,
-    rooms: (userId?: string, tabType?: string, sortOption?: string) =>
-      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption].filter(Boolean),
+    rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number) =>
+      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter(Boolean),
     counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter(Boolean),
     room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
     messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),

--- a/src/hooks/use-chat-rooms.ts
+++ b/src/hooks/use-chat-rooms.ts
@@ -1,6 +1,4 @@
-"use client";
-
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { CHAT_ROOM_PAGE_SIZE } from "@/constants/chat-room";
 import { QUERY_KEYS } from "@/constants/query-keys";
 import { useUser } from "@/hooks/use-profile";
@@ -37,18 +35,21 @@ const fetchRooms = async (
 
 /**
  * 채팅방 목록 조회 커스텀 훅
- * - 유저 프로필 정보가 로드된 후에만 목록을 페칭하도록 안전장치를 추가했습니다.
+ * - 페이지 단위로 limit/offset 기반 페이지네이션을 수행한다.
  */
-export function useChatRooms(tabType: ChatRoomTab, sortOption: ChatRoomSortOption) {
+export function useChatRooms(
+  tabType: ChatRoomTab,
+  sortOption: ChatRoomSortOption,
+  currentPage: number,
+) {
   const { data: currentUser, isFetched: isUserFetched } = useUser();
+  const offset = (currentPage - 1) * CHAT_ROOM_PAGE_SIZE;
 
-  return useInfiniteQuery<ChatRoomByTabWithUnreadCount[]>({
-    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption),
-    queryFn: ({ pageParam }) => fetchRooms(currentUser!.id, tabType, sortOption, Number(pageParam)),
+  return useQuery<ChatRoomByTabWithUnreadCount[]>({
+    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption, currentPage),
+    queryFn: () => fetchRooms(currentUser!.id, tabType, sortOption, offset),
     enabled: !!currentUser?.id && isUserFetched,
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === CHAT_ROOM_PAGE_SIZE ? allPages.length * CHAT_ROOM_PAGE_SIZE : undefined,
+    placeholderData: keepPreviousData,
     refetchOnMount: "always",
   });
 }

--- a/src/stores/chat-room.ts
+++ b/src/stores/chat-room.ts
@@ -6,8 +6,10 @@ import { devtools } from "zustand/middleware";
 interface ChatRoomState {
   tabType: ChatRoomTab;
   sortOption: ChatRoomSortOption;
+  currentPage: number;
   setTabType: (tabType: ChatRoomTab) => void;
   setSortOption: (sortOption: ChatRoomSortOption) => void;
+  setCurrentPage: (page: number) => void;
 }
 
 export const useChatRoomStore = create<ChatRoomState>()(
@@ -15,16 +17,21 @@ export const useChatRoomStore = create<ChatRoomState>()(
     (set) => ({
       tabType: "JOINED",
       sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
+      currentPage: 1,
       setTabType: (tabType) =>
         set(
           {
             tabType,
             sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
+            currentPage: 1,
           },
           false,
           "chatRoom/setTabType",
         ),
-      setSortOption: (sortOption) => set({ sortOption }, false, "chatRoom/setSortOption"),
+      setSortOption: (sortOption) =>
+        set({ sortOption, currentPage: 1 }, false, "chatRoom/setSortOption"),
+      setCurrentPage: (currentPage) =>
+        set({ currentPage }, false, "chatRoom/setCurrentPage"),
     }),
     {
       name: "ChatRoomStore",

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,3 @@
+// 페이지네이션 항목 타입 (페이지 번호 또는 줄임표)
+
+export type PageItem = number | "ellipsis-left" | "ellipsis-right";

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,31 @@
+// 현재 페이지 / 전체 페이지로부터 표시할 항목 배열을 계산하는 순수 함수
+
+import type { PageItem } from "@/types/pagination";
+
+/**
+ * 페이지네이션 표시 항목 배열을 생성한다.
+ * - totalPages <= 5: 모든 페이지
+ * - currentPage <= 3: 1 2 3 4 … last
+ * - currentPage >= totalPages - 2: 1 … last-3 last-2 last-1 last
+ * - 중간: 1 … cur-1 cur cur+1 … last
+ */
+export function getPageItems(currentPage: number, totalPages: number): PageItem[] {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  if (currentPage <= 3) {
+    return [1, 2, 3, 4, "ellipsis-right", totalPages];
+  }
+  if (currentPage >= totalPages - 2) {
+    return [1, "ellipsis-left", totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+  }
+  return [
+    1,
+    "ellipsis-left",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "ellipsis-right",
+    totalPages,
+  ];
+}


### PR DESCRIPTION
﻿### 📌 반영 브랜치

#### refactor/chat/list/pagination/#61 -> dev

### ✅ 작업 내용 `리팩토링`, `기능 개선`

- `useInfiniteQuery` → `useQuery` + `keepPreviousData`로 페이지 단위 조회로 전환
- Zustand store에 `currentPage` 상태 관리, 탭/정렬 변경 시 page=1 자동 리셋
- `CHAT_ROOM_PAGE_SIZE` 30 → 16으로 변경 (한 화면에 깔끔한 그리드)
- shadcn Pagination 기반 도메인 컴포넌트 (`ChatRoomPagination`) 신규 추가
- 페이지네이션 UI: `1 2 3 4 … last` 형태, 마지막 페이지에서 "다음" 클릭 시 page=1로 순환
- 스켈레톤 깜빡임 개선: `isFetching && isPlaceholderData` 조건으로 placeholder 데이터 유지, Spinner 표시
- 탭 로딩 상태: 활성 탭의 count 배지에 Spinner 표시하여 명확한 로딩 피드백
- 페이지네이션 바닥 고정: flex 레이아웃 (`min-h-full`, `flex-1`, `mt-auto`)으로 UI 안정화
- 브랜드 컬러 스타일링: 민트 그린 배경, 라운드 버튼, brand/shadow 통일
- 채팅방 카드 Owner 시인성 개선: Crown 아이콘 + 브랜드 배지로 방장 강조
- 멤버 목록 방장 표시: 방장을 맨 위로 정렬, Realtime owner_id 변경 시 자동 업데이트
- 탭 카운트 99+ 호버 Tooltip: 탭 전체 호버 시 정확한 개수 표시 (브랜드 스타일, 즉시 표시)

### 🎯 단독 테스트 결과

- **기본 페이지네이션**: JOINED 탭에서 12개 이상 채팅방 → 페이지 번호 정상 표시, 클릭 시 페이지 이동 성공
- **마지막 페이지 순환**: 마지막 페이지에서 "다음" 클릭 → page=1로 자동 순환, 활성 표시도 1번으로 즉시 변경
- **이전 버튼 비활성**: page=1에서 "이전" 버튼 disabled 상태 유지
- **중간 페이지 윈도우**: page ≥ 4인 경우 `1 … cur-1 cur cur+1 … last` 형태 정상 표시
- **마지막 부근 페이지**: page ≥ last-2인 경우 `1 … last-3 last-2 last-1 last` 형태 정상 표시
- **탭 전환 시 리셋**: JOINED → NOT_JOINED 탭 전환 → page=1로 자동 리셋, 새 탭의 채팅방 데이터 로드
- **스켈레톤 깜빡임 방지**: page 변경 중 placeholder 데이터로 기존 목록 유지, Spinner만 표시
- **Tooltip 즉시 표시**: count > 99인 탭에 호버 → 지연 없이 즉시 Tooltip 표시 (e.g., "참여중인 채팅방 1,234개")
- **방장 강조**: 채팅방 카드의 Owner 배지(Crown + "방장") 표시, 멤버 목록에서 방장이 맨 위 정렬
- **Realtime 반영**: 다른 사용자가 방장 변경 → owner_id 업데이트 → 즉시 UI 반영
- **다크 모드**: 모든 브랜드 색상, 그림자, 배지가 다크 모드에서도 일관성 있게 표시

### 🚨 연관 이슈

closes #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 목록에 페이지네이션 및 페이지 내비게이션 UI 추가
  * 채팅방·멤버에 방장 크라운 배지(오너 표기) 도입

* **개선 사항**
  * 탭·헤더·페이지네이션의 로딩 표시 개선(활성 탭에만 스피너 노출)
  * 99개 초과 카운트는 툴팁으로 전체 수 표시
  * 멤버 목록에서 방장을 항상 맨 앞에 노출
  * 페이지당 항목 수 기본값을 낮추어 리스트 밀도 완화
* **사용성**
  * 방장 배지 내 닉네임 길이 제한으로 레이아웃 안정성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
