### PR TITLE
feat: 메시지 낙관적업데이트 + 메시지 재전송,취소

### DIFF
--- a/src/actions/message.ts
+++ b/src/actions/message.ts
@@ -6,6 +6,7 @@ import { getAuthenticatedActorId } from "@/actions/authenticated-actor";
 import { createAdminClient } from "@/lib/supabase/admin-client";
 import { messageContentSchema } from "@/lib/zod/message";
 import type { AppActionResult } from "@/types/action";
+import type { MessageQuery } from "@/types/message";
 import { isKnownMessageRpcError, resolveMessageRpcErrorCode } from "@/utils/app-message";
 
 interface SendMessageActionInput {
@@ -16,7 +17,7 @@ interface SendMessageActionInput {
 export async function sendMessageAction({
   roomId,
   content,
-}: SendMessageActionInput): Promise<AppActionResult> {
+}: SendMessageActionInput): Promise<AppActionResult<{ message: MessageQuery }>> {
   if (!roomId) {
     return {
       success: false,
@@ -38,7 +39,11 @@ export async function sendMessageAction({
   });
 
   if (!actor.success) {
-    return actor.result;
+    return {
+      success: false,
+      code: actor.result.code,
+      photoUrl: actor.result.photoUrl,
+    };
   }
 
   const supabase = createAdminClient();
@@ -59,7 +64,26 @@ export async function sendMessageAction({
     };
   }
 
+  const { data: messageRow, error: rowError } = await supabase
+    .from("message")
+    .select("*, user:user_id!inner(nickname, photo_url)")
+    .eq("chat_room_id", roomId)
+    .eq("user_id", actor.userId)
+    .eq("content", parsed.data)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (rowError || !messageRow) {
+    console.error("전송 직후 메시지 조회 실패", rowError);
+    return {
+      success: false,
+      code: APP_MESSAGE_CODE.error.message.sendFailed,
+    };
+  }
+
   return {
     success: true,
+    data: { message: messageRow as MessageQuery },
   };
 }

--- a/src/components/chat-room/chat-room-message-section.tsx
+++ b/src/components/chat-room/chat-room-message-section.tsx
@@ -7,19 +7,31 @@ import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { useChatRoomDetail } from "@/hooks/chat-room/use-chat-room-detail";
 import { useChatRoomReadLifecycle } from "@/hooks/chat-room/use-chat-room-read-lifecycle";
 import useMessages from "@/hooks/message/use-messages";
+import { removeOptimisticMessage, useSendMessage } from "@/hooks/message/use-send-message";
 import { getAppMessage } from "@/utils/app-message";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface Props {
   roomId: string;
 }
 
 export function ChatRoomMessageSection({ roomId }: Props) {
+  const queryClient = useQueryClient();
+  const sendMessageMutation = useSendMessage(roomId);
   const { currentUserId, isKicked, canFetchMessages, canMarkRoomRead, canSendMessage } =
     useChatRoomDetail(roomId);
   const { messages, hasMorePrevious, isLoadingPrevious, fetchPreviousPage, isLoadingInitial } =
     useMessages(roomId, canFetchMessages);
 
   useChatRoomReadLifecycle({ roomId, enabled: canMarkRoomRead });
+
+  const handleRetryFailedSend = (messageId: string, content: string) => {
+    void sendMessageMutation.mutateAsync({ content, reuseMessageId: messageId });
+  };
+
+  const handleCancelFailedSend = (messageId: string) => {
+    removeOptimisticMessage(queryClient, roomId, messageId);
+  };
 
   const handleLoadPrevious = (): boolean => {
     if (isLoadingPrevious || !hasMorePrevious) {
@@ -39,10 +51,14 @@ export function ChatRoomMessageSection({ roomId }: Props) {
         hasMorePrevious={hasMorePrevious}
         isLoadingPrevious={isLoadingPrevious || isLoadingInitial}
         onReachTop={handleLoadPrevious}
+        onRetryFailedSend={handleRetryFailedSend}
+        onCancelFailedSend={handleCancelFailedSend}
+        isSendMutationPending={sendMessageMutation.isPending}
       />
 
       <MessageInput
         roomId={roomId}
+        sendMessageMutation={sendMessageMutation}
         disabled={!canSendMessage}
         disabledHint={
           getAppMessage(

--- a/src/components/chat-room/message/message-input.tsx
+++ b/src/components/chat-room/message/message-input.tsx
@@ -10,25 +10,39 @@ import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { MESSAGE_CONTENT_MAX_LENGTH } from "@/constants/message";
 import { useAutoResizeTextarea } from "@/hooks/common/use-auto-resize-textarea";
 import { useMessageDraft } from "@/hooks/message/use-message-draft";
-import { useSendMessage } from "@/hooks/message/use-send-message";
+import type { SendMessageVariables } from "@/hooks/message/use-send-message";
 import { cn } from "@/lib/utils";
+import type { AppActionResult } from "@/types/action";
+import type { MessageQuery } from "@/types/message";
 import { messageContentSchema } from "@/lib/zod/message";
 import { getAppMessageTitle } from "@/utils/app-message";
 import { toastAppError } from "@/utils/toast-message";
+import type { UseMutationResult } from "@tanstack/react-query";
 
 interface Props {
   roomId: string;
+  sendMessageMutation: UseMutationResult<
+    AppActionResult<{ message: MessageQuery }>,
+    Error,
+    SendMessageVariables
+  >;
   disabled?: boolean;
   disabledHint?: string;
 }
 
 const MAX_TEXTAREA_HEIGHT_PX = 128; // max-h-32 (8rem)
 
-export function MessageInput({ roomId, disabled = false, disabledHint }: Props) {
-  const sendMessageMutation = useSendMessage(roomId);
-  const { draft, setDraft, appendDraft, clearDraft } = useMessageDraft(MESSAGE_CONTENT_MAX_LENGTH);
+export function MessageInput({
+  roomId,
+  sendMessageMutation,
+  disabled = false,
+  disabledHint,
+}: Props) {
+  const { mutateAsync, isPending } = sendMessageMutation;
+  const { draft, setDraft, appendDraft } = useMessageDraft(MESSAGE_CONTENT_MAX_LENGTH);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const submitDisabled = disabled || sendMessageMutation.isPending;
+  const sendingRef = useRef(false);
+  const submitDisabled = disabled || isPending;
 
   useAutoResizeTextarea({
     textareaRef,
@@ -39,7 +53,7 @@ export function MessageInput({ roomId, disabled = false, disabledHint }: Props) 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (submitDisabled || !roomId) {
+    if (submitDisabled || !roomId || sendingRef.current) {
       return;
     }
 
@@ -51,14 +65,15 @@ export function MessageInput({ roomId, disabled = false, disabledHint }: Props) 
 
     const content = parsed.data;
 
-    try {
-      const result = await sendMessageMutation.mutateAsync(content);
+    sendingRef.current = true;
+    setDraft("");
 
-      if (result.success) {
-        clearDraft(content);
-      }
+    try {
+      await mutateAsync({ content });
     } catch {
-      return;
+      /* 실패한 메시지는 목록에 남고 clientFailed UI로 처리 */
+    } finally {
+      sendingRef.current = false;
     }
   };
 
@@ -77,7 +92,7 @@ export function MessageInput({ roomId, disabled = false, disabledHint }: Props) 
         title={disabled ? disabledHint : undefined}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
-          if (submitDisabled) return;
+          if (submitDisabled || sendingRef.current) return;
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             e.currentTarget.form?.requestSubmit();

--- a/src/components/chat-room/message/message-item.tsx
+++ b/src/components/chat-room/message/message-item.tsx
@@ -1,8 +1,11 @@
+"use client";
 // 채팅방 메시지 단일 항목을 표시하는 컴포넌트
+
+import { SystemMessageItem } from "@/components/chat-room/message/system-message-item";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { MessageQuery } from "@/types/message";
-import { SystemMessageItem } from "@/components/chat-room/message/system-message-item";
 import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/avatar";
 
 interface Props {
@@ -11,6 +14,37 @@ interface Props {
   isGroupedWithPrevious: boolean;
   isGroupedWithNext: boolean;
   showAuthor: boolean;
+  onRetryFailedSend?: (messageId: string, content: string) => void;
+  onCancelFailedSend?: (messageId: string) => void;
+  isSendMutationPending?: boolean;
+}
+
+function MessageBubble({
+  message,
+  isOwn,
+  showAuthor,
+  isGroupedWithNext,
+}: {
+  message: MessageQuery;
+  isOwn: boolean;
+  showAuthor: boolean;
+  isGroupedWithNext: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "inline-block max-w-full rounded-2xl px-3 py-1.5 text-sm leading-snug",
+        isOwn ? "bg-brand text-white" : "bg-muted/60 text-foreground",
+        showAuthor && (isOwn ? "rounded-tr-sm" : "rounded-tl-sm"),
+        !showAuthor && (isOwn ? "rounded-tr-md" : "rounded-tl-md"),
+        isGroupedWithNext && "rounded-br-md",
+        message.clientFailed &&
+          "ring-destructive/60 ring-2 ring-offset-1 ring-offset-background",
+      )}
+    >
+      <span className="wrap-break-word whitespace-pre-wrap">{message.content}</span>
+    </div>
+  );
 }
 
 export function MessageItem({
@@ -19,6 +53,9 @@ export function MessageItem({
   isGroupedWithPrevious,
   isGroupedWithNext,
   showAuthor,
+  onRetryFailedSend,
+  onCancelFailedSend,
+  isSendMutationPending = false,
 }: Props) {
   if (message.message_type === "system") {
     return <SystemMessageItem message={message} />;
@@ -27,22 +64,50 @@ export function MessageItem({
   const { nickname, photo_url: photoUrl } = message.user;
   const fallbackText = getAvatarFallbackText(nickname);
   const avatarSrc = getAvatarImageSrc(photoUrl);
+  const showFailedActions =
+    isOwn &&
+    message.clientFailed &&
+    onRetryFailedSend != null &&
+    onCancelFailedSend != null;
 
   if (isOwn) {
     return (
       <div
         className={cn("flex justify-end px-3 pb-0.5", isGroupedWithPrevious ? "pt-0.5" : "pt-2")}
       >
-        <div
-          className={cn(
-            "max-w-80 rounded-2xl px-3 py-1.5 text-sm leading-snug sm:max-w-md lg:max-w-lg",
-            "bg-brand text-white",
-            !isGroupedWithPrevious && "rounded-tr-sm",
-            isGroupedWithPrevious && "rounded-tr-md",
-            isGroupedWithNext && "rounded-br-md",
-          )}
-        >
-          <span className="wrap-break-word whitespace-pre-wrap">{message.content}</span>
+        <div className={cn("flex max-w-80 items-end gap-2 sm:max-w-md lg:max-w-lg")}>
+          {showFailedActions ? (
+            <div className="flex shrink-0 flex-nowrap items-center gap-1.5 pb-0.5">
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                className="h-7 text-xs"
+                disabled={isSendMutationPending}
+                onClick={() => onRetryFailedSend(message.id, message.content)}
+              >
+                재전송
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                className="h-7 text-xs"
+                disabled={isSendMutationPending}
+                onClick={() => onCancelFailedSend(message.id)}
+              >
+                취소
+              </Button>
+            </div>
+          ) : null}
+          <div className="min-w-0 shrink">
+            <MessageBubble
+              message={message}
+              isOwn
+              showAuthor={showAuthor}
+              isGroupedWithNext={isGroupedWithNext}
+            />
+          </div>
         </div>
       </div>
     );
@@ -60,17 +125,12 @@ export function MessageItem({
       )}
       <div className="min-w-0 flex-1">
         {showAuthor ? <div className="mb-1.5 text-xs font-medium">{nickname}</div> : null}
-        <div
-          className={cn(
-            "inline-block max-w-full rounded-2xl px-3 py-1.5 text-sm leading-snug",
-            "bg-muted/60 text-foreground",
-            showAuthor && "rounded-tl-sm",
-            !showAuthor && "rounded-tl-md",
-            isGroupedWithNext && "rounded-bl-md",
-          )}
-        >
-          <span className="wrap-break-word whitespace-pre-wrap">{message.content}</span>
-        </div>
+        <MessageBubble
+          message={message}
+          isOwn={false}
+          showAuthor={showAuthor}
+          isGroupedWithNext={isGroupedWithNext}
+        />
       </div>
     </div>
   );

--- a/src/components/chat-room/message/message-list.tsx
+++ b/src/components/chat-room/message/message-list.tsx
@@ -16,6 +16,9 @@ interface Props {
   hasMorePrevious: boolean;
   isLoadingPrevious: boolean;
   onReachTop: () => boolean;
+  onRetryFailedSend?: (messageId: string, content: string) => void;
+  onCancelFailedSend?: (messageId: string) => void;
+  isSendMutationPending?: boolean;
 }
 
 function canGroupMessages(current: MessageQuery, adjacent?: MessageQuery) {
@@ -31,6 +34,9 @@ export function MessageList({
   hasMorePrevious,
   isLoadingPrevious,
   onReachTop,
+  onRetryFailedSend,
+  onCancelFailedSend,
+  isSendMutationPending = false,
 }: Props) {
   const { viewportRef, showLatestButton, handleScroll, scrollToLatest } = useMessageListViewport({
     messages,
@@ -58,6 +64,9 @@ export function MessageList({
                 isGroupedWithPrevious={isGroupedWithPrevious}
                 isGroupedWithNext={isGroupedWithNext}
                 showAuthor={!isGroupedWithPrevious}
+                onRetryFailedSend={onRetryFailedSend}
+                onCancelFailedSend={onCancelFailedSend}
+                isSendMutationPending={isSendMutationPending}
               />
             );
           })}

--- a/src/hooks/message/use-messages.ts
+++ b/src/hooks/message/use-messages.ts
@@ -15,7 +15,7 @@ interface MessagesPage {
   nextCursor?: string;
 }
 
-function insertMessageByCreatedAtDesc(items: MessageQuery[], nextMessage: MessageQuery) {
+export function insertMessageByCreatedAtDesc(items: MessageQuery[], nextMessage: MessageQuery) {
   if (items.some((item) => item.id === nextMessage.id)) {
     return items;
   }

--- a/src/hooks/message/use-send-message.ts
+++ b/src/hooks/message/use-send-message.ts
@@ -1,27 +1,242 @@
 "use client";
 // 메시지 전송 서버 액션과 후속 캐시 갱신을 담당하는 mutation 훅
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+  type QueryClient,
+} from "@tanstack/react-query";
 
 import { sendMessageAction } from "@/actions/message";
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { QUERY_KEYS } from "@/constants/query-keys";
+import { insertMessageByCreatedAtDesc } from "@/hooks/message/use-messages";
+import { useNullableUser } from "@/hooks/profile/use-profile";
+import { useAuthStore } from "@/stores/auth";
+import type { AppActionResult } from "@/types/action";
+import type { MessageQuery } from "@/types/message";
 import { toastAppError } from "@/utils/toast-message";
+
+export type SendMessageVariables =
+  | string
+  | {
+      content: string;
+      reuseMessageId?: string;
+    };
+
+function toSendVariables(input: SendMessageVariables): {
+  content: string;
+  reuseMessageId?: string;
+} {
+  if (typeof input === "string") {
+    return { content: input };
+  }
+  return {
+    content: input.content,
+    reuseMessageId: input.reuseMessageId,
+  };
+}
+
+interface MessagesPage {
+  items: MessageQuery[];
+  nextCursor?: string;
+}
+
+function markMessageFailedInCache(
+  queryClient: QueryClient,
+  roomId: string,
+  tempId: string,
+): void {
+  const queryKey = QUERY_KEYS.chat.messages(roomId);
+  queryClient.setQueryData<InfiniteData<MessagesPage>>(queryKey, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        items: page.items.map((item) =>
+          item.id === tempId ? { ...item, clientFailed: true } : item,
+        ),
+      })),
+    };
+  });
+}
+
+/** 낙관적(임시 id) 메시지를 목록 캐시에서 제거합니다. */
+export function removeOptimisticMessage(
+  queryClient: QueryClient,
+  roomId: string,
+  messageId: string,
+): void {
+  const queryKey = QUERY_KEYS.chat.messages(roomId);
+  queryClient.setQueryData<InfiniteData<MessagesPage>>(queryKey, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        items: page.items.filter((item) => item.id !== messageId),
+      })),
+    };
+  });
+}
+
+function applyReconciledMessage(
+  previous: InfiniteData<MessagesPage>,
+  tempId: string,
+  replacement: MessageQuery,
+): InfiniteData<MessagesPage> {
+  const withoutTempPages = previous.pages.map((page) => ({
+    ...page,
+    items: page.items.filter((item) => item.id !== tempId),
+  }));
+
+  const replacementExists = withoutTempPages.some((page) =>
+    page.items.some((item) => item.id === replacement.id),
+  );
+
+  if (replacementExists) {
+    return {
+      ...previous,
+      pages: withoutTempPages,
+    };
+  }
+
+  const [firstPage, ...restPages] = withoutTempPages;
+  if (!firstPage) {
+    return {
+      pageParams: previous.pageParams,
+      pages: [{ items: [replacement], nextCursor: undefined }],
+    };
+  }
+
+  return {
+    ...previous,
+    pages: [
+      {
+        ...firstPage,
+        items: insertMessageByCreatedAtDesc(firstPage.items, replacement),
+      },
+      ...restPages,
+    ],
+  };
+}
+
+interface SendMessageContext {
+  tempId: string | null;
+}
 
 export function useSendMessage(roomId: string) {
   const queryClient = useQueryClient();
+  const authUser = useAuthStore((s) => s.user);
+  const { data: profile } = useNullableUser();
 
-  return useMutation({
-    mutationFn: (content: string) => sendMessageAction({ roomId, content }),
-    onSuccess: (result) => {
+  return useMutation<
+    AppActionResult<{ message: MessageQuery }>,
+    Error,
+    SendMessageVariables,
+    SendMessageContext
+  >({
+    // 기본 online 모드에서는 오프라인 시 mutation이 pause되어 onError·실패 UI가 뜨지 않음
+    networkMode: "always",
+    mutationFn: (variables) => {
+      const { content } = toSendVariables(variables);
+      return sendMessageAction({ roomId, content });
+    },
+    onMutate: async (variables) => {
+      const { content, reuseMessageId } = toSendVariables(variables);
+      const queryKey = QUERY_KEYS.chat.messages(roomId);
+      await queryClient.cancelQueries({ queryKey });
+
+      if (reuseMessageId) {
+        queryClient.setQueryData<InfiniteData<MessagesPage>>(queryKey, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              items: page.items.map((item) =>
+                item.id === reuseMessageId
+                  ? { ...item, clientFailed: undefined }
+                  : item,
+              ),
+            })),
+          };
+        });
+        return { tempId: reuseMessageId };
+      }
+
+      const userId = authUser?.id;
+      if (!userId) {
+        return { tempId: null };
+      }
+
+      const tempId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      const optimistic: MessageQuery = {
+        id: tempId,
+        chat_room_id: roomId,
+        user_id: userId,
+        content,
+        created_at: now,
+        modified_at: now,
+        message_type: "text",
+        user: {
+          nickname: profile?.nickname ?? "",
+          photo_url: profile?.photo_url ?? null,
+        },
+      };
+
+      queryClient.setQueryData<InfiniteData<MessagesPage>>(queryKey, (old) => {
+        if (!old) {
+          return {
+            pageParams: [undefined],
+            pages: [{ items: [optimistic], nextCursor: undefined }],
+          };
+        }
+        const [firstPage, ...restPages] = old.pages;
+        if (!firstPage) return old;
+        return {
+          ...old,
+          pages: [
+            {
+              ...firstPage,
+              items: insertMessageByCreatedAtDesc(firstPage.items, optimistic),
+            },
+            ...restPages,
+          ],
+        };
+      });
+
+      return { tempId };
+    },
+    onSuccess: (result, _variables, context) => {
+      const queryKey = QUERY_KEYS.chat.messages(roomId);
+
       if (!result.success) {
+        if (context?.tempId) {
+          markMessageFailedInCache(queryClient, roomId, context.tempId);
+        }
         toastAppError(result.code ?? APP_MESSAGE_CODE.error.message.sendFailed);
         return;
       }
 
+      if (context?.tempId && result.data?.message) {
+        const replacement = result.data.message;
+        const tempId = context.tempId;
+        queryClient.setQueryData<InfiniteData<MessagesPage>>(queryKey, (old) => {
+          if (!old) return old;
+          return applyReconciledMessage(old, tempId, replacement);
+        });
+      }
+
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chat.list() });
     },
-    onError: (error) => {
+    onError: (error, _variables, context) => {
+      if (context?.tempId) {
+        markMessageFailedInCache(queryClient, roomId, context.tempId);
+      }
       console.error("메시지 전송 처리 실패", error);
       toastAppError(APP_MESSAGE_CODE.error.message.sendFailed);
     },

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -11,4 +11,6 @@ export interface MessageQuery extends Message {
     nickname: string;
     photo_url: string | null;
   };
+  /** 클라이언트 전용: DB 전송 실패 시 재전송·취소 UI */
+  clientFailed?: boolean;
 }


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/chat/opt-message/#66 -> refactor/project-wide/#65

### ✅ 작업 내용 `기능 추가`

- 낙관적 업데이트 구현
- 취소 재전송 ui 구현
- 취소 재전송 기능 구현

### 🎯 단독 테스트 결과

- network offilne일때 재전송, 취소 UI 뜸
- 재전송, 취소 정상작동
- 낙관적 업데이트 가능

### 🚨 연관 이슈

closes #66 
