### PR TITLE
fix(#65): auth toast next redirect 경로 보존

### DIFF
--- a/src/components/auth/auth-toast-handler.tsx
+++ b/src/components/auth/auth-toast-handler.tsx
@@ -4,11 +4,12 @@
 import { APP_MESSAGE_CODE } from "@/constants/app-message-code";
 import { useNullableUser } from "@/hooks/profile/use-profile";
 import { toastAppSuccess } from "@/utils/toast-message";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect } from "react";
 
 function AuthToastInner({ nickname }: { nickname: string }) {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const router = useRouter();
 
   useEffect(() => {
@@ -33,16 +34,10 @@ function AuthToastInner({ nickname }: { nickname: string }) {
       params.delete("welcome");
     }
 
-    const currentPath = window.location.pathname;
-    if (currentPath.includes("profile")) {
-      router.replace("/profile");
-      return;
-    }
-
-    // 토스트 표시 후 URL에서 파라미터 제거 (새로고침 시 재표시 방지)
-    const newUrl = params.size > 0 ? `?${params.toString()}` : "/";
+    // 토스트 표시 후 URL에서 파라미터만 제거해 next redirect 경로를 보존
+    const newUrl = params.size > 0 ? `${pathname}?${params.toString()}` : pathname;
     router.replace(newUrl, { scroll: false });
-  }, [searchParams, router, nickname]);
+  }, [searchParams, pathname, router, nickname]);
 
   return null;
 }


### PR DESCRIPTION
### 📌 반영 브랜치

#### fix/auth-toast-next-redirect-65 -> dev

### ✅ 작업 내용 버그 수정

-> PR에서 작업한 내용을 간략히 설명해주세요!

- 공유 채팅방 링크에서 로그인 후 /chat-room/:roomId?login=true에 도착했다가 auth toast 후처리로 /로 이동하던 문제를 수정했습니다.
- AuthToastHandler가 login, welcome, linked query만 제거하고 현재 pathname과 나머지 query를 보존하도록 정리했습니다.

### 🎯 단독 테스트 결과

-> dev 브랜치에 포함되기 전에 코드가 정상적으로 동작하는지 확인해주세요!

- C:\Program Files\nodejs\npm.cmd run format:check 통과.
- C:\Program Files\nodejs\npm.cmd run lint 통과.
- C:\Program Files\nodejs\npm.cmd run build 통과.
- 정적 검색으로 auth toast 후처리 내 / 강제 이동과 window.location.pathname 의존이 제거된 것을 확인했습니다.

### 🚨 연관 이슈

closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 인증 프로세스 완료 후 사용자가 원래 방문하던 페이지로 더욱 정확하게 이동하도록 개선했습니다. 인증 성공 메시지 표시 이후 현재 페이지의 경로와 검색 쿼리 파라미터가 올바르게 유지되어, 사용자의 탐색 컨텍스트가 더 이상 손실되지 않습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PixelPlay-RGB/pixel-play-project/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->