### PR TITLE
feat(#63): 채팅방 탭 내 검색 필터 추가 및 채팅 UX 개선

### DIFF
--- a/src/components/chat/chat-room-card.tsx
+++ b/src/components/chat/chat-room-card.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { ChatRoomCardData } from "@/types/chat-room";
 import { formatCapacity, formatRoomDate } from "@/utils/chat-room";
-import { Clock, MessageCircle, Users } from "lucide-react";
+import { Clock, Crown, MessageCircle, Users } from "lucide-react";
 import Link from "next/link";
 
 interface Props {
@@ -42,11 +42,13 @@ export default function ChatRoomCard({ chatRoom, unreadMessageCount = 0 }: Props
           </h3>
           <span
             className={cn(
-              "text-muted-foreground shrink-0 font-medium tracking-tight",
-              "text-xs",
+              "inline-flex w-fit shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5",
+              "bg-brand/10 text-brand dark:bg-brand/15",
+              "text-xs font-semibold tracking-tight",
             )}
           >
-            @{chatRoom.owner_nickname}
+            <Crown className="size-3" aria-hidden />
+            <span className="max-w-24 truncate">{chatRoom.owner_nickname}</span>
           </span>
         </div>
         {chatRoom.description && (

--- a/src/components/chat/chat-room-empty-state.tsx
+++ b/src/components/chat/chat-room-empty-state.tsx
@@ -1,13 +1,16 @@
 import { CHAT_ROOM_EMPTY_MESSAGES } from "@/constants/chat-room";
 import { cn } from "@/lib/utils";
 import type { ChatRoomTab } from "@/types/chat-room";
-import { MessageSquare } from "lucide-react";
+import { MessageSquare, Search } from "lucide-react";
 
 interface Props {
   tabType: ChatRoomTab;
+  searchQuery?: string;
 }
 
-export default function ChatRoomEmptyState({ tabType }: Props) {
+export default function ChatRoomEmptyState({ tabType, searchQuery }: Props) {
+  const isSearching = !!searchQuery && searchQuery.trim().length > 0;
+
   return (
     <div className={cn("flex flex-col items-center justify-center text-center", "py-24")}>
       <div
@@ -17,10 +20,20 @@ export default function ChatRoomEmptyState({ tabType }: Props) {
           "mb-4",
         )}
       >
-        <MessageSquare className="text-brand h-7 w-7" />
+        {isSearching ? (
+          <Search className="text-brand h-7 w-7" />
+        ) : (
+          <MessageSquare className="text-brand h-7 w-7" />
+        )}
       </div>
-      <h3 className="text-foreground text-base font-bold">채팅방이 없습니다</h3>
-      <p className="text-muted-foreground mt-1.5 text-sm">{CHAT_ROOM_EMPTY_MESSAGES[tabType]}</p>
+      <h3 className="text-foreground text-base font-bold">
+        {isSearching ? "검색 결과가 없습니다" : "채팅방이 없습니다"}
+      </h3>
+      <p className="text-muted-foreground mt-1.5 text-sm">
+        {isSearching
+          ? `"${searchQuery.trim()}"에 해당하는 채팅방을 찾지 못했습니다.`
+          : CHAT_ROOM_EMPTY_MESSAGES[tabType]}
+      </p>
     </div>
   );
 }

--- a/src/components/chat/chat-room-list-header.tsx
+++ b/src/components/chat/chat-room-list-header.tsx
@@ -1,4 +1,5 @@
 import CreateChatRoomDialog from "@/components/chat/create-chat-room-dialog";
+import ChatRoomSearchInput from "@/components/chat/chat-room-search-input";
 import ChatRoomSortMenu from "@/components/chat/chat-room-sort-menu";
 import ChatRoomTabs from "@/components/chat/chat-room-tabs";
 import { cn } from "@/lib/utils";
@@ -11,19 +12,22 @@ interface Props {
 
 export default function ChatRoomListHeader({ counts, isFetching = false }: Props) {
   return (
-    <div
-      className={cn(
-        "border-border/50 flex flex-col gap-3 border-b pb-5",
-        "lg:flex-row lg:items-center lg:justify-between",
-      )}
-    >
-      <ChatRoomTabs counts={counts} isFetching={isFetching} />
+    <div className={cn("border-border/50 flex flex-col gap-3 border-b pb-5")}>
       <div
-        className={cn("flex w-full items-center justify-between gap-3", "lg:w-auto lg:justify-end")}
+        className={cn(
+          "flex flex-col gap-3",
+          "lg:flex-row lg:items-center lg:justify-between",
+        )}
       >
-        <ChatRoomSortMenu />
-        <CreateChatRoomDialog />
+        <ChatRoomTabs counts={counts} isFetching={isFetching} />
+        <div
+          className={cn("flex w-full items-center justify-between gap-3", "lg:w-auto lg:justify-end")}
+        >
+          <ChatRoomSortMenu />
+          <CreateChatRoomDialog />
+        </div>
       </div>
+      <ChatRoomSearchInput />
     </div>
   );
 }

--- a/src/components/chat/chat-room-list-header.tsx
+++ b/src/components/chat/chat-room-list-header.tsx
@@ -6,9 +6,10 @@ import type { ChatRoomCounts } from "@/types/chat-room";
 
 interface Props {
   counts?: ChatRoomCounts;
+  isFetching?: boolean;
 }
 
-export default function ChatRoomListHeader({ counts }: Props) {
+export default function ChatRoomListHeader({ counts, isFetching = false }: Props) {
   return (
     <div
       className={cn(
@@ -16,7 +17,7 @@ export default function ChatRoomListHeader({ counts }: Props) {
         "lg:flex-row lg:items-center lg:justify-between",
       )}
     >
-      <ChatRoomTabs counts={counts} />
+      <ChatRoomTabs counts={counts} isFetching={isFetching} />
       <div
         className={cn("flex w-full items-center justify-between gap-3", "lg:w-auto lg:justify-end")}
       >

--- a/src/components/chat/chat-room-list.tsx
+++ b/src/components/chat/chat-room-list.tsx
@@ -21,17 +21,22 @@ export default function ChatRoomList() {
   const tabType = useChatRoomStore((state) => state.tabType);
   const sortOption = useChatRoomStore((state) => state.sortOption);
   const currentPage = useChatRoomStore((state) => state.currentPage);
+  const searchQuery = useChatRoomStore((state) => state.searchQuery);
   const setCurrentPage = useChatRoomStore((state) => state.setCurrentPage);
   const { isFetched: isUserFetched } = useUser();
 
   const selectedSortOption = CHAT_ROOM_SORT_OPTIONS_BY_TAB[tabType].includes(sortOption)
     ? sortOption
     : DEFAULT_CHAT_ROOM_SORT_OPTION;
-  const query = useChatRooms(tabType, selectedSortOption, currentPage);
+  const query = useChatRooms(tabType, selectedSortOption, currentPage, searchQuery);
   const { data: counts } = useChatRoomCounts();
 
   const chatRooms = query.data ?? [];
-  const totalPages = Math.ceil((counts?.[tabType] ?? 0) / CHAT_ROOM_PAGE_SIZE);
+
+  // 검색 중이면 RPC 응답의 total_count 기반, 아니면 캐시된 counts[tabType] 사용
+  const isSearching = searchQuery.trim().length > 0;
+  const totalItems = isSearching ? (chatRooms[0]?.total_count ?? 0) : (counts?.[tabType] ?? 0);
+  const totalPages = Math.ceil(totalItems / CHAT_ROOM_PAGE_SIZE);
 
   const isInitialLoading = !isUserFetched || query.isLoading;
   const isEmpty = isUserFetched && !query.isLoading && chatRooms.length === 0;
@@ -52,7 +57,7 @@ export default function ChatRoomList() {
         {isInitialLoading ? (
           <ChatRoomListSkeleton />
         ) : isEmpty ? (
-          <ChatRoomEmptyState tabType={tabType} />
+          <ChatRoomEmptyState tabType={tabType} searchQuery={searchQuery} />
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {chatRooms.map((chatRoom) => (

--- a/src/components/chat/chat-room-list.tsx
+++ b/src/components/chat/chat-room-list.tsx
@@ -38,6 +38,11 @@ export default function ChatRoomList() {
   const totalItems = isSearching ? (chatRooms[0]?.total_count ?? 0) : (counts?.[tabType] ?? 0);
   const totalPages = Math.ceil(totalItems / CHAT_ROOM_PAGE_SIZE);
 
+  // 검색 중일 때 현재 탭의 카운트를 total_count로 교체 → ChatRoomTabs에 반영
+  const effectiveCounts = isSearching && counts
+    ? { ...counts, [tabType]: chatRooms[0]?.total_count ?? 0 }
+    : counts;
+
   const isInitialLoading = !isUserFetched || query.isLoading;
   const isEmpty = isUserFetched && !query.isLoading && chatRooms.length === 0;
   const isPageFetching = query.isFetching && query.isPlaceholderData;
@@ -51,7 +56,7 @@ export default function ChatRoomList() {
 
   return (
     <div className="flex min-h-full flex-col gap-5">
-      <ChatRoomListHeader counts={counts} isFetching={isPageFetching} />
+      <ChatRoomListHeader counts={effectiveCounts} isFetching={isPageFetching} />
 
       <div className="flex flex-1 flex-col">
         {isInitialLoading ? (

--- a/src/components/chat/chat-room-list.tsx
+++ b/src/components/chat/chat-room-list.tsx
@@ -4,15 +4,15 @@ import ChatRoomCard from "@/components/chat/chat-room-card";
 import ChatRoomEmptyState from "@/components/chat/chat-room-empty-state";
 import ChatRoomListHeader from "@/components/chat/chat-room-list-header";
 import ChatRoomListSkeleton from "@/components/chat/chat-room-list-skeleton";
+import ChatRoomPagination from "@/components/chat/chat-room-pagination";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
-import { Spinner } from "@/components/ui/spinner";
 import { useChatRoomCounts } from "@/hooks/use-chat-room-counts";
 import {
+  CHAT_ROOM_PAGE_SIZE,
   CHAT_ROOM_SORT_OPTIONS_BY_TAB,
   DEFAULT_CHAT_ROOM_SORT_OPTION,
 } from "@/constants/chat-room";
 import { useChatRooms } from "@/hooks/use-chat-rooms";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useUser } from "@/hooks/use-profile";
 import { useChatRoomStore } from "@/stores/chat-room";
 import { getAppMessage } from "@/utils/app-message";
@@ -20,24 +20,22 @@ import { getAppMessage } from "@/utils/app-message";
 export default function ChatRoomList() {
   const tabType = useChatRoomStore((state) => state.tabType);
   const sortOption = useChatRoomStore((state) => state.sortOption);
+  const currentPage = useChatRoomStore((state) => state.currentPage);
+  const setCurrentPage = useChatRoomStore((state) => state.setCurrentPage);
   const { isFetched: isUserFetched } = useUser();
 
   const selectedSortOption = CHAT_ROOM_SORT_OPTIONS_BY_TAB[tabType].includes(sortOption)
     ? sortOption
     : DEFAULT_CHAT_ROOM_SORT_OPTION;
-  const query = useChatRooms(tabType, selectedSortOption);
+  const query = useChatRooms(tabType, selectedSortOption, currentPage);
   const { data: counts } = useChatRoomCounts();
 
-  const chatRooms = query.data?.pages.flatMap((page) => page) ?? [];
-
-  const sentinelRef = useIntersectionObserver(() => {
-    if (query.hasNextPage && !query.isFetchingNextPage) {
-      void query.fetchNextPage();
-    }
-  });
+  const chatRooms = query.data ?? [];
+  const totalPages = Math.ceil((counts?.[tabType] ?? 0) / CHAT_ROOM_PAGE_SIZE);
 
   const isInitialLoading = !isUserFetched || query.isLoading;
   const isEmpty = isUserFetched && !query.isLoading && chatRooms.length === 0;
+  const isPageFetching = query.isFetching && query.isPlaceholderData;
 
   if (query.isError) {
     const message = getAppMessage(APP_MESSAGE_CODE.error.chatRoomList.loadFailed);
@@ -47,15 +45,15 @@ export default function ChatRoomList() {
   }
 
   return (
-    <div className="flex flex-col gap-5">
-      <ChatRoomListHeader counts={counts} />
+    <div className="flex min-h-full flex-col gap-5">
+      <ChatRoomListHeader counts={counts} isFetching={isPageFetching} />
 
-      {isInitialLoading ? (
-        <ChatRoomListSkeleton />
-      ) : isEmpty ? (
-        <ChatRoomEmptyState tabType={tabType} />
-      ) : (
-        <>
+      <div className="flex flex-1 flex-col">
+        {isInitialLoading ? (
+          <ChatRoomListSkeleton />
+        ) : isEmpty ? (
+          <ChatRoomEmptyState tabType={tabType} />
+        ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {chatRooms.map((chatRoom) => (
               <ChatRoomCard
@@ -65,17 +63,15 @@ export default function ChatRoomList() {
               />
             ))}
           </div>
-          {query.isFetchingNextPage && (
-            <div className="flex justify-center py-4">
-              <Spinner className="text-muted-foreground size-5" />
-            </div>
-          )}
-          <div ref={sentinelRef} aria-hidden="true" />
-          {!query.hasNextPage && !query.isLoading && chatRooms.length > 0 && (
-            <p className="text-muted-foreground text-center text-sm">모든 채팅방을 불러왔습니다.</p>
-          )}
-        </>
-      )}
+        )}
+      </div>
+
+      <ChatRoomPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        isFetching={isPageFetching}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 }

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -21,12 +21,6 @@ interface Props {
   onPageChange: (page: number) => void;
 }
 
-const activePageButtonClass = cn(
-  "bg-brand text-white shadow-sm shadow-brand/20 rounded-xl font-bold",
-  "hover:bg-brand/90 hover:text-white",
-  "dark:hover:bg-brand/90",
-);
-
 export default function ChatRoomPagination({
   currentPage,
   totalPages,

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -96,17 +96,16 @@ export default function ChatRoomPagination({
                 aria-disabled={isFetching}
                 onClick={(e) => handlePageClick(e, item)}
                 className={cn(
-                  item === currentPage
-                    ? cn(
-                        "bg-brand shadow-brand/20 rounded-xl font-bold text-white shadow-sm",
-                        "hover:bg-brand/90 hover:text-white",
-                        "dark:hover:bg-brand/90",
-                      )
-                    : cn(
-                        "text-muted-foreground rounded-xl font-semibold",
-                        "hover:bg-brand/10 hover:text-brand",
-                        "dark:hover:bg-brand/15",
-                      ),
+                  item === currentPage && [
+                    "bg-brand shadow-brand/20 rounded-xl font-bold text-white shadow-sm",
+                    "hover:bg-brand/90 hover:text-white",
+                    "dark:hover:bg-brand/90",
+                  ],
+                  item !== currentPage && [
+                    "text-muted-foreground rounded-xl font-semibold",
+                    "hover:bg-brand/10 hover:text-brand",
+                    "dark:hover:bg-brand/15",
+                  ],
                   isFetching && "pointer-events-none opacity-50",
                 )}
               >

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -1,0 +1,151 @@
+// 채팅방 목록 페이지네이션 (shadcn Pagination wrapper)
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+} from "@/components/ui/pagination";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { getPageItems } from "@/utils/pagination";
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  isFetching: boolean;
+  onPageChange: (page: number) => void;
+}
+
+const activePageButtonClass = cn(
+  "bg-brand text-white shadow-sm shadow-brand/20 rounded-xl font-bold",
+  "hover:bg-brand/90 hover:text-white",
+  "dark:hover:bg-brand/90",
+);
+
+export default function ChatRoomPagination({
+  currentPage,
+  totalPages,
+  isFetching,
+  onPageChange,
+}: Props) {
+  if (totalPages <= 1) return null;
+
+  const items = getPageItems(currentPage, totalPages);
+  const isFirstPage = currentPage <= 1;
+
+  const handlePageClick = (e: React.MouseEvent, page: number) => {
+    e.preventDefault();
+    if (isFetching) return;
+    if (page < 1 || page > totalPages || page === currentPage) return;
+    onPageChange(page);
+  };
+
+  const handlePrevious = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isFetching || isFirstPage) return;
+    onPageChange(currentPage - 1);
+  };
+
+  // 마지막 페이지에서 "다음" 클릭 시 page=1로 순환
+  const handleNext = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isFetching) return;
+    if (currentPage >= totalPages) {
+      onPageChange(1);
+      return;
+    }
+    onPageChange(currentPage + 1);
+  };
+
+  const isPrevDisabled = isFirstPage || isFetching;
+
+  return (
+    <Pagination className="pt-2">
+      <PaginationContent className="gap-1">
+        <PaginationItem>
+          <PaginationLink
+            href="#"
+            onClick={handlePrevious}
+            aria-disabled={isPrevDisabled}
+            aria-label="Go to previous page"
+            size="default"
+            className={cn(
+              "pl-1.5!",
+              "border-border/60 bg-background text-muted-foreground rounded-xl border font-semibold",
+              "hover:border-brand/40 hover:bg-brand/10 hover:text-brand",
+              "dark:border-border/30 dark:hover:bg-brand/15 dark:bg-zinc-900/50",
+              isPrevDisabled && "pointer-events-none opacity-50",
+            )}
+          >
+            {isFetching ? (
+              <Spinner data-icon="inline-start" className="size-4" />
+            ) : (
+              <ChevronLeftIcon data-icon="inline-start" />
+            )}
+            <span className="hidden sm:block">이전</span>
+          </PaginationLink>
+        </PaginationItem>
+        {items.map((item) =>
+          typeof item === "number" ? (
+            <PaginationItem key={item}>
+              <PaginationLink
+                href="#"
+                isActive={item === currentPage}
+                aria-disabled={isFetching}
+                onClick={(e) => handlePageClick(e, item)}
+                className={cn(
+                  item === currentPage
+                    ? cn(
+                        "bg-brand shadow-brand/20 rounded-xl font-bold text-white shadow-sm",
+                        "hover:bg-brand/90 hover:text-white",
+                        "dark:hover:bg-brand/90",
+                      )
+                    : cn(
+                        "text-muted-foreground rounded-xl font-semibold",
+                        "hover:bg-brand/10 hover:text-brand",
+                        "dark:hover:bg-brand/15",
+                      ),
+                  isFetching && "pointer-events-none opacity-50",
+                )}
+              >
+                {item}
+              </PaginationLink>
+            </PaginationItem>
+          ) : (
+            <PaginationItem key={item}>
+              <PaginationEllipsis className="text-muted-foreground/70" />
+            </PaginationItem>
+          ),
+        )}
+        <PaginationItem>
+          <PaginationLink
+            href="#"
+            onClick={handleNext}
+            aria-disabled={isFetching}
+            aria-label="Go to next page"
+            size="default"
+            className={cn(
+              "pr-1.5!",
+              "border-border/60 bg-background text-muted-foreground rounded-xl border font-semibold",
+              "hover:border-brand/40 hover:bg-brand/10 hover:text-brand",
+              "dark:border-border/30 dark:hover:bg-brand/15 dark:bg-zinc-900/50",
+              isFetching && "pointer-events-none opacity-50",
+            )}
+          >
+            <span className="hidden sm:block">다음</span>
+            {isFetching ? (
+              <Spinner data-icon="inline-end" className="size-4" />
+            ) : (
+              <ChevronRightIcon data-icon="inline-end" />
+            )}
+          </PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/src/components/chat/chat-room-pagination.tsx
+++ b/src/components/chat/chat-room-pagination.tsx
@@ -36,7 +36,6 @@ export default function ChatRoomPagination({
   if (totalPages <= 1) return null;
 
   const items = getPageItems(currentPage, totalPages);
-  const isFirstPage = currentPage <= 1;
 
   const handlePageClick = (e: React.MouseEvent, page: number) => {
     e.preventDefault();
@@ -47,7 +46,11 @@ export default function ChatRoomPagination({
 
   const handlePrevious = (e: React.MouseEvent) => {
     e.preventDefault();
-    if (isFetching || isFirstPage) return;
+    if (isFetching) return;
+    if (currentPage <= 1) {
+      onPageChange(totalPages);
+      return;
+    }
     onPageChange(currentPage - 1);
   };
 
@@ -62,7 +65,7 @@ export default function ChatRoomPagination({
     onPageChange(currentPage + 1);
   };
 
-  const isPrevDisabled = isFirstPage || isFetching;
+  const isPrevDisabled = isFetching;
 
   return (
     <Pagination className="pt-2">

--- a/src/components/chat/chat-room-search-input.tsx
+++ b/src/components/chat/chat-room-search-input.tsx
@@ -1,0 +1,35 @@
+// 채팅방 목록 탭 내부 검색 입력 컴포넌트 (Submit 기반)
+"use client";
+
+import SearchInput from "@/components/search/search-input";
+import { useChatRoomStore } from "@/stores/chat-room";
+import { useEffect, useState } from "react";
+
+export default function ChatRoomSearchInput() {
+  const tabType = useChatRoomStore((s) => s.tabType);
+  const searchQuery = useChatRoomStore((s) => s.searchQuery);
+  const setSearchQuery = useChatRoomStore((s) => s.setSearchQuery);
+
+  const [localValue, setLocalValue] = useState(searchQuery);
+
+  // tab 변경 시 store의 searchQuery가 ""로 초기화됨 → 로컬 input도 동기화
+  useEffect(() => {
+    setLocalValue(searchQuery);
+  }, [tabType, searchQuery]);
+
+  const handleSubmit = () => {
+    const trimmed = localValue.trim();
+    if (trimmed === searchQuery) return;
+    setSearchQuery(trimmed);
+  };
+
+  return (
+    <SearchInput
+      value={localValue}
+      onChange={setLocalValue}
+      onSubmit={handleSubmit}
+      placeholder="현재 탭에서 채팅방 검색"
+      className="lg:w-80"
+    />
+  );
+}

--- a/src/components/chat/chat-room-search-input.tsx
+++ b/src/components/chat/chat-room-search-input.tsx
@@ -14,6 +14,7 @@ export default function ChatRoomSearchInput() {
 
   // tab 변경 시 store의 searchQuery가 ""로 초기화됨 → 로컬 input도 동기화
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLocalValue(searchQuery);
   }, [tabType, searchQuery]);
 

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -19,7 +19,7 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TooltipProvider delay={300}>
+      <TooltipProvider delay={0}>
         <TabsList
           className={cn(
             "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CHAT_ROOM_TABS, ROOM_TAB_LABELS } from "@/constants/chat-room";
 import { useChatRoomStore } from "@/stores/chat-room";
@@ -8,9 +9,10 @@ import { cn } from "@/lib/utils";
 
 interface Props {
   counts?: ChatRoomCounts;
+  isFetching?: boolean;
 }
 
-export default function ChatRoomTabs({ counts }: Props) {
+export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
   const tabType = useChatRoomStore((state) => state.tabType);
   const setTabType = useChatRoomStore((state) => state.setTabType);
 
@@ -50,7 +52,13 @@ export default function ChatRoomTabs({ counts }: Props) {
                       : "bg-muted-foreground/20 text-muted-foreground",
                 )}
               >
-                {count === undefined ? null : count > 99 ? "99+" : count}
+                {isFetching && tabType === tab ? (
+                  <Spinner className="size-3 text-white" />
+                ) : count === undefined ? null : count > 99 ? (
+                  "99+"
+                ) : (
+                  count
+                )}
               </span>
             </TabsTrigger>
           );

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -19,7 +19,7 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TooltipProvider delay={500}>
+      <TooltipProvider delay={300}>
         <TabsList
           className={cn(
             "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",

--- a/src/components/chat/chat-room-tabs.tsx
+++ b/src/components/chat/chat-room-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { CHAT_ROOM_TABS, ROOM_TAB_LABELS } from "@/constants/chat-room";
 import { useChatRoomStore } from "@/stores/chat-room";
 import type { ChatRoomCounts, ChatRoomTab } from "@/types/chat-room";
@@ -18,52 +19,76 @@ export default function ChatRoomTabs({ counts, isFetching = false }: Props) {
 
   return (
     <Tabs value={tabType} onValueChange={(nextValue) => setTabType(nextValue as ChatRoomTab)}>
-      <TabsList
-        className={cn(
-          "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",
-          "bg-muted/50 rounded-xl dark:bg-zinc-800/40",
-          "lg:w-150",
-        )}
-      >
-        {CHAT_ROOM_TABS.map((tab) => {
-          const count = counts?.[tab];
+      <TooltipProvider delay={500}>
+        <TabsList
+          className={cn(
+            "grid h-auto w-full min-w-0 grid-cols-3 items-center gap-1 p-1",
+            "bg-muted/50 rounded-xl dark:bg-zinc-800/40",
+            "lg:w-150",
+          )}
+        >
+          {CHAT_ROOM_TABS.map((tab) => {
+            const count = counts?.[tab];
+            const isActive = tabType === tab;
+            const showSpinner = isFetching && isActive;
+            // 정확한 개수를 보여줄 수 있을 때만 Tooltip 활성화 (Spinner 중에는 비활성)
+            const hasOverflowCount = typeof count === "number" && count > 99 && !showSpinner;
 
-          return (
-            <TabsTrigger
-              key={tab}
-              value={tab}
-              className={({ active }) =>
-                cn(
-                  "relative flex h-auto min-w-0 cursor-pointer items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-semibold transition-all duration-200 lg:gap-1.5 lg:px-4",
-                  active
-                    ? "text-brand shadow-brand/10 bg-white shadow-sm dark:bg-zinc-900 dark:shadow-none"
-                    : "text-muted-foreground hover:text-foreground hover:bg-white/50 dark:hover:bg-zinc-700/40",
-                )
-              }
-            >
-              {ROOM_TAB_LABELS[tab]}
-              <span
-                className={cn(
-                  "flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-xs leading-none font-black",
-                  count === undefined
-                    ? "invisible"
-                    : tabType === tab
-                      ? "bg-brand text-white"
-                      : "bg-muted-foreground/20 text-muted-foreground",
-                )}
+            const trigger = (
+              <TabsTrigger
+                key={tab}
+                value={tab}
+                className={({ active }) =>
+                  cn(
+                    "relative flex h-auto min-w-0 cursor-pointer items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-semibold transition-all duration-200 lg:gap-1.5 lg:px-4",
+                    active
+                      ? "text-brand shadow-brand/10 bg-white shadow-sm dark:bg-zinc-900 dark:shadow-none"
+                      : "text-muted-foreground hover:text-foreground hover:bg-white/50 dark:hover:bg-zinc-700/40",
+                  )
+                }
               >
-                {isFetching && tabType === tab ? (
-                  <Spinner className="size-3 text-white" />
-                ) : count === undefined ? null : count > 99 ? (
-                  "99+"
-                ) : (
-                  count
-                )}
-              </span>
-            </TabsTrigger>
-          );
-        })}
-      </TabsList>
+                {ROOM_TAB_LABELS[tab]}
+                <span
+                  className={cn(
+                    "flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-xs leading-none font-black",
+                    count === undefined
+                      ? "invisible"
+                      : isActive
+                        ? "bg-brand text-white"
+                        : "bg-muted-foreground/20 text-muted-foreground",
+                  )}
+                >
+                  {showSpinner ? (
+                    <Spinner className="size-3 text-white" />
+                  ) : count === undefined ? null : count > 99 ? (
+                    "99+"
+                  ) : (
+                    count
+                  )}
+                </span>
+              </TabsTrigger>
+            );
+
+            if (!hasOverflowCount) return trigger;
+
+            return (
+              <Tooltip key={tab}>
+                <TooltipTrigger render={trigger} />
+                <TooltipContent
+                  className={cn(
+                    "bg-brand text-white",
+                    "shadow-brand/30 shadow-md",
+                    // TooltipContent 내부 자식(Arrow)에도 브랜드 컬러를 강제 적용
+                    "*:bg-brand! *:fill-brand!",
+                  )}
+                >
+                  {ROOM_TAB_LABELS[tab]} {count.toLocaleString()}개
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </TabsList>
+      </TooltipProvider>
     </Tabs>
   );
 }

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -2,28 +2,92 @@
 import { MemberActionPopover } from "@/components/member/member-action-popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import type { RoomMemberQuery } from "@/types/chat-room-member";
 import { getAvatarFallbackText } from "@/utils/avatar";
+import { Crown } from "lucide-react";
 
 interface Props {
   roomId: string;
   member: RoomMemberQuery;
+  isOwner: boolean;
   canManage: boolean;
 }
 
-export function MemberItem({ roomId, member, canManage }: Props) {
+function OwnerBadge() {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5",
+        "bg-brand/10 text-brand dark:bg-brand/15",
+        "text-[10px] leading-none font-black tracking-tight",
+      )}
+    >
+      <Crown className="size-2.5" aria-hidden />
+      방장
+    </span>
+  );
+}
+
+function MemberContent({
+  photoUrl,
+  fallbackText,
+  nickname,
+  isOwner,
+}: {
+  photoUrl: string | null;
+  fallbackText: string;
+  nickname: string;
+  isOwner: boolean;
+}) {
+  return (
+    <>
+      <div className="relative shrink-0">
+        <Avatar size="default">
+          {photoUrl ? <AvatarImage src={photoUrl} alt={`${nickname}의 프로필 사진`} /> : null}
+          <AvatarFallback>{fallbackText}</AvatarFallback>
+        </Avatar>
+        {isOwner && (
+          <span
+            aria-hidden
+            className="border-background bg-brand absolute -right-0.5 -bottom-0.5 h-3 w-3 rounded-full border-2"
+          />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span
+          className={cn(
+            "text-foreground min-w-0 truncate text-sm",
+            isOwner ? "font-semibold" : "font-normal",
+          )}
+        >
+          {nickname}
+        </span>
+        {isOwner && <OwnerBadge />}
+      </div>
+    </>
+  );
+}
+
+export function MemberItem({ roomId, member, isOwner, canManage }: Props) {
   const nickname = member.user.nickname;
   const photoUrl = member.user.photo_url;
   const fallbackText = getAvatarFallbackText(nickname);
 
   if (!canManage) {
     return (
-      <div className="flex w-full items-center gap-3 rounded-md px-3 py-2">
-        <Avatar size="default" className="shrink-0">
-          {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-          <AvatarFallback>{fallbackText}</AvatarFallback>
-        </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
+      <div
+        className={cn(
+          "flex w-full items-center gap-3 rounded-md px-3 py-2",
+          isOwner && "bg-brand/5 dark:bg-brand/10",
+        )}
+      >
+        <MemberContent
+          photoUrl={photoUrl}
+          fallbackText={fallbackText}
+          nickname={nickname}
+          isOwner={isOwner}
+        />
       </div>
     );
   }
@@ -32,13 +96,17 @@ export function MemberItem({ roomId, member, canManage }: Props) {
     <MemberActionPopover roomId={roomId} member={member}>
       <Button
         variant="ghost"
-        className="flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors"
+        className={cn(
+          "flex h-auto w-full items-center justify-start gap-3 rounded-md px-3 py-2 font-normal transition-colors",
+          isOwner && "bg-brand/5 hover:bg-brand/10 dark:bg-brand/10 dark:hover:bg-brand/15",
+        )}
       >
-        <Avatar size="default" className="shrink-0">
-          {photoUrl ? <AvatarImage src={photoUrl} alt="" /> : null}
-          <AvatarFallback>{fallbackText}</AvatarFallback>
-        </Avatar>
-        <span className="min-w-0 truncate text-sm text-foreground">{nickname}</span>
+        <MemberContent
+          photoUrl={photoUrl}
+          fallbackText={fallbackText}
+          nickname={nickname}
+          isOwner={isOwner}
+        />
       </Button>
     </MemberActionPopover>
   );

--- a/src/components/member/member-item.tsx
+++ b/src/components/member/member-item.tsx
@@ -20,7 +20,7 @@ function OwnerBadge() {
       className={cn(
         "inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5",
         "bg-brand/10 text-brand dark:bg-brand/15",
-        "text-[10px] leading-none font-black tracking-tight",
+        "text-xs leading-none font-black tracking-tight",
       )}
     >
       <Crown className="size-2.5" aria-hidden />

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -27,16 +27,23 @@ export function MemberList({ roomId, currentUserId, ownerId, className }: Props)
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <ul className="py-1.5" role="list">
-          {members.map((member) => (
-            <li key={`${member.chat_room_id}-${member.user_id}`}>
-              <MemberItem
-                roomId={roomId}
-                member={member}
-                canManage={canManageMembers && member.user_id !== currentUserId}
-              />
-            </li>
-          ))}
+        <ul className="flex flex-col gap-1 px-2 py-3">
+          {[...members]
+            .sort((a, b) => {
+              if (a.user_id === ownerId) return -1;
+              if (b.user_id === ownerId) return 1;
+              return 0;
+            })
+            .map((member) => (
+              <li key={`${member.chat_room_id}-${member.user_id}`}>
+                <MemberItem
+                  roomId={roomId}
+                  member={member}
+                  isOwner={member.user_id === ownerId}
+                  canManage={canManageMembers && member.user_id !== currentUserId}
+                />
+              </li>
+            ))}
         </ul>
       </ScrollArea>
     </section>

--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -21,6 +21,8 @@ interface Props {
   disabledHint?: string;
 }
 
+const MAX_TEXTAREA_HEIGHT_PX = 128; // max-h-32 (8rem)
+
 export function MessageInput({ roomId, currentUserId, disabled = false, disabledHint }: Props) {
   const supabase = createClient();
   const [draft, setDraft] = useState("");
@@ -35,7 +37,8 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
     el.style.height = "auto";
     const scrollHeight = el.scrollHeight;
     el.style.height = `${scrollHeight}px`;
-    el.style.overflowY = scrollHeight > 128 ? "auto" : "hidden";
+    // Tailwind max-h-32와 동기화: 초과 시에만 스크롤바 노출
+    el.style.overflowY = scrollHeight > MAX_TEXTAREA_HEIGHT_PX ? "auto" : "hidden";
   }, [draft]);
 
   const handleSend = async () => {
@@ -102,10 +105,10 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
         aria-label="메시지 입력"
         className={cn(
           "flex-1 resize-none overflow-y-hidden rounded-xl px-3 py-2 text-sm leading-normal",
-          "min-h-9 max-h-32",
-          "border border-border/60 bg-muted/30",
+          "max-h-32 min-h-9",
+          "border-border/60 bg-muted/30 border",
           "placeholder:text-muted-foreground/60",
-          "outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
+          "focus-visible:ring-ring/60 outline-none focus-visible:ring-1",
           "disabled:cursor-not-allowed disabled:opacity-50",
           // 스크롤바: max-h 초과 시에만 노출, 브랜드 톤에 맞춘 thin 디자인
           "[&::-webkit-scrollbar]:w-1",
@@ -123,7 +126,7 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
         title={disabled ? disabledHint : undefined}
         onClick={() => void handleSend()}
         aria-label="전송"
-        className="shrink-0 text-brand hover:bg-brand/10 hover:text-brand"
+        className="text-brand hover:bg-brand/10 hover:text-brand shrink-0"
       >
         <SendHorizontal className="size-5" />
       </Button>

--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -27,12 +27,15 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   const sendMessageLockRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // draft 변경마다 높이 자동 조절 (이모지 삽입·직접 입력·전송 후 리셋 모두 커버)
+  // draft 변경마다 높이 자동 조절 + max-h 초과 시에만 스크롤 노출
+  // overflow-y는 기본 hidden → max-h(8rem=128px) 초과 시 auto로 전환
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
+    const scrollHeight = el.scrollHeight;
+    el.style.height = `${scrollHeight}px`;
+    el.style.overflowY = scrollHeight > 128 ? "auto" : "hidden";
   }, [draft]);
 
   const handleSend = async () => {
@@ -98,7 +101,7 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
         }
         aria-label="메시지 입력"
         className={cn(
-          "flex-1 resize-none overflow-y-auto rounded-xl px-3 py-2 text-sm leading-normal",
+          "flex-1 resize-none overflow-y-hidden rounded-xl px-3 py-2 text-sm leading-normal",
           "min-h-9 max-h-32",
           "border border-border/60 bg-muted/30",
           "placeholder:text-muted-foreground/60",

--- a/src/components/message/message-input.tsx
+++ b/src/components/message/message-input.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { SendHorizontal } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import ChatEmojiPicker from "@/components/chat/chat-emoji-picker";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { createClient } from "@/lib/supabase/client";
 import { getAppMessageTitle, resolveSupabaseErrorCode } from "@/utils/app-message";
 import { toastAppError } from "@/utils/toast-message";
 import { MESSAGE_CONTENT_MAX_LENGTH } from "@/constants/message";
 import { messageContentSchema } from "@/lib/zod/message";
+import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
 interface Props {
@@ -25,6 +25,15 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   const supabase = createClient();
   const [draft, setDraft] = useState("");
   const sendMessageLockRef = useRef(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // draft 변경마다 높이 자동 조절 (이모지 삽입·직접 입력·전송 후 리셋 모두 커버)
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
 
   const handleSend = async () => {
     if (sendMessageLockRef.current || !currentUserId || !roomId) {
@@ -60,16 +69,18 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
   };
 
   return (
-    <div className="border-border bg-background/95 flex shrink-0 items-center gap-2 border-t px-3 py-2 backdrop-blur-sm">
+    <div className="border-border bg-background/95 flex shrink-0 items-end gap-2 border-t px-3 py-2 backdrop-blur-sm">
       <ChatEmojiPicker
         disabled={disabled}
         onEmojiSelect={(emoji) =>
           setDraft((prev) => (prev + emoji).slice(0, MESSAGE_CONTENT_MAX_LENGTH))
         }
       />
-      <Input
+      <textarea
+        ref={textareaRef}
         value={draft}
         disabled={disabled}
+        rows={1}
         maxLength={MESSAGE_CONTENT_MAX_LENGTH}
         title={disabled ? disabledHint : undefined}
         onChange={(e) => setDraft(e.target.value.slice(0, MESSAGE_CONTENT_MAX_LENGTH))}
@@ -85,8 +96,21 @@ export function MessageInput({ roomId, currentUserId, disabled = false, disabled
             ? (disabledHint ?? getAppMessageTitle(APP_MESSAGE_CODE.error.chatRoom.inputLocked))
             : "채팅하기"
         }
-        className="h-9 flex-1 rounded-xl border-border/60 bg-muted/30 py-0 text-sm placeholder:text-muted-foreground/60"
         aria-label="메시지 입력"
+        className={cn(
+          "flex-1 resize-none overflow-y-auto rounded-xl px-3 py-2 text-sm leading-normal",
+          "min-h-9 max-h-32",
+          "border border-border/60 bg-muted/30",
+          "placeholder:text-muted-foreground/60",
+          "outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          // 스크롤바: max-h 초과 시에만 노출, 브랜드 톤에 맞춘 thin 디자인
+          "[&::-webkit-scrollbar]:w-1",
+          "[&::-webkit-scrollbar-track]:bg-transparent",
+          "[&::-webkit-scrollbar-thumb]:rounded-full",
+          "[&::-webkit-scrollbar-thumb]:bg-border",
+          "[&::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/40",
+        )}
       />
       <Button
         type="button"

--- a/src/components/message/message-item.tsx
+++ b/src/components/message/message-item.tsx
@@ -27,7 +27,7 @@ export function MessageItem({ message, isOwn }: Props) {
             "bg-brand text-white",
           )}
         >
-          <span className="wrap-break-word">{message.content}</span>
+          <span className="wrap-break-word whitespace-pre-wrap">{message.content}</span>
         </div>
       </div>
     );
@@ -47,7 +47,7 @@ export function MessageItem({ message, isOwn }: Props) {
             "bg-muted/60 text-foreground",
           )}
         >
-          <span className="wrap-break-word">{message.content}</span>
+          <span className="wrap-break-word whitespace-pre-wrap">{message.content}</span>
         </div>
       </div>
     </div>

--- a/src/components/message/message-list.tsx
+++ b/src/components/message/message-list.tsx
@@ -73,7 +73,7 @@ export function MessageList({
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
       <ScrollArea ref={viewportRef} className="size-full" onScroll={handleScroll}>
-        <div className="flex flex-col-reverse gap-0.5 py-2">
+        <div className="flex flex-col-reverse gap-3 py-2">
           {messages.map((message) => (
             <MessageItem
               key={message.id}

--- a/src/components/message/system-message-item.tsx
+++ b/src/components/message/system-message-item.tsx
@@ -1,15 +1,24 @@
 // 채팅방 시스템 메시지를 중앙 안내 형태로 표시하는 컴포넌트
+import { Calendar } from "lucide-react";
 import type { Message } from "@/types/message";
 
 interface Props {
   message: Message;
 }
 
+const DATE_DIVIDER_PREFIX = "📅 ";
+
 export function SystemMessageItem({ message }: Props) {
+  const isDateDivider = message.content.startsWith(DATE_DIVIDER_PREFIX);
+  const displayContent = isDateDivider
+    ? message.content.slice(DATE_DIVIDER_PREFIX.length)
+    : message.content;
+
   return (
     <div className="flex justify-center px-3 py-1.5">
-      <p className="bg-muted/70 text-muted-foreground rounded-full px-3 py-1 text-center text-xs">
-        {message.content}
+      <p className="bg-muted/70 text-muted-foreground inline-flex items-center gap-1 rounded-full px-3 py-1 text-center text-xs">
+        {isDateDivider && <Calendar className="size-3 shrink-0" />}
+        {displayContent}
       </p>
     </div>
   );

--- a/src/components/search/header-search-form.tsx
+++ b/src/components/search/header-search-form.tsx
@@ -46,7 +46,7 @@ export default function HeaderSearchForm() {
               value={query}
               onChange={setQuery}
               onSubmit={handleSearch}
-              placeholder="채팅방 검색"
+              placeholder="채팅방 전체 검색"
               disabled={isLiveSearchDisabled}
               className="w-44"
             />
@@ -66,7 +66,7 @@ export default function HeaderSearchForm() {
             size="icon-sm"
             onClick={() => !isLiveSearchDisabled && setMobileOpen(true)}
             disabled={isLiveSearchDisabled}
-            aria-label="채팅방 검색"
+            aria-label="채팅방 전체 검색"
             className={cn(
               "text-muted-foreground hover:text-foreground",
               isLiveSearchDisabled && "cursor-not-allowed",
@@ -82,7 +82,7 @@ export default function HeaderSearchForm() {
         value={query}
         onChange={setQuery}
         onSubmit={handleSearch}
-        placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 검색"}
+        placeholder={isLiveSearchDisabled ? "라이브 검색 준비 중" : "채팅방 전체 검색"}
         disabled={isLiveSearchDisabled}
         className="hidden sm:block sm:w-48 md:w-64"
       />

--- a/src/components/search/search-input.tsx
+++ b/src/components/search/search-input.tsx
@@ -2,7 +2,7 @@
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { Search } from "lucide-react";
-import type { FormEvent } from "react";
+import { SubmitEvent } from "react";
 
 interface Props {
   value: string;
@@ -21,7 +21,7 @@ export default function SearchInput({
   className,
   disabled = false,
 }: Props) {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit();
   };

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils/index";
+import { Button } from "@/components/ui/button";
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex items-center gap-0.5", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">;
+
+function PaginationLink({ className, isActive, size = "icon", ...props }: PaginationLinkProps) {
+  return (
+    <Button
+      variant={isActive ? "outline" : "ghost"}
+      size={size}
+      className={cn(className)}
+      nativeButton={false}
+      render={
+        <a
+          aria-current={isActive ? "page" : undefined}
+          data-slot="pagination-link"
+          data-active={isActive}
+          {...props}
+        />
+      }
+    />
+  );
+}
+
+function PaginationPrevious({
+  className,
+  text = "Previous",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("pl-1.5!", className)}
+      {...props}
+    >
+      <ChevronLeftIcon data-icon="inline-start" />
+      <span className="hidden sm:block">{text}</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({
+  className,
+  text = "Next",
+  ...props
+}: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("pr-1.5!", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">{text}</span>
+      <ChevronRightIcon data-icon="inline-end" />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn(
+        "flex size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/src/constants/chat-room.ts
+++ b/src/constants/chat-room.ts
@@ -2,7 +2,7 @@ import type { ChatRoomSortOption, ChatRoomTab } from "@/types/chat-room";
 
 export const CHAT_ROOM_MIN_CAPACITY = 2;
 export const CHAT_ROOM_MAX_CAPACITY = 50;
-export const CHAT_ROOM_PAGE_SIZE = 30;
+export const CHAT_ROOM_PAGE_SIZE = 16;
 
 export const CHAT_ROOM_TABS: ChatRoomTab[] = ["JOINED", "NOT_JOINED", "OWNED"];
 

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -17,12 +17,12 @@ export const QUERY_KEYS = {
   chat: {
     all: ["chat"] as const,
     rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number) =>
-      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter(Boolean),
-    counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter(Boolean),
-    room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
-    messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),
-    members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter(Boolean),
+      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter((v) => v !== undefined),
+    counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter((v) => v !== undefined),
+    room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter((v) => v !== undefined),
+    messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter((v) => v !== undefined),
+    members: (roomId?: string) => [...QUERY_KEYS.chat.all, "members", roomId].filter((v) => v !== undefined),
     search: (query?: string, section?: string) =>
-      [...QUERY_KEYS.chat.all, "search", query, section].filter(Boolean),
+      [...QUERY_KEYS.chat.all, "search", query, section].filter((v) => v !== undefined),
   },
 } as const;

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -16,8 +16,8 @@ export const QUERY_KEYS = {
   },
   chat: {
     all: ["chat"] as const,
-    rooms: (userId?: string, tabType?: string, sortOption?: string) =>
-      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption].filter(Boolean),
+    rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number) =>
+      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter(Boolean),
     counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter(Boolean),
     room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter(Boolean),
     messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter(Boolean),

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -16,8 +16,8 @@ export const QUERY_KEYS = {
   },
   chat: {
     all: ["chat"] as const,
-    rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number) =>
-      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page].filter((v) => v !== undefined),
+    rooms: (userId?: string, tabType?: string, sortOption?: string, page?: number, searchQuery?: string) =>
+      [...QUERY_KEYS.chat.all, "rooms", userId, tabType, sortOption, page, searchQuery].filter((v) => v !== undefined),
     counts: (userId?: string) => [...QUERY_KEYS.chat.all, "counts", userId].filter((v) => v !== undefined),
     room: (roomId?: string) => [...QUERY_KEYS.chat.all, "room", roomId].filter((v) => v !== undefined),
     messages: (roomId?: string) => [...QUERY_KEYS.chat.all, "messages", roomId].filter((v) => v !== undefined),

--- a/src/hooks/use-chat-rooms.ts
+++ b/src/hooks/use-chat-rooms.ts
@@ -17,6 +17,7 @@ const fetchRooms = async (
   tabType: ChatRoomTab,
   sortOption: ChatRoomSortOption,
   offset: number,
+  searchQuery: string,
 ): Promise<ChatRoomByTabWithUnreadCount[]> => {
   const supabase = createClient();
 
@@ -26,6 +27,7 @@ const fetchRooms = async (
     p_limit: CHAT_ROOM_PAGE_SIZE,
     p_offset: offset,
     p_sort_option: sortOption,
+    p_query: searchQuery || undefined,
   });
 
   if (error) throw error;
@@ -36,18 +38,22 @@ const fetchRooms = async (
 /**
  * 채팅방 목록 조회 커스텀 훅
  * - 페이지 단위로 limit/offset 기반 페이지네이션을 수행한다.
+ * - searchQuery가 있으면 현재 탭 내에서 채팅방 제목으로 필터링한다.
  */
 export function useChatRooms(
   tabType: ChatRoomTab,
   sortOption: ChatRoomSortOption,
   currentPage: number,
+  searchQuery: string,
 ) {
   const { data: currentUser, isFetched: isUserFetched } = useUser();
   const offset = (currentPage - 1) * CHAT_ROOM_PAGE_SIZE;
+  const trimmedQuery = searchQuery.trim();
+  const queryParam = trimmedQuery || undefined; // 빈 문자열은 캐시 키에서 제거 → 검색 없는 상태와 동일 키
 
   return useQuery<ChatRoomByTabWithUnreadCount[]>({
-    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption, currentPage),
-    queryFn: () => fetchRooms(currentUser!.id, tabType, sortOption, offset),
+    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption, currentPage, queryParam),
+    queryFn: () => fetchRooms(currentUser!.id, tabType, sortOption, offset, trimmedQuery),
     enabled: !!currentUser?.id && isUserFetched,
     placeholderData: keepPreviousData,
     refetchOnMount: "always",

--- a/src/hooks/use-chat-rooms.ts
+++ b/src/hooks/use-chat-rooms.ts
@@ -1,6 +1,4 @@
-"use client";
-
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { CHAT_ROOM_PAGE_SIZE } from "@/constants/chat-room";
 import { QUERY_KEYS } from "@/constants/query-keys";
 import { useUser } from "@/hooks/use-profile";
@@ -37,18 +35,21 @@ const fetchRooms = async (
 
 /**
  * 채팅방 목록 조회 커스텀 훅
- * - 유저 프로필 정보가 로드된 후에만 목록을 페칭하도록 안전장치를 추가했습니다.
+ * - 페이지 단위로 limit/offset 기반 페이지네이션을 수행한다.
  */
-export function useChatRooms(tabType: ChatRoomTab, sortOption: ChatRoomSortOption) {
+export function useChatRooms(
+  tabType: ChatRoomTab,
+  sortOption: ChatRoomSortOption,
+  currentPage: number,
+) {
   const { data: currentUser, isFetched: isUserFetched } = useUser();
+  const offset = (currentPage - 1) * CHAT_ROOM_PAGE_SIZE;
 
-  return useInfiniteQuery<ChatRoomByTabWithUnreadCount[]>({
-    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption),
-    queryFn: ({ pageParam }) => fetchRooms(currentUser!.id, tabType, sortOption, Number(pageParam)),
+  return useQuery<ChatRoomByTabWithUnreadCount[]>({
+    queryKey: QUERY_KEYS.chat.rooms(currentUser?.id, tabType, sortOption, currentPage),
+    queryFn: () => fetchRooms(currentUser!.id, tabType, sortOption, offset),
     enabled: !!currentUser?.id && isUserFetched,
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === CHAT_ROOM_PAGE_SIZE ? allPages.length * CHAT_ROOM_PAGE_SIZE : undefined,
+    placeholderData: keepPreviousData,
     refetchOnMount: "always",
   });
 }

--- a/src/lib/zod/message.ts
+++ b/src/lib/zod/message.ts
@@ -5,7 +5,6 @@ import { MESSAGE_CONTENT_MAX_LENGTH } from "@/constants/message";
 
 export const messageContentSchema = z
   .string()
-  .trim()
   .min(1, "메시지를 입력해주세요.")
   .max(
     MESSAGE_CONTENT_MAX_LENGTH,

--- a/src/stores/chat-room.ts
+++ b/src/stores/chat-room.ts
@@ -7,9 +7,11 @@ interface ChatRoomState {
   tabType: ChatRoomTab;
   sortOption: ChatRoomSortOption;
   currentPage: number;
+  searchQuery: string;
   setTabType: (tabType: ChatRoomTab) => void;
   setSortOption: (sortOption: ChatRoomSortOption) => void;
   setCurrentPage: (page: number) => void;
+  setSearchQuery: (query: string) => void;
 }
 
 export const useChatRoomStore = create<ChatRoomState>()(
@@ -18,12 +20,14 @@ export const useChatRoomStore = create<ChatRoomState>()(
       tabType: "JOINED",
       sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
       currentPage: 1,
+      searchQuery: "",
       setTabType: (tabType) =>
         set(
           {
             tabType,
             sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
             currentPage: 1,
+            searchQuery: "",
           },
           false,
           "chatRoom/setTabType",
@@ -32,6 +36,8 @@ export const useChatRoomStore = create<ChatRoomState>()(
         set({ sortOption, currentPage: 1 }, false, "chatRoom/setSortOption"),
       setCurrentPage: (currentPage) =>
         set({ currentPage }, false, "chatRoom/setCurrentPage"),
+      setSearchQuery: (searchQuery) =>
+        set({ searchQuery, currentPage: 1 }, false, "chatRoom/setSearchQuery"),
     }),
     {
       name: "ChatRoomStore",

--- a/src/stores/chat-room.ts
+++ b/src/stores/chat-room.ts
@@ -6,8 +6,10 @@ import { devtools } from "zustand/middleware";
 interface ChatRoomState {
   tabType: ChatRoomTab;
   sortOption: ChatRoomSortOption;
+  currentPage: number;
   setTabType: (tabType: ChatRoomTab) => void;
   setSortOption: (sortOption: ChatRoomSortOption) => void;
+  setCurrentPage: (page: number) => void;
 }
 
 export const useChatRoomStore = create<ChatRoomState>()(
@@ -15,16 +17,21 @@ export const useChatRoomStore = create<ChatRoomState>()(
     (set) => ({
       tabType: "JOINED",
       sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
+      currentPage: 1,
       setTabType: (tabType) =>
         set(
           {
             tabType,
             sortOption: DEFAULT_CHAT_ROOM_SORT_OPTION,
+            currentPage: 1,
           },
           false,
           "chatRoom/setTabType",
         ),
-      setSortOption: (sortOption) => set({ sortOption }, false, "chatRoom/setSortOption"),
+      setSortOption: (sortOption) =>
+        set({ sortOption, currentPage: 1 }, false, "chatRoom/setSortOption"),
+      setCurrentPage: (currentPage) =>
+        set({ currentPage }, false, "chatRoom/setCurrentPage"),
     }),
     {
       name: "ChatRoomStore",

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -209,6 +209,7 @@ export type Database = {
         Args: {
           p_limit?: number
           p_offset?: number
+          p_query?: string
           p_sort_option?: string
           p_tab_type: string
           p_user_id: string
@@ -222,6 +223,7 @@ export type Database = {
           owner_id: string
           owner_nickname: string
           title: string
+          total_count: number
           unread_count: number
         }[]
       }

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,3 @@
+// 페이지네이션 항목 타입 (페이지 번호 또는 줄임표)
+
+export type PageItem = number | "ellipsis-left" | "ellipsis-right";

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,31 @@
+// 현재 페이지 / 전체 페이지로부터 표시할 항목 배열을 계산하는 순수 함수
+
+import type { PageItem } from "@/types/pagination";
+
+/**
+ * 페이지네이션 표시 항목 배열을 생성한다.
+ * - totalPages <= 5: 모든 페이지
+ * - currentPage <= 3: 1 2 3 4 … last
+ * - currentPage >= totalPages - 2: 1 … last-3 last-2 last-1 last
+ * - 중간: 1 … cur-1 cur cur+1 … last
+ */
+export function getPageItems(currentPage: number, totalPages: number): PageItem[] {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  if (currentPage <= 3) {
+    return [1, 2, 3, 4, "ellipsis-right", totalPages];
+  }
+  if (currentPage >= totalPages - 2) {
+    return [1, "ellipsis-left", totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+  }
+  return [
+    1,
+    "ellipsis-left",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "ellipsis-right",
+    totalPages,
+  ];
+}

--- a/supabase/migrations/20260515000000_get_rooms_by_tab_count_add_query.sql
+++ b/supabase/migrations/20260515000000_get_rooms_by_tab_count_add_query.sql
@@ -1,0 +1,158 @@
+-- get_rooms_by_tab_count에 p_query 파라미터 추가 (탭 내 채팅방 제목 검색)
+-- RETURNS에 total_count(윈도우 함수) 추가 → 검색 결과의 전체 개수 반환
+-- 시그니처 변경으로 기존 5-파라미터 함수 DROP 후 재생성
+
+DROP FUNCTION IF EXISTS public.get_rooms_by_tab_count(uuid, text, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION public.get_rooms_by_tab_count(
+  p_user_id    uuid,
+  p_tab_type   text,
+  p_sort_option text    DEFAULT 'CREATED_AT_DESC',
+  p_limit      integer  DEFAULT 30,
+  p_offset     integer  DEFAULT 0,
+  p_query      text     DEFAULT NULL
+)
+RETURNS TABLE(
+  id              uuid,
+  title           text,
+  description     text,
+  max_capacity    integer,
+  current_member  integer,
+  owner_id        uuid,
+  owner_nickname  text,
+  created_at      timestamp with time zone,
+  unread_count    integer,
+  total_count     integer
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public'
+AS $function$
+declare
+  v_tab_type   text := upper(coalesce(p_tab_type, ''));
+  v_sort_option text := upper(coalesce(p_sort_option, 'CREATED_AT_DESC'));
+  v_query      text := nullif(btrim(coalesce(p_query, '')), '');
+begin
+  if v_sort_option not in ('CREATED_AT_DESC', 'LAST_MESSAGE_DESC', 'CURRENT_MEMBER_DESC') then
+    v_sort_option := 'CREATED_AT_DESC';
+  end if;
+
+  -- NOT_JOINED는 최신 메시지순 미지원 → 기본값으로 리셋
+  if v_tab_type = 'NOT_JOINED' and v_sort_option = 'LAST_MESSAGE_DESC' then
+    v_sort_option := 'CREATED_AT_DESC';
+  end if;
+
+  if v_tab_type = 'OWNED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      coalesce(
+        (
+          select count(*)::integer
+          from public.message m
+          where m.chat_room_id = room.id
+            and m.created_at > coalesce(crm_read.last_read_at, 'epoch'::timestamptz)
+            and m.user_id <> p_user_id
+        ),
+        0
+      ) as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    left join public.chat_room_member as crm_read
+      on crm_read.chat_room_id = room.id
+     and crm_read.user_id = p_user_id
+    left join lateral (
+      select max(message.created_at) as last_message_at
+      from public.message as message
+      where message.chat_room_id = room.id
+    ) as latest_message on true
+    where room.owner_id = p_user_id
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'LAST_MESSAGE_DESC' then coalesce(latest_message.last_message_at, room.created_at) end desc nulls last,
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+
+  elsif v_tab_type = 'JOINED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      coalesce(
+        (
+          select count(*)::integer
+          from public.message m
+          where m.chat_room_id = room.id
+            and m.created_at > coalesce(member.last_read_at, 'epoch'::timestamptz)
+            and m.user_id <> p_user_id
+        ),
+        0
+      ) as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    join public.chat_room_member as member on member.chat_room_id = room.id
+    left join lateral (
+      select max(message.created_at) as last_message_at
+      from public.message as message
+      where message.chat_room_id = room.id
+    ) as latest_message on true
+    where member.user_id = p_user_id
+      and member.is_banned = false
+      and member.last_joined_at is not null
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'LAST_MESSAGE_DESC' then coalesce(latest_message.last_message_at, room.created_at) end desc nulls last,
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+
+  elsif v_tab_type = 'NOT_JOINED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      0::integer as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    left join public.chat_room_member as member
+      on member.chat_room_id = room.id
+     and member.user_id = p_user_id
+    where room.owner_id <> p_user_id
+      and (
+        member.user_id is null
+        or (member.is_banned = false and member.last_joined_at is null)
+      )
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+  end if;
+end;
+$function$;

--- a/supabase/migrations/20260515010000_get_rooms_by_tab_count_fix_unread_and_full_room.sql
+++ b/supabase/migrations/20260515010000_get_rooms_by_tab_count_fix_unread_and_full_room.sql
@@ -1,0 +1,159 @@
+-- get_rooms_by_tab_count 버그 수정 2건
+-- 1. OWNED/JOINED 탭 unread_count: system 메시지 제외 (message_type = 'text' 조건 추가)
+-- 2. NOT_JOINED 탭: 정원 가득 찬 채팅방 제외 (room.current_member < room.max_capacity 조건 추가)
+
+CREATE OR REPLACE FUNCTION public.get_rooms_by_tab_count(
+  p_user_id    uuid,
+  p_tab_type   text,
+  p_sort_option text    DEFAULT 'CREATED_AT_DESC',
+  p_limit      integer  DEFAULT 30,
+  p_offset     integer  DEFAULT 0,
+  p_query      text     DEFAULT NULL
+)
+RETURNS TABLE(
+  id              uuid,
+  title           text,
+  description     text,
+  max_capacity    integer,
+  current_member  integer,
+  owner_id        uuid,
+  owner_nickname  text,
+  created_at      timestamp with time zone,
+  unread_count    integer,
+  total_count     integer
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public'
+AS $function$
+declare
+  v_tab_type   text := upper(coalesce(p_tab_type, ''));
+  v_sort_option text := upper(coalesce(p_sort_option, 'CREATED_AT_DESC'));
+  v_query      text := nullif(btrim(coalesce(p_query, '')), '');
+begin
+  if v_sort_option not in ('CREATED_AT_DESC', 'LAST_MESSAGE_DESC', 'CURRENT_MEMBER_DESC') then
+    v_sort_option := 'CREATED_AT_DESC';
+  end if;
+
+  -- NOT_JOINED는 최신 메시지순 미지원 → 기본값으로 리셋
+  if v_tab_type = 'NOT_JOINED' and v_sort_option = 'LAST_MESSAGE_DESC' then
+    v_sort_option := 'CREATED_AT_DESC';
+  end if;
+
+  if v_tab_type = 'OWNED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      coalesce(
+        (
+          select count(*)::integer
+          from public.message m
+          where m.chat_room_id = room.id
+            and m.created_at > coalesce(crm_read.last_read_at, 'epoch'::timestamptz)
+            and m.user_id <> p_user_id
+            and m.message_type = 'text'  -- system 메시지 제외
+        ),
+        0
+      ) as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    left join public.chat_room_member as crm_read
+      on crm_read.chat_room_id = room.id
+     and crm_read.user_id = p_user_id
+    left join lateral (
+      select max(message.created_at) as last_message_at
+      from public.message as message
+      where message.chat_room_id = room.id
+    ) as latest_message on true
+    where room.owner_id = p_user_id
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'LAST_MESSAGE_DESC' then coalesce(latest_message.last_message_at, room.created_at) end desc nulls last,
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+
+  elsif v_tab_type = 'JOINED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      coalesce(
+        (
+          select count(*)::integer
+          from public.message m
+          where m.chat_room_id = room.id
+            and m.created_at > coalesce(member.last_read_at, 'epoch'::timestamptz)
+            and m.user_id <> p_user_id
+            and m.message_type = 'text'  -- system 메시지 제외
+        ),
+        0
+      ) as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    join public.chat_room_member as member on member.chat_room_id = room.id
+    left join lateral (
+      select max(message.created_at) as last_message_at
+      from public.message as message
+      where message.chat_room_id = room.id
+    ) as latest_message on true
+    where member.user_id = p_user_id
+      and member.is_banned = false
+      and member.last_joined_at is not null
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'LAST_MESSAGE_DESC' then coalesce(latest_message.last_message_at, room.created_at) end desc nulls last,
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+
+  elsif v_tab_type = 'NOT_JOINED' then
+    return query
+    select
+      room.id,
+      room.title,
+      room.description,
+      room.max_capacity::integer,
+      room.current_member,
+      room.owner_id,
+      owner.nickname,
+      room.created_at,
+      0::integer as unread_count,
+      count(*) OVER ()::integer as total_count
+    from public.chat_room as room
+    join public."user" as owner on owner.id = room.owner_id
+    left join public.chat_room_member as member
+      on member.chat_room_id = room.id
+     and member.user_id = p_user_id
+    where room.owner_id <> p_user_id
+      and (
+        member.user_id is null
+        or (member.is_banned = false and member.last_joined_at is null)
+      )
+      and room.current_member < room.max_capacity  -- 정원 가득 찬 방 제외
+      and (v_query is null or room.title ilike '%' || v_query || '%')
+    order by
+      case when v_sort_option = 'CURRENT_MEMBER_DESC' then room.current_member end desc nulls last,
+      room.created_at desc,
+      room.id desc
+    limit p_limit offset p_offset;
+  end if;
+end;
+$function$;

--- a/supabase/migrations/20260515010000_get_rooms_by_tab_count_fix_unread_and_full_room.sql
+++ b/supabase/migrations/20260515010000_get_rooms_by_tab_count_fix_unread_and_full_room.sql
@@ -1,6 +1,7 @@
--- get_rooms_by_tab_count 버그 수정 2건
+-- get_rooms_by_tab_count 버그 수정 3건
 -- 1. OWNED/JOINED 탭 unread_count: system 메시지 제외 (message_type = 'text' 조건 추가)
--- 2. NOT_JOINED 탭: 정원 가득 찬 채팅방 제외 (room.current_member < room.max_capacity 조건 추가)
+-- 2. OWNED/JOINED 탭 lateral 최신 메시지 정렬: system 메시지 제외 (message_type = 'text' 조건 추가)
+-- 3. NOT_JOINED 탭: 정원 가득 찬 채팅방 제외 (room.current_member < room.max_capacity 조건 추가)
 
 CREATE OR REPLACE FUNCTION public.get_rooms_by_tab_count(
   p_user_id    uuid,
@@ -72,6 +73,7 @@ begin
       select max(message.created_at) as last_message_at
       from public.message as message
       where message.chat_room_id = room.id
+        and message.message_type = 'text'  -- system 메시지 제외
     ) as latest_message on true
     where room.owner_id = p_user_id
       and (v_query is null or room.title ilike '%' || v_query || '%')
@@ -112,6 +114,7 @@ begin
       select max(message.created_at) as last_message_at
       from public.message as message
       where message.chat_room_id = room.id
+        and message.message_type = 'text'  -- system 메시지 제외
     ) as latest_message on true
     where member.user_id = p_user_id
       and member.is_banned = false

--- a/supabase/migrations/20260515020000_insert_date_divider_message_trigger.sql
+++ b/supabase/migrations/20260515020000_insert_date_divider_message_trigger.sql
@@ -1,0 +1,60 @@
+-- 채팅방 날짜 구분 시스템 메시지 자동 삽입 Trigger
+-- text 메시지 INSERT 시 해당 날짜(KST)의 첫 번째 메시지인지 확인,
+-- 첫 메시지라면 "📅 YYYY년 MM월 DD일 요일" 형태의 system 메시지를 1ms 앞에 삽입
+
+CREATE OR REPLACE FUNCTION public.insert_date_divider_message()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_kst_date        date;
+  v_dow             text;
+  v_content         text;
+  v_prev_text_today integer;
+BEGIN
+  -- system 메시지 INSERT 시 재귀 차단
+  IF NEW.message_type = 'system' THEN
+    RETURN NEW;
+  END IF;
+
+  -- UTC → KST 변환
+  v_kst_date := (NEW.created_at AT TIME ZONE 'Asia/Seoul')::date;
+
+  -- 같은 채팅방·같은 날짜(KST)의 다른 text 메시지가 이미 있는지 확인
+  SELECT COUNT(*) INTO v_prev_text_today
+  FROM public.message
+  WHERE chat_room_id = NEW.chat_room_id
+    AND message_type = 'text'
+    AND (created_at AT TIME ZONE 'Asia/Seoul')::date = v_kst_date
+    AND id != NEW.id;
+
+  -- 오늘 첫 text 메시지인 경우에만 날짜 구분선 삽입
+  IF v_prev_text_today = 0 THEN
+    v_dow := CASE EXTRACT(DOW FROM v_kst_date)
+      WHEN 0 THEN '일요일'
+      WHEN 1 THEN '월요일'
+      WHEN 2 THEN '화요일'
+      WHEN 3 THEN '수요일'
+      WHEN 4 THEN '목요일'
+      WHEN 5 THEN '금요일'
+      WHEN 6 THEN '토요일'
+    END;
+
+    v_content := '📅 ' || to_char(v_kst_date, 'YYYY"년" MM"월" DD"일" ') || v_dow;
+
+    INSERT INTO public.message (chat_room_id, user_id, content, message_type, created_at)
+    VALUES (
+      NEW.chat_room_id,
+      NEW.user_id,
+      v_content,
+      'system',
+      NEW.created_at - interval '1 millisecond'
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public';
+
+CREATE TRIGGER trigger_insert_date_divider_message
+  AFTER INSERT ON public.message
+  FOR EACH ROW
+  EXECUTE FUNCTION public.insert_date_divider_message();


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/search/tab-filter/#63 -> dev

### ✅ 작업 내용 `기능 추가`, `기능 개선`, `버그 수정`

**탭 내 채팅방 검색**
- `get_rooms_by_tab_count` RPC에 `p_query`(제목 필터) / `total_count`(검색 결과 전체 개수) 추가
- Zustand store에 `searchQuery` 추가 (tab 변경 시 초기화, sort 변경 시 유지, Submit 기반)
- `ChatRoomSearchInput` 신규 생성 → `chat-room-list-header` 두 번째 줄 배치
- 검색 중 탭 카운트를 `total_count` 기반으로 반영, empty state 메시지 분기

**RPC 버그 수정**
- OWNED/JOINED 탭 `unread_count` 및 `LAST_MESSAGE_DESC` 정렬 lateral 서브쿼리에 `message_type = 'text'` 조건 추가 (system 메시지 오염 제거)
- NOT_JOINED 탭 만석 채팅방 필터링 (`room.current_member < room.max_capacity`)

**메시지 입력 UX 개선**
- `message-input` Input → auto-resize Textarea 교체 (Shift+Enter 줄바꿈 / Enter 전송)
- max-h-32 초과 시에만 스크롤바 노출, webkit 커스텀 스크롤 스타일
- `message-item`에 `whitespace-pre-wrap` 추가 → 줄바꿈 메시지 정상 표시
- `messageContentSchema` `.trim()` 제거 → 앞뒤 줄바꿈 보존

**날짜 구분 시스템 메시지**
- `AFTER INSERT ON message` Trigger 추가 (KST 기준 당일 첫 text 메시지 감지 → 날짜 구분 system 메시지 자동 삽입)
- `SystemMessageItem`에서 `📅` prefix 제거 후 lucide Calendar SVG 아이콘으로 교체 렌더링

### 🎯 단독 테스트 결과

- 탭별 채팅방 검색 → 제목 매칭 결과만 표시, 탭 카운트·페이지네이션 정상 반영
- 탭 전환 시 검색어 초기화, 정렬 변경 시 검색어 유지 확인
- Shift+Enter 줄바꿈 입력 → 전송 후 줄바꿈 그대로 표시 확인
- 5줄 이상 입력 시 스크롤바 노출, 그 이하에서는 숨김 확인
- 당일 첫 메시지 전송 시 날짜 구분 system 메시지 자동 생성 확인

### 🚨 연관 이슈

closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 채팅방 전체 검색(검색창/검색 결과 문구 포함) 및 페이지네이션 UI 추가
  * 채팅 내 자동 날짜 구분선(system 메시지) 삽입 기능 추가

* **Improvements**
  * 채팅방 카드·멤버 항목에 소유자 배지 표시 강화 및 소유자 상단 정렬
  * 메시지 입력창 다중 라인 자동 높이 조정
  * 메시지 본문 공백·개행 렌더링 개선
  * 탭 카운트 99+에 대한 툴팁 및 로딩 표시 개선

* **Bug Fixes**
  * 일부 탭의 미읽음 집계와 조회 로직 정확도 개선(시스템 메시지 제외, 만원 방 제외)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/64)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->