### PR TITLE
feat(#99): 팔로우 크리에이터 라이브·커뮤니티 인앱 알림(수신함) 구현

### DIFF
--- a/src/actions/notification/notification.ts
+++ b/src/actions/notification/notification.ts
@@ -25,3 +25,46 @@ export async function markNotificationsSeenAction(): Promise<AppActionResult> {
 
   return { success: true };
 }
+
+export async function deleteAllNotificationsAction(): Promise<AppActionResult> {
+  const actor = await getAuthenticatedActorId({
+    logLabel: "알림 전체 삭제 중 인증 유저 조회 실패",
+  });
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("delete_all_notifications", {
+    p_actor_user_id: actor.userId,
+  });
+
+  if (error) {
+    console.error("알림 전체 삭제 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.notification.deleteFailed };
+  }
+
+  return { success: true };
+}
+
+export async function deleteNotificationAction(notificationId: string): Promise<AppActionResult> {
+  const actor = await getAuthenticatedActorId({
+    logLabel: "알림 삭제 중 인증 유저 조회 실패",
+  });
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("delete_notification", {
+    p_actor_user_id: actor.userId,
+    p_notification_id: notificationId,
+  });
+
+  if (error) {
+    console.error("알림 삭제 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.notification.deleteFailed };
+  }
+
+  return { success: true };
+}

--- a/src/actions/notification/notification.ts
+++ b/src/actions/notification/notification.ts
@@ -1,0 +1,27 @@
+"use server";
+// 알림 읽음(방문 기준) 처리 Server Action. service_role 전용 RPC를 admin client로 호출합니다.
+import { getAuthenticatedActorId } from "@/actions/common/authenticated-actor";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import type { AppActionResult } from "@/types/common/action";
+
+export async function markNotificationsSeenAction(): Promise<AppActionResult> {
+  const actor = await getAuthenticatedActorId({
+    logLabel: "알림 읽음 처리 중 인증 유저 조회 실패",
+  });
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("mark_notifications_seen", {
+    p_actor_user_id: actor.userId,
+  });
+
+  if (error) {
+    console.error("알림 읽음 처리 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.common.unknown };
+  }
+
+  return { success: true };
+}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -31,7 +31,7 @@ export default async function Header() {
             <BroadcastButton />
           </div>
 
-          <Separator orientation="vertical" className="h-6" />
+          <Separator orientation="vertical" className="h-6 data-vertical:self-center" />
 
           {/* 섹션 2: 알림 + 테마 토글 */}
           <div className="flex items-center gap-2 sm:gap-3">
@@ -39,7 +39,7 @@ export default async function Header() {
             <ThemeToggleButton />
           </div>
 
-          <Separator orientation="vertical" className="h-6" />
+          <Separator orientation="vertical" className="h-6 data-vertical:self-center" />
 
           {/* 섹션 3: 계정 */}
           <div className="flex items-center">

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,4 +1,4 @@
-// 애플리케이션 헤더 - 로고, 검색, 테마 전환, 프로필 배지 표시
+// 애플리케이션 헤더 - 로고, 검색/방송, 알림/테마, 계정 3개 섹션 표시
 
 import LoginButton from "@/components/auth/login-button";
 import BroadcastButton from "@/components/common/broadcast-button";
@@ -7,6 +7,7 @@ import ThemeToggleButton from "@/components/common/theme-toggle-button";
 import NotificationBell from "@/components/notification/notification-bell";
 import UserAccountMenu from "@/components/common/user-account-menu";
 import HeaderSearchForm from "@/components/search/header-search-form";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { getCurrentProfileSnapshot } from "@/utils/profile/profile-server";
 
@@ -24,12 +25,27 @@ export default async function Header() {
         <HeaderMainNav />
 
         <div className="flex items-center gap-2 sm:gap-3">
-          <HeaderSearchForm />
-          <BroadcastButton />
-          <ThemeToggleButton />
-          {hasAuthUser && <NotificationBell />}
-          {profile && <UserAccountMenu profile={profile} />}
-          {!hasAuthUser && <LoginButton />}
+          {/* 섹션 1: 검색 + 방송하기 */}
+          <div className="flex items-center gap-2 sm:gap-3">
+            <HeaderSearchForm />
+            <BroadcastButton />
+          </div>
+
+          <Separator orientation="vertical" className="h-6" />
+
+          {/* 섹션 2: 알림 + 테마 토글 */}
+          <div className="flex items-center gap-2 sm:gap-3">
+            {hasAuthUser && <NotificationBell />}
+            <ThemeToggleButton />
+          </div>
+
+          <Separator orientation="vertical" className="h-6" />
+
+          {/* 섹션 3: 계정 */}
+          <div className="flex items-center">
+            {profile && <UserAccountMenu profile={profile} />}
+            {!hasAuthUser && <LoginButton />}
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -4,6 +4,7 @@ import LoginButton from "@/components/auth/login-button";
 import BroadcastButton from "@/components/common/broadcast-button";
 import HeaderMainNav from "@/components/common/header-main-nav";
 import ThemeToggleButton from "@/components/common/theme-toggle-button";
+import NotificationBell from "@/components/notification/notification-bell";
 import UserAccountMenu from "@/components/common/user-account-menu";
 import HeaderSearchForm from "@/components/search/header-search-form";
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ export default async function Header() {
           <HeaderSearchForm />
           <BroadcastButton />
           <ThemeToggleButton />
+          {hasAuthUser && <NotificationBell />}
           {profile && <UserAccountMenu profile={profile} />}
           {!hasAuthUser && <LoginButton />}
         </div>

--- a/src/components/notification/notification-bell.tsx
+++ b/src/components/notification/notification-bell.tsx
@@ -1,0 +1,44 @@
+"use client";
+// 헤더 종 아이콘 + 안읽음 빨간 점 + 수신함 드롭다운(Popover). 로그인 시에만 노출.
+import { useState } from "react";
+import { Bell } from "lucide-react";
+
+import NotificationInbox from "@/components/notification/notification-inbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useMarkNotificationsSeen } from "@/hooks/notification/use-mark-notifications-seen";
+import { useNotificationBadge } from "@/hooks/notification/use-notification-badge";
+
+export default function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const { unreadCount, isLoggedIn } = useNotificationBadge();
+  const markSeen = useMarkNotificationsSeen();
+
+  if (!isLoggedIn) return null;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    // 수신함을 열 때 안읽음이 있으면 방문 기준 읽음 처리(배지 0).
+    if (next && unreadCount > 0) markSeen.mutate();
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        type="button"
+        aria-label="알림"
+        className="text-muted-foreground hover:text-foreground relative inline-flex size-9 items-center justify-center rounded-full"
+      >
+        <Bell className="size-5" />
+        {unreadCount > 0 && (
+          <span className="bg-live ring-background absolute top-1.5 right-1.5 size-2 rounded-full ring-2" />
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[22rem] gap-0 p-0">
+        <div className="border-border flex items-center justify-between border-b px-4 py-3">
+          <span className="text-foreground text-sm font-bold">알림</span>
+        </div>
+        <NotificationInbox onNavigate={() => setOpen(false)} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/notification/notification-bell.tsx
+++ b/src/components/notification/notification-bell.tsx
@@ -33,7 +33,7 @@ export default function NotificationBell() {
           <span className="bg-live ring-background absolute top-1.5 right-1.5 size-2 rounded-full ring-2" />
         )}
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-[22rem] gap-0 p-0">
+      <PopoverContent align="end" className="w-88 gap-0 p-0">
         <div className="border-border flex items-center justify-between border-b px-4 py-3">
           <span className="text-foreground text-sm font-bold">알림</span>
         </div>

--- a/src/components/notification/notification-bell.tsx
+++ b/src/components/notification/notification-bell.tsx
@@ -7,6 +7,7 @@ import NotificationInbox from "@/components/notification/notification-inbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useMarkNotificationsSeen } from "@/hooks/notification/use-mark-notifications-seen";
 import { useNotificationBadge } from "@/hooks/notification/use-notification-badge";
+import { cn } from "@/lib/utils";
 
 export default function NotificationBell() {
   const [open, setOpen] = useState(false);
@@ -26,11 +27,16 @@ export default function NotificationBell() {
       <PopoverTrigger
         type="button"
         aria-label="알림"
-        className="text-muted-foreground hover:text-foreground relative inline-flex size-9 items-center justify-center rounded-full"
+        className={cn(
+          "relative grid size-10 place-items-center rounded-md border border-transparent bg-transparent",
+          "cursor-pointer",
+          "text-foreground hover:bg-muted hover:text-foreground dark:hover:bg-muted/50",
+          "transition-all duration-200",
+        )}
       >
-        <Bell className="size-5" />
+        <Bell size={24} />
         {unreadCount > 0 && (
-          <span className="bg-live ring-background absolute top-1.5 right-1.5 size-2 rounded-full ring-2" />
+          <span className="bg-live ring-background absolute top-2 right-2 size-2 rounded-full ring-2" />
         )}
       </PopoverTrigger>
       <PopoverContent align="end" className="w-88 gap-0 p-0">

--- a/src/components/notification/notification-bell.tsx
+++ b/src/components/notification/notification-bell.tsx
@@ -40,9 +40,6 @@ export default function NotificationBell() {
         )}
       </PopoverTrigger>
       <PopoverContent align="end" className="w-88 gap-0 p-0">
-        <div className="border-border flex items-center justify-between border-b px-4 py-3">
-          <span className="text-foreground text-sm font-bold">알림</span>
-        </div>
         <NotificationInbox onNavigate={() => setOpen(false)} />
       </PopoverContent>
     </Popover>

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -1,5 +1,5 @@
 "use client";
-// 수신함 패널: 헤더(알림 + 모두 삭제) + 날짜 그룹(오늘/어제/최근 일주일/이전) 목록 + 더보기 + 개별 삭제.
+// 수신함 패널: 헤더(알림 + 모두 삭제) + 날짜 그룹(오늘/최근 일주일/이전) 목록 + 더보기 + 개별 삭제.
 import { Fragment, useState } from "react";
 
 import DeleteConfirmDialog from "@/components/common/delete-confirm-dialog";

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -6,15 +6,7 @@ import NotificationItem from "@/components/notification/notification-item";
 import { Spinner } from "@/components/ui/spinner";
 import { useNotifications } from "@/hooks/notification/use-notifications";
 import type { AppNotification } from "@/types/notification/notification";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function groupLabel(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  if (diff < DAY_MS) return "오늘";
-  if (diff < 7 * DAY_MS) return "최근 일주일";
-  return "이전";
-}
+import { formatNotificationGroupLabel } from "@/utils/common/format";
 
 export default function NotificationInbox({ onNavigate }: { onNavigate: () => void }) {
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useNotifications(true);
@@ -37,11 +29,12 @@ export default function NotificationInbox({ onNavigate }: { onNavigate: () => vo
   }
 
   return (
-    <div className="flex max-h-[28rem] flex-col overflow-y-auto p-1">
+    <div className="flex max-h-112 flex-col overflow-y-auto p-1">
       {items.map((item, index) => {
-        const label = groupLabel(item.createdAt);
+        const label = formatNotificationGroupLabel(item.createdAt);
         // 직전 아이템과 그룹 라벨이 다를 때(또는 첫 아이템)만 그룹 헤더를 노출합니다.
-        const prevLabel = index > 0 ? groupLabel(items[index - 1].createdAt) : null;
+        const prevLabel =
+          index > 0 ? formatNotificationGroupLabel(items[index - 1].createdAt) : null;
         const showLabel = label !== prevLabel;
         return (
           <Fragment key={item.id}>

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -46,18 +46,19 @@ export default function NotificationInbox({ onNavigate }: { onNavigate: () => vo
       );
     }
 
+    // 그룹 라벨을 아이템당 한 번만 계산하고, 직전 라벨과 다를 때만 헤더를 노출한다.
+    const groupLabels = items.map((item) => formatNotificationGroupLabel(item.createdAt));
+
     return (
       <div className="flex max-h-112 flex-col overflow-y-auto p-1">
         {items.map((item, index) => {
-          const label = formatNotificationGroupLabel(item.createdAt);
-          // 직전 아이템과 그룹 라벨이 다를 때(또는 첫 아이템)만 그룹 헤더를 노출합니다.
-          const prevLabel =
-            index > 0 ? formatNotificationGroupLabel(items[index - 1].createdAt) : null;
-          const showLabel = label !== prevLabel;
+          const showLabel = groupLabels[index] !== groupLabels[index - 1];
           return (
             <Fragment key={item.id}>
               {showLabel && (
-                <p className="text-muted-foreground px-3 pt-3 pb-1 text-xs font-bold">{label}</p>
+                <p className="text-muted-foreground px-3 pt-3 pb-1 text-xs font-bold">
+                  {groupLabels[index]}
+                </p>
               )}
               <NotificationItem
                 notification={item}

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -1,0 +1,67 @@
+"use client";
+// 수신함 패널: 알림을 상대시간 그룹(오늘/최근 일주일/이전)으로 묶어 보여주고 더보기로 추가 로드.
+import { Fragment } from "react";
+
+import NotificationItem from "@/components/notification/notification-item";
+import { Spinner } from "@/components/ui/spinner";
+import { useNotifications } from "@/hooks/notification/use-notifications";
+import type { AppNotification } from "@/types/notification/notification";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function groupLabel(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < DAY_MS) return "오늘";
+  if (diff < 7 * DAY_MS) return "최근 일주일";
+  return "이전";
+}
+
+export default function NotificationInbox({ onNavigate }: { onNavigate: () => void }) {
+  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useNotifications(true);
+  const items: AppNotification[] = data?.pages.flat() ?? [];
+
+  if (isPending) {
+    return (
+      <div className="flex justify-center py-10">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="text-muted-foreground py-10 text-center text-sm font-semibold">
+        아직 받은 알림이 없어요.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex max-h-[28rem] flex-col overflow-y-auto p-1">
+      {items.map((item, index) => {
+        const label = groupLabel(item.createdAt);
+        // 직전 아이템과 그룹 라벨이 다를 때(또는 첫 아이템)만 그룹 헤더를 노출합니다.
+        const prevLabel = index > 0 ? groupLabel(items[index - 1].createdAt) : null;
+        const showLabel = label !== prevLabel;
+        return (
+          <Fragment key={item.id}>
+            {showLabel && (
+              <p className="text-muted-foreground px-3 pt-3 pb-1 text-xs font-bold">{label}</p>
+            )}
+            <NotificationItem notification={item} onNavigate={onNavigate} />
+          </Fragment>
+        );
+      })}
+      {hasNextPage && (
+        <button
+          type="button"
+          onClick={() => void fetchNextPage()}
+          disabled={isFetchingNextPage}
+          className="text-muted-foreground hover:text-foreground py-2 text-center text-xs font-semibold"
+        >
+          {isFetchingNextPage ? "불러오는 중…" : "더보기"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -14,7 +14,8 @@ import type { AppNotification } from "@/types/notification/notification";
 import { formatNotificationGroupLabel } from "@/utils/common/format";
 
 export default function NotificationInbox({ onNavigate }: { onNavigate: () => void }) {
-  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useNotifications(true);
+  const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useNotifications(true);
   const deleteAll = useDeleteAllNotifications();
   const deleteOne = useDeleteNotification();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -35,6 +36,14 @@ export default function NotificationInbox({ onNavigate }: { onNavigate: () => vo
         <div className="flex justify-center py-10">
           <Spinner />
         </div>
+      );
+    }
+
+    if (isError) {
+      return (
+        <p className="text-muted-foreground py-10 text-center text-sm font-semibold">
+          알림을 불러오지 못했어요.
+        </p>
       );
     }
 

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -5,12 +5,14 @@ import { Fragment, useState } from "react";
 import DeleteConfirmDialog from "@/components/common/delete-confirm-dialog";
 import NotificationItem from "@/components/notification/notification-item";
 import { Spinner } from "@/components/ui/spinner";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import {
   useDeleteAllNotifications,
   useDeleteNotification,
 } from "@/hooks/notification/use-delete-notifications";
 import { useNotifications } from "@/hooks/notification/use-notifications";
 import type { AppNotification } from "@/types/notification/notification";
+import { getAppMessage } from "@/utils/common/app-message";
 import { formatNotificationGroupLabel } from "@/utils/common/format";
 
 export default function NotificationInbox({ onNavigate }: { onNavigate: () => void }) {
@@ -40,10 +42,12 @@ export default function NotificationInbox({ onNavigate }: { onNavigate: () => vo
     }
 
     if (isError) {
+      const message = getAppMessage(APP_MESSAGE_CODE.error.notification.loadFailed);
       return (
-        <p className="text-muted-foreground py-10 text-center text-sm font-semibold">
-          알림을 불러오지 못했어요.
-        </p>
+        <div className="text-muted-foreground flex flex-col items-center gap-1 py-10 text-center">
+          <p className="text-foreground text-sm font-semibold">{message.title}</p>
+          <p className="text-xs">{message.description}</p>
+        </div>
       );
     }
 

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -1,5 +1,5 @@
 "use client";
-// 수신함 패널: 헤더(알림 + 모두 삭제) + 상대시간 그룹(오늘/최근 일주일/이전) 목록 + 더보기 + 개별 삭제.
+// 수신함 패널: 헤더(알림 + 모두 삭제) + 날짜 그룹(오늘/어제/최근 일주일/이전) 목록 + 더보기 + 개별 삭제.
 import { Fragment, useState } from "react";
 
 import DeleteConfirmDialog from "@/components/common/delete-confirm-dialog";

--- a/src/components/notification/notification-inbox.tsx
+++ b/src/components/notification/notification-inbox.tsx
@@ -1,60 +1,112 @@
 "use client";
-// 수신함 패널: 알림을 상대시간 그룹(오늘/최근 일주일/이전)으로 묶어 보여주고 더보기로 추가 로드.
-import { Fragment } from "react";
+// 수신함 패널: 헤더(알림 + 모두 삭제) + 상대시간 그룹(오늘/최근 일주일/이전) 목록 + 더보기 + 개별 삭제.
+import { Fragment, useState } from "react";
 
+import DeleteConfirmDialog from "@/components/common/delete-confirm-dialog";
 import NotificationItem from "@/components/notification/notification-item";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  useDeleteAllNotifications,
+  useDeleteNotification,
+} from "@/hooks/notification/use-delete-notifications";
 import { useNotifications } from "@/hooks/notification/use-notifications";
 import type { AppNotification } from "@/types/notification/notification";
 import { formatNotificationGroupLabel } from "@/utils/common/format";
 
 export default function NotificationInbox({ onNavigate }: { onNavigate: () => void }) {
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } = useNotifications(true);
+  const deleteAll = useDeleteAllNotifications();
+  const deleteOne = useDeleteNotification();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
   const items: AppNotification[] = data?.pages.flat() ?? [];
 
-  if (isPending) {
+  const handleDeleteAll = () => {
+    deleteAll.mutate(undefined, {
+      onSuccess: (result) => {
+        if (result.success) setConfirmOpen(false);
+      },
+    });
+  };
+
+  const renderBody = () => {
+    if (isPending) {
+      return (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      );
+    }
+
+    if (items.length === 0) {
+      return (
+        <p className="text-muted-foreground py-10 text-center text-sm font-semibold">
+          아직 받은 알림이 없어요.
+        </p>
+      );
+    }
+
     return (
-      <div className="flex justify-center py-10">
-        <Spinner />
+      <div className="flex max-h-112 flex-col overflow-y-auto p-1">
+        {items.map((item, index) => {
+          const label = formatNotificationGroupLabel(item.createdAt);
+          // 직전 아이템과 그룹 라벨이 다를 때(또는 첫 아이템)만 그룹 헤더를 노출합니다.
+          const prevLabel =
+            index > 0 ? formatNotificationGroupLabel(items[index - 1].createdAt) : null;
+          const showLabel = label !== prevLabel;
+          return (
+            <Fragment key={item.id}>
+              {showLabel && (
+                <p className="text-muted-foreground px-3 pt-3 pb-1 text-xs font-bold">{label}</p>
+              )}
+              <NotificationItem
+                notification={item}
+                onNavigate={onNavigate}
+                onDelete={(id) => deleteOne.mutate(id)}
+              />
+            </Fragment>
+          );
+        })}
+        {hasNextPage && (
+          <button
+            type="button"
+            onClick={() => void fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="text-muted-foreground hover:text-foreground py-2 text-center text-xs font-semibold"
+          >
+            {isFetchingNextPage ? "불러오는 중…" : "더보기"}
+          </button>
+        )}
       </div>
     );
-  }
-
-  if (items.length === 0) {
-    return (
-      <p className="text-muted-foreground py-10 text-center text-sm font-semibold">
-        아직 받은 알림이 없어요.
-      </p>
-    );
-  }
+  };
 
   return (
-    <div className="flex max-h-112 flex-col overflow-y-auto p-1">
-      {items.map((item, index) => {
-        const label = formatNotificationGroupLabel(item.createdAt);
-        // 직전 아이템과 그룹 라벨이 다를 때(또는 첫 아이템)만 그룹 헤더를 노출합니다.
-        const prevLabel =
-          index > 0 ? formatNotificationGroupLabel(items[index - 1].createdAt) : null;
-        const showLabel = label !== prevLabel;
-        return (
-          <Fragment key={item.id}>
-            {showLabel && (
-              <p className="text-muted-foreground px-3 pt-3 pb-1 text-xs font-bold">{label}</p>
-            )}
-            <NotificationItem notification={item} onNavigate={onNavigate} />
-          </Fragment>
-        );
-      })}
-      {hasNextPage && (
-        <button
-          type="button"
-          onClick={() => void fetchNextPage()}
-          disabled={isFetchingNextPage}
-          className="text-muted-foreground hover:text-foreground py-2 text-center text-xs font-semibold"
-        >
-          {isFetchingNextPage ? "불러오는 중…" : "더보기"}
-        </button>
-      )}
+    <div className="flex flex-col">
+      <div className="border-border flex items-center justify-between border-b px-4 py-3">
+        <span className="text-foreground text-sm font-bold">알림</span>
+        {items.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            className="text-muted-foreground hover:text-foreground text-xs font-semibold"
+          >
+            모두 삭제
+          </button>
+        )}
+      </div>
+
+      {renderBody()}
+
+      <DeleteConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="알림 전체 삭제"
+        description={"받은 알림을 모두 삭제할까요?\n삭제한 알림은 되돌릴 수 없어요."}
+        isPending={deleteAll.isPending}
+        onConfirm={handleDeleteAll}
+        confirmLabel="모두 삭제"
+      />
     </div>
   );
 }

--- a/src/components/notification/notification-item.tsx
+++ b/src/components/notification/notification-item.tsx
@@ -1,0 +1,41 @@
+"use client";
+// 알림 단건: 아바타 + 제목 + 본문 + 상대시간. 클릭 시 link_path로 이동.
+import Link from "next/link";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { AppNotification } from "@/types/notification/notification";
+import { formatRelativeTime } from "@/utils/common/format";
+import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar";
+
+interface Props {
+  notification: AppNotification;
+  onNavigate: () => void;
+}
+
+export default function NotificationItem({ notification, onNavigate }: Props) {
+  const nickname = notification.actorNickname ?? "크리에이터";
+
+  return (
+    <Link
+      href={notification.linkPath}
+      onClick={onNavigate}
+      className="hover:bg-muted/60 flex gap-3 rounded-xl px-3 py-2.5 transition-colors"
+    >
+      <Avatar className="size-9 shrink-0">
+        <AvatarImage src={getAvatarImageSrc(notification.actorPhotoUrl)} alt={nickname} />
+        <AvatarFallback className="text-xs font-black">
+          {getAvatarFallbackText(nickname, 1)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-bold">{notification.title}</p>
+        {notification.body && (
+          <p className="text-muted-foreground line-clamp-1 text-xs">{notification.body}</p>
+        )}
+        <p className="text-muted-foreground/70 mt-0.5 text-xs">
+          {formatRelativeTime(notification.createdAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/notification/notification-item.tsx
+++ b/src/components/notification/notification-item.tsx
@@ -1,6 +1,7 @@
 "use client";
-// 알림 단건: 아바타 + 제목 + 본문 + 상대시간. 클릭 시 link_path로 이동.
+// 알림 단건: 아바타 + 제목 + 본문 + 상대시간. 클릭 시 link_path로 이동, 우상단 X로 개별 삭제.
 import Link from "next/link";
+import { X } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { AppNotification } from "@/types/notification/notification";
@@ -10,32 +11,43 @@ import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar
 interface Props {
   notification: AppNotification;
   onNavigate: () => void;
+  onDelete: (id: string) => void;
 }
 
-export default function NotificationItem({ notification, onNavigate }: Props) {
+export default function NotificationItem({ notification, onNavigate, onDelete }: Props) {
   const nickname = notification.actorNickname ?? "크리에이터";
 
   return (
-    <Link
-      href={notification.linkPath}
-      onClick={onNavigate}
-      className="hover:bg-muted/60 flex gap-3 rounded-xl px-3 py-2.5 transition-colors"
-    >
-      <Avatar className="size-9 shrink-0">
-        <AvatarImage src={getAvatarImageSrc(notification.actorPhotoUrl)} alt={nickname} />
-        <AvatarFallback className="text-xs font-black">
-          {getAvatarFallbackText(nickname, 1)}
-        </AvatarFallback>
-      </Avatar>
-      <div className="min-w-0 flex-1">
-        <p className="text-foreground truncate text-sm font-bold">{notification.title}</p>
-        {notification.body && (
-          <p className="text-muted-foreground line-clamp-1 text-xs">{notification.body}</p>
-        )}
-        <p className="text-muted-foreground/70 mt-0.5 text-xs">
-          {formatRelativeTime(notification.createdAt)}
-        </p>
-      </div>
-    </Link>
+    <div className="group relative">
+      <Link
+        href={notification.linkPath}
+        onClick={onNavigate}
+        className="hover:bg-muted/60 flex gap-3 rounded-xl px-3 py-2.5 pr-10 transition-colors"
+      >
+        <Avatar className="size-9 shrink-0">
+          <AvatarImage src={getAvatarImageSrc(notification.actorPhotoUrl)} alt={nickname} />
+          <AvatarFallback className="text-xs font-black">
+            {getAvatarFallbackText(nickname, 1)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground truncate text-sm font-bold">{notification.title}</p>
+          {notification.body && (
+            <p className="text-muted-foreground line-clamp-1 text-xs">{notification.body}</p>
+          )}
+          <p className="text-muted-foreground/70 mt-0.5 text-xs">
+            {formatRelativeTime(notification.createdAt)}
+          </p>
+        </div>
+      </Link>
+      <button
+        type="button"
+        aria-label="알림 삭제"
+        onClick={() => onDelete(notification.id)}
+        className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-2 right-2 z-10 grid size-7 place-items-center rounded-md opacity-0 transition group-hover:opacity-100"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
   );
 }

--- a/src/components/notification/notification-item.tsx
+++ b/src/components/notification/notification-item.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { X } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
 import type { AppNotification } from "@/types/notification/notification";
 import { formatRelativeTime } from "@/utils/common/format";
 import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar";
@@ -22,7 +23,10 @@ export default function NotificationItem({ notification, onNavigate, onDelete }:
       <Link
         href={notification.linkPath}
         onClick={onNavigate}
-        className="hover:bg-muted/60 flex gap-3 rounded-xl px-3 py-2.5 pr-10 transition-colors"
+        className={cn(
+          "flex gap-3 rounded-xl px-3 py-2.5 pr-10",
+          "hover:bg-muted/60 transition-colors",
+        )}
       >
         <Avatar className="size-9 shrink-0">
           <AvatarImage src={getAvatarImageSrc(notification.actorPhotoUrl)} alt={nickname} />
@@ -44,7 +48,11 @@ export default function NotificationItem({ notification, onNavigate, onDelete }:
         type="button"
         aria-label="알림 삭제"
         onClick={() => onDelete(notification.id)}
-        className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-2 right-2 z-10 grid size-7 place-items-center rounded-md opacity-0 transition group-hover:opacity-100"
+        className={cn(
+          "absolute top-2 right-2 z-10 grid size-7 place-items-center rounded-md",
+          "text-muted-foreground hover:bg-muted hover:text-foreground",
+          "opacity-70 transition group-hover:opacity-100",
+        )}
       >
         <X className="size-4" />
       </button>

--- a/src/constants/common/app-message-code.ts
+++ b/src/constants/common/app-message-code.ts
@@ -55,6 +55,9 @@ export const APP_MESSAGE_CODE = {
       urlCopied: "success.live.urlCopied",
       voteUnchanged: "success.live.voteUnchanged",
     },
+    notification: {
+      allDeleted: "success.notification.allDeleted",
+    },
   },
   error: {
     common: {
@@ -182,6 +185,9 @@ export const APP_MESSAGE_CODE = {
       loadFailed: "error.community.loadFailed",
       postUpdateFailed: "error.community.postUpdateFailed",
       commentUpdateFailed: "error.community.commentUpdateFailed",
+    },
+    notification: {
+      deleteFailed: "error.notification.deleteFailed",
     },
     supabase: {
       permissionDenied: "error.supabase.permissionDenied",

--- a/src/constants/common/app-message-code.ts
+++ b/src/constants/common/app-message-code.ts
@@ -187,6 +187,7 @@ export const APP_MESSAGE_CODE = {
       commentUpdateFailed: "error.community.commentUpdateFailed",
     },
     notification: {
+      loadFailed: "error.notification.loadFailed",
       deleteFailed: "error.notification.deleteFailed",
     },
     supabase: {

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -140,6 +140,11 @@ export const APP_MESSAGE = {
         description: "다른 항목 번호를 입력하면 투표가 변경됩니다.",
       },
     },
+    notification: {
+      allDeleted: {
+        title: "알림 전체 삭제 완료",
+      },
+    },
   },
   error: {
     common: {
@@ -558,6 +563,12 @@ export const APP_MESSAGE = {
       },
       commentUpdateFailed: {
         title: "댓글 수정 실패",
+        description: "잠시 후 다시 시도해주세요.",
+      },
+    },
+    notification: {
+      deleteFailed: {
+        title: "알림 삭제 실패",
         description: "잠시 후 다시 시도해주세요.",
       },
     },

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -567,6 +567,10 @@ export const APP_MESSAGE = {
       },
     },
     notification: {
+      loadFailed: {
+        title: "알림 조회 실패",
+        description: "잠시 후 다시 시도해주세요.",
+      },
       deleteFailed: {
         title: "알림 삭제 실패",
         description: "잠시 후 다시 시도해주세요.",

--- a/src/constants/common/query-keys.ts
+++ b/src/constants/common/query-keys.ts
@@ -134,4 +134,16 @@ export const QUERY_KEYS = {
         (v) => v !== undefined,
       ),
   },
+  notification: {
+    all: ["notification"] as const,
+    listAll: () => [...QUERY_KEYS.notification.all, "list"],
+    list: (userId?: string) =>
+      [...QUERY_KEYS.notification.listAll(), userId ?? "public"].filter((v) => v !== undefined),
+    lastSeen: (userId?: string) =>
+      [...QUERY_KEYS.notification.all, "last-seen", userId ?? "public"].filter(
+        (v) => v !== undefined,
+      ),
+    unreadCount: (userId?: string) =>
+      [...QUERY_KEYS.notification.all, "unread", userId ?? "public"].filter((v) => v !== undefined),
+  },
 } as const;

--- a/src/constants/common/query-keys.ts
+++ b/src/constants/common/query-keys.ts
@@ -143,7 +143,9 @@ export const QUERY_KEYS = {
       [...QUERY_KEYS.notification.all, "last-seen", userId ?? "public"].filter(
         (v) => v !== undefined,
       ),
-    unreadCount: (userId?: string) =>
+    unreadCountAll: (userId?: string) =>
       [...QUERY_KEYS.notification.all, "unread", userId ?? "public"].filter((v) => v !== undefined),
+    unreadCount: (userId?: string, lastSeen?: string | null) =>
+      [...QUERY_KEYS.notification.unreadCountAll(userId), lastSeen].filter((v) => v !== undefined),
   },
 } as const;

--- a/src/hooks/notification/use-delete-notifications.ts
+++ b/src/hooks/notification/use-delete-notifications.ts
@@ -1,0 +1,62 @@
+"use client";
+// 알림 삭제 mutation(전체/개별). 성공 시 목록·안읽음 캐시를 무효화합니다.
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  deleteAllNotificationsAction,
+  deleteNotificationAction,
+} from "@/actions/notification/notification";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { useAuthStore } from "@/stores/auth";
+import type { AppActionResult } from "@/types/common/action";
+import { toastAppError, toastAppSuccess } from "@/utils/common/toast-message";
+
+// 전체 삭제: 확인 다이얼로그를 거치므로 성공 토스트로 결과를 알린다.
+export function useDeleteAllNotifications() {
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.user?.id);
+
+  return useMutation<AppActionResult, Error, void>({
+    mutationFn: () => deleteAllNotificationsAction(),
+    onSuccess: (result) => {
+      if (!result.success) {
+        toastAppError(result.code ?? APP_MESSAGE_CODE.error.notification.deleteFailed);
+        return;
+      }
+      toastAppSuccess(APP_MESSAGE_CODE.success.notification.allDeleted);
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.list(userId) });
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
+      });
+    },
+    onError: (error) => {
+      console.error("알림 전체 삭제 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.notification.deleteFailed);
+    },
+  });
+}
+
+// 개별 삭제: 항목이 즉시 사라지므로 성공 토스트는 생략하고 실패만 알린다.
+export function useDeleteNotification() {
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.user?.id);
+
+  return useMutation<AppActionResult, Error, string>({
+    mutationFn: (notificationId: string) => deleteNotificationAction(notificationId),
+    onSuccess: (result) => {
+      if (!result.success) {
+        toastAppError(result.code ?? APP_MESSAGE_CODE.error.notification.deleteFailed);
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.list(userId) });
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
+      });
+    },
+    onError: (error) => {
+      console.error("알림 삭제 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.notification.deleteFailed);
+    },
+  });
+}

--- a/src/hooks/notification/use-delete-notifications.ts
+++ b/src/hooks/notification/use-delete-notifications.ts
@@ -1,6 +1,6 @@
 "use client";
-// 알림 삭제 mutation(전체/개별). 성공 시 목록·안읽음 캐시를 무효화합니다.
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+// 알림 삭제 mutation(전체/개별). 전체 재요청 없이 목록 캐시를 직접 갱신하고 안읽음 수만 무효화합니다.
+import { type InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
   deleteAllNotificationsAction,
@@ -10,7 +10,10 @@ import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import { QUERY_KEYS } from "@/constants/common/query-keys";
 import { useAuthStore } from "@/stores/auth";
 import type { AppActionResult } from "@/types/common/action";
+import type { AppNotification } from "@/types/notification/notification";
 import { toastAppError, toastAppSuccess } from "@/utils/common/toast-message";
+
+type NotificationPages = InfiniteData<AppNotification[]>;
 
 // 전체 삭제: 확인 다이얼로그를 거치므로 성공 토스트로 결과를 알린다.
 export function useDeleteAllNotifications() {
@@ -25,7 +28,10 @@ export function useDeleteAllNotifications() {
         return;
       }
       toastAppSuccess(APP_MESSAGE_CODE.success.notification.allDeleted);
-      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.list(userId) });
+      // 결과가 빈 목록으로 확정적이므로 재요청 없이 캐시를 비운다.
+      queryClient.setQueryData<NotificationPages>(QUERY_KEYS.notification.list(userId), (data) =>
+        data ? { ...data, pages: [[]], pageParams: data.pageParams.slice(0, 1) } : data,
+      );
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
       });
@@ -37,19 +43,26 @@ export function useDeleteAllNotifications() {
   });
 }
 
-// 개별 삭제: 항목이 즉시 사라지므로 성공 토스트는 생략하고 실패만 알린다.
+// 개별 삭제: 성공 시 해당 한 건만 캐시에서 제거해 즉시 사라지게 한다(전체 재요청 없음).
 export function useDeleteNotification() {
   const queryClient = useQueryClient();
   const userId = useAuthStore((s) => s.user?.id);
 
   return useMutation<AppActionResult, Error, string>({
     mutationFn: (notificationId: string) => deleteNotificationAction(notificationId),
-    onSuccess: (result) => {
+    onSuccess: (result, notificationId) => {
       if (!result.success) {
         toastAppError(result.code ?? APP_MESSAGE_CODE.error.notification.deleteFailed);
         return;
       }
-      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.list(userId) });
+      queryClient.setQueryData<NotificationPages>(QUERY_KEYS.notification.list(userId), (data) =>
+        data
+          ? {
+              ...data,
+              pages: data.pages.map((page) => page.filter((item) => item.id !== notificationId)),
+            }
+          : data,
+      );
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
       });

--- a/src/hooks/notification/use-mark-notifications-seen.ts
+++ b/src/hooks/notification/use-mark-notifications-seen.ts
@@ -15,7 +15,9 @@ export function useMarkNotificationsSeen() {
     onSuccess: (result) => {
       if (!result.success) return;
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.lastSeen(userId) });
-      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.unreadCount(userId) });
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
+      });
     },
   });
 }

--- a/src/hooks/notification/use-mark-notifications-seen.ts
+++ b/src/hooks/notification/use-mark-notifications-seen.ts
@@ -1,0 +1,21 @@
+"use client";
+// 수신함을 열 때 호출 → last_seen 갱신 → 배지 안읽음 수를 0으로 만듭니다.
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { markNotificationsSeenAction } from "@/actions/notification/notification";
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { useAuthStore } from "@/stores/auth";
+
+export function useMarkNotificationsSeen() {
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.user?.id);
+
+  return useMutation({
+    mutationFn: () => markNotificationsSeenAction(),
+    onSuccess: (result) => {
+      if (!result.success) return;
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.lastSeen(userId) });
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.unreadCount(userId) });
+    },
+  });
+}

--- a/src/hooks/notification/use-notification-badge.ts
+++ b/src/hooks/notification/use-notification-badge.ts
@@ -1,0 +1,71 @@
+"use client";
+// 종 배지용: 마지막 확인 시각(last_seen) 이후 안읽음 수 + notification INSERT 실시간 반영.
+import { useEffect, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { createClient } from "@/lib/supabase/client";
+import { useAuthStore } from "@/stores/auth";
+
+export function useNotificationBadge() {
+  const supabase = useMemo(() => createClient(), []);
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.user?.id);
+
+  const lastSeenQuery = useQuery({
+    queryKey: QUERY_KEYS.notification.lastSeen(userId),
+    enabled: !!userId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("user")
+        .select("notifications_last_seen_at")
+        .eq("id", userId!)
+        .single();
+      if (error) throw error;
+      return data.notifications_last_seen_at;
+    },
+  });
+
+  const lastSeen = lastSeenQuery.data ?? null;
+
+  const unreadQuery = useQuery({
+    // lastSeen을 키에 포함해야 읽음 처리(last_seen 갱신) 후 카운트가 재조회되어 배지가 0으로 떨어진다.
+    queryKey: [...QUERY_KEYS.notification.unreadCount(userId), lastSeen],
+    enabled: !!userId && lastSeenQuery.isFetched,
+    queryFn: async () => {
+      let q = supabase.from("notification").select("id", { count: "exact", head: true });
+      if (lastSeen) q = q.gt("created_at", lastSeen);
+      const { count, error } = await q;
+      if (error) throw error;
+      return count ?? 0;
+    },
+  });
+
+  useEffect(() => {
+    if (!userId) return;
+    const channel = supabase
+      .channel(`notification-${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "notification",
+          filter: `recipient_id=eq.${userId}`,
+        },
+        () => {
+          void queryClient.invalidateQueries({
+            queryKey: QUERY_KEYS.notification.unreadCount(userId),
+          });
+          void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.listAll() });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void channel.unsubscribe();
+    };
+  }, [userId, supabase, queryClient]);
+
+  return { unreadCount: unreadQuery.data ?? 0, isLoggedIn: !!userId };
+}

--- a/src/hooks/notification/use-notification-badge.ts
+++ b/src/hooks/notification/use-notification-badge.ts
@@ -15,6 +15,7 @@ export function useNotificationBadge() {
   const lastSeenQuery = useQuery({
     queryKey: QUERY_KEYS.notification.lastSeen(userId),
     enabled: !!userId,
+    staleTime: 1000 * 30,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("user")
@@ -30,10 +31,15 @@ export function useNotificationBadge() {
 
   const unreadQuery = useQuery({
     // lastSeen을 키에 포함해야 읽음 처리(last_seen 갱신) 후 카운트가 재조회되어 배지가 0으로 떨어진다.
-    queryKey: [...QUERY_KEYS.notification.unreadCount(userId), lastSeen],
+    queryKey: QUERY_KEYS.notification.unreadCount(userId, lastSeen),
     enabled: !!userId && lastSeenQuery.isFetched,
+    staleTime: 1000 * 30,
     queryFn: async () => {
-      let q = supabase.from("notification").select("id", { count: "exact", head: true });
+      // RLS로도 본인 수신분만 보이지만, 명시적 recipient 필터로 인덱스 활용 + 정책 변경에 대한 방어.
+      let q = supabase
+        .from("notification")
+        .select("id", { count: "exact", head: true })
+        .eq("recipient_id", userId!);
       if (lastSeen) q = q.gt("created_at", lastSeen);
       const { count, error } = await q;
       if (error) throw error;
@@ -55,9 +61,9 @@ export function useNotificationBadge() {
         },
         () => {
           void queryClient.invalidateQueries({
-            queryKey: QUERY_KEYS.notification.unreadCount(userId),
+            queryKey: QUERY_KEYS.notification.unreadCountAll(userId),
           });
-          void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.listAll() });
+          void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notification.list(userId) });
         },
       )
       .subscribe();

--- a/src/hooks/notification/use-notifications.ts
+++ b/src/hooks/notification/use-notifications.ts
@@ -24,7 +24,8 @@ export function useNotifications(enabled: boolean) {
       const to = from + NOTIFICATION_PAGE_SIZE - 1;
       const { data, error } = await supabase
         .from("notification")
-        .select("*")
+        // 파서가 쓰는 컬럼만 명시적으로 선택(과조회 방지 + DB 계약 고정).
+        .select("id, type, actor_id, actor_nickname, actor_photo_url, title, body, link_path, created_at")
         // RLS로도 본인 수신분만 보이지만, 명시적 recipient 필터로 인덱스 활용 + 정책 변경 방어.
         .eq("recipient_id", userId!)
         // 같은 created_at(동시 이벤트) 페이지 경계에서 중복/누락이 없도록 id로 안정 정렬한다.

--- a/src/hooks/notification/use-notifications.ts
+++ b/src/hooks/notification/use-notifications.ts
@@ -17,6 +17,7 @@ export function useNotifications(enabled: boolean) {
   return useInfiniteQuery({
     queryKey: QUERY_KEYS.notification.list(userId),
     enabled: enabled && !!userId,
+    staleTime: 1000 * 30,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const from = pageParam * NOTIFICATION_PAGE_SIZE;
@@ -24,7 +25,11 @@ export function useNotifications(enabled: boolean) {
       const { data, error } = await supabase
         .from("notification")
         .select("*")
+        // RLS로도 본인 수신분만 보이지만, 명시적 recipient 필터로 인덱스 활용 + 정책 변경 방어.
+        .eq("recipient_id", userId!)
+        // 같은 created_at(동시 이벤트) 페이지 경계에서 중복/누락이 없도록 id로 안정 정렬한다.
         .order("created_at", { ascending: false })
+        .order("id", { ascending: false })
         .range(from, to);
       if (error) throw error;
       return (data ?? []).map(parseNotification);

--- a/src/hooks/notification/use-notifications.ts
+++ b/src/hooks/notification/use-notifications.ts
@@ -1,0 +1,35 @@
+"use client";
+// 알림 수신함 목록을 created_at 내림차순 무한 스크롤로 조회합니다(RLS로 본인 수신분만).
+import { useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { createClient } from "@/lib/supabase/client";
+import { useAuthStore } from "@/stores/auth";
+import { parseNotification } from "@/utils/notification/notification-parser";
+
+const NOTIFICATION_PAGE_SIZE = 15;
+
+export function useNotifications(enabled: boolean) {
+  const supabase = useMemo(() => createClient(), []);
+  const userId = useAuthStore((s) => s.user?.id);
+
+  return useInfiniteQuery({
+    queryKey: QUERY_KEYS.notification.list(userId),
+    enabled: enabled && !!userId,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const from = pageParam * NOTIFICATION_PAGE_SIZE;
+      const to = from + NOTIFICATION_PAGE_SIZE - 1;
+      const { data, error } = await supabase
+        .from("notification")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .range(from, to);
+      if (error) throw error;
+      return (data ?? []).map(parseNotification);
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === NOTIFICATION_PAGE_SIZE ? allPages.length : undefined,
+  });
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1067,6 +1067,10 @@ export type Database = {
         }
         Returns: string
       }
+      delete_all_notifications: {
+        Args: { p_actor_user_id: string }
+        Returns: undefined
+      }
       delete_channel_banner: {
         Args: { p_actor_user_id: string; p_banner_id: string }
         Returns: Json
@@ -1078,6 +1082,10 @@ export type Database = {
       delete_community_post: {
         Args: { p_actor_user_id: string; p_post_id: string }
         Returns: string
+      }
+      delete_notification: {
+        Args: { p_actor_user_id: string; p_notification_id: string }
+        Returns: undefined
       }
       emit_follower_notification: {
         Args: {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -776,6 +776,63 @@ export type Database = {
           },
         ]
       }
+      notification: {
+        Row: {
+          actor_id: string
+          actor_nickname: string | null
+          actor_photo_url: string | null
+          body: string | null
+          created_at: string
+          id: string
+          link_path: string
+          recipient_id: string
+          resource_id: string | null
+          title: string
+          type: string
+        }
+        Insert: {
+          actor_id: string
+          actor_nickname?: string | null
+          actor_photo_url?: string | null
+          body?: string | null
+          created_at?: string
+          id?: string
+          link_path: string
+          recipient_id: string
+          resource_id?: string | null
+          title: string
+          type: string
+        }
+        Update: {
+          actor_id?: string
+          actor_nickname?: string | null
+          actor_photo_url?: string | null
+          body?: string | null
+          created_at?: string
+          id?: string
+          link_path?: string
+          recipient_id?: string
+          resource_id?: string | null
+          title?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notification_actor_id_fkey"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notification_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       user: {
         Row: {
           birth: string
@@ -787,6 +844,7 @@ export type Database = {
           modified_at: string
           name: string
           nickname: string
+          notifications_last_seen_at: string | null
           phone: string
           photo_url: string | null
         }
@@ -800,6 +858,7 @@ export type Database = {
           modified_at?: string
           name: string
           nickname: string
+          notifications_last_seen_at?: string | null
           phone: string
           photo_url?: string | null
         }
@@ -813,6 +872,7 @@ export type Database = {
           modified_at?: string
           name?: string
           nickname?: string
+          notifications_last_seen_at?: string | null
           phone?: string
           photo_url?: string | null
         }
@@ -1019,6 +1079,17 @@ export type Database = {
         Args: { p_actor_user_id: string; p_post_id: string }
         Returns: string
       }
+      emit_follower_notification: {
+        Args: {
+          p_actor_id: string
+          p_body: string
+          p_link_path: string
+          p_resource_id: string
+          p_title: string
+          p_type: string
+        }
+        Returns: undefined
+      }
       end_live_broadcast: {
         Args: { p_actor_user_id: string; p_broadcast_id?: string }
         Returns: string
@@ -1210,6 +1281,10 @@ export type Database = {
       leave_live_viewer_presence: {
         Args: { p_broadcast_id: string; p_viewer_key: string }
         Returns: number
+      }
+      mark_notifications_seen: {
+        Args: { p_actor_user_id: string }
+        Returns: undefined
       }
       mark_room_read: {
         Args: { p_actor_user_id: string; p_room_id: string }

--- a/src/types/notification/notification.ts
+++ b/src/types/notification/notification.ts
@@ -1,0 +1,15 @@
+// 인앱 알림(수신함) 화면용 타입을 정의합니다.
+
+export type NotificationType = "live_start" | "community_post";
+
+export interface AppNotification {
+  id: string;
+  type: NotificationType;
+  actorId: string;
+  actorNickname: string | null;
+  actorPhotoUrl: string | null;
+  title: string;
+  body: string | null;
+  linkPath: string;
+  createdAt: string;
+}

--- a/src/utils/common/format.ts
+++ b/src/utils/common/format.ts
@@ -46,22 +46,32 @@ export function formatRelativeTime(iso: string): string {
   return formatDate(iso);
 }
 
-// 알림 수신함 그룹 라벨(오늘/최근 일주일/이전). '오늘'은 rolling 24h가 아니라 달력 날짜 기준으로 판정한다.
-const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+// 알림 수신함 그룹 라벨(오늘/어제/최근 일주일/이전).
+// rolling(시간 누적)이 아니라 자정(00시) 기준 달력 일수 차이로 판정한다.
+const GROUP_DAY_MS = 24 * 60 * 60 * 1000;
 
 export function formatNotificationGroupLabel(iso: string): string {
-  const target = new Date(iso).getTime();
-  if (Number.isNaN(target)) {
+  const target = new Date(iso);
+  if (Number.isNaN(target.getTime())) {
     return "이전";
   }
 
   const now = new Date();
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfTargetDay = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  ).getTime();
+  const daysAgo = Math.round((startOfToday - startOfTargetDay) / GROUP_DAY_MS);
 
-  if (target >= startOfToday) {
+  if (daysAgo <= 0) {
     return "오늘";
   }
-  if (Date.now() - target < WEEK_MS) {
+  if (daysAgo === 1) {
+    return "어제";
+  }
+  if (daysAgo < 7) {
     return "최근 일주일";
   }
   return "이전";

--- a/src/utils/common/format.ts
+++ b/src/utils/common/format.ts
@@ -46,7 +46,7 @@ export function formatRelativeTime(iso: string): string {
   return formatDate(iso);
 }
 
-// 알림 수신함 그룹 라벨(오늘/어제/최근 일주일/이전).
+// 알림 수신함 그룹 라벨(오늘/최근 일주일/이전).
 // rolling(시간 누적)이 아니라 자정(00시) 기준 달력 일수 차이로 판정한다.
 const GROUP_DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -67,9 +67,6 @@ export function formatNotificationGroupLabel(iso: string): string {
 
   if (daysAgo <= 0) {
     return "오늘";
-  }
-  if (daysAgo === 1) {
-    return "어제";
   }
   if (daysAgo < 7) {
     return "최근 일주일";

--- a/src/utils/common/format.ts
+++ b/src/utils/common/format.ts
@@ -46,6 +46,27 @@ export function formatRelativeTime(iso: string): string {
   return formatDate(iso);
 }
 
+// 알림 수신함 그룹 라벨(오늘/최근 일주일/이전). '오늘'은 rolling 24h가 아니라 달력 날짜 기준으로 판정한다.
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function formatNotificationGroupLabel(iso: string): string {
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) {
+    return "이전";
+  }
+
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+
+  if (target >= startOfToday) {
+    return "오늘";
+  }
+  if (Date.now() - target < WEEK_MS) {
+    return "최근 일주일";
+  }
+  return "이전";
+}
+
 export const formatPhone = (value: string) => {
   const digits = value.replace(/\D/g, "").slice(0, 11);
   if (digits.length <= 3) return digits;

--- a/src/utils/notification/notification-parser.ts
+++ b/src/utils/notification/notification-parser.ts
@@ -1,4 +1,6 @@
 // notification 테이블 Row를 화면 타입(AppNotification)으로 변환합니다.
+// actorNickname/actorPhotoUrl은 발행 시점에 스냅샷된 값(이벤트 로그 의도)이라,
+// 크리에이터가 이후 닉네임/사진을 바꿔도 과거 알림에는 반영되지 않는다.
 import type { Database } from "@/types/database.types";
 import type { AppNotification, NotificationType } from "@/types/notification/notification";
 

--- a/src/utils/notification/notification-parser.ts
+++ b/src/utils/notification/notification-parser.ts
@@ -4,7 +4,19 @@
 import type { Database } from "@/types/database.types";
 import type { AppNotification, NotificationType } from "@/types/notification/notification";
 
-type NotificationRow = Database["public"]["Tables"]["notification"]["Row"];
+// 목록 조회에서 선택하는 컬럼만 받는다(use-notifications의 select와 일치).
+type NotificationRow = Pick<
+  Database["public"]["Tables"]["notification"]["Row"],
+  | "id"
+  | "type"
+  | "actor_id"
+  | "actor_nickname"
+  | "actor_photo_url"
+  | "title"
+  | "body"
+  | "link_path"
+  | "created_at"
+>;
 
 export function parseNotification(row: NotificationRow): AppNotification {
   return {

--- a/src/utils/notification/notification-parser.ts
+++ b/src/utils/notification/notification-parser.ts
@@ -1,0 +1,19 @@
+// notification 테이블 Row를 화면 타입(AppNotification)으로 변환합니다.
+import type { Database } from "@/types/database.types";
+import type { AppNotification, NotificationType } from "@/types/notification/notification";
+
+type NotificationRow = Database["public"]["Tables"]["notification"]["Row"];
+
+export function parseNotification(row: NotificationRow): AppNotification {
+  return {
+    id: row.id,
+    type: row.type as NotificationType,
+    actorId: row.actor_id,
+    actorNickname: row.actor_nickname,
+    actorPhotoUrl: row.actor_photo_url,
+    title: row.title,
+    body: row.body,
+    linkPath: row.link_path,
+    createdAt: row.created_at,
+  };
+}

--- a/supabase/migrations/20260608023414_create_notification_table.sql
+++ b/supabase/migrations/20260608023414_create_notification_table.sql
@@ -1,0 +1,42 @@
+-- 인앱 알림 수신함: notification 테이블 + 읽음 기준(last_seen) + RLS + realtime
+
+create table if not exists public.notification (
+  id uuid primary key default gen_random_uuid(),
+  recipient_id uuid not null references public."user"(id) on delete cascade,
+  type text not null check (type in ('live_start', 'community_post')),
+  actor_id uuid not null references public."user"(id) on delete cascade,
+  actor_nickname text,
+  actor_photo_url text,
+  title text not null,
+  body text,
+  link_path text not null,
+  resource_id uuid,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists notification_recipient_created_idx
+  on public.notification (recipient_id, created_at desc);
+
+alter table public.notification enable row level security;
+
+drop policy if exists notification_select_own on public.notification;
+create policy notification_select_own
+  on public.notification for select to authenticated
+  using (recipient_id = (select auth.uid()));
+
+grant select on table public.notification to authenticated;
+
+-- 읽음 = 방문 기준(유저당 마지막 확인 시각)
+alter table public."user"
+  add column if not exists notifications_last_seen_at timestamptz;
+
+-- 실시간: 수신자 본인 INSERT를 종 배지에 즉시 반영 (중복 add 방지)
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'notification'
+  ) then
+    alter publication supabase_realtime add table public.notification;
+  end if;
+end $$;

--- a/supabase/migrations/20260608023433_add_notification_fanout.sql
+++ b/supabase/migrations/20260608023433_add_notification_fanout.sql
@@ -1,0 +1,86 @@
+-- 알림 fan-out 공용 함수 + 트리거(best-effort) + 읽음 처리 RPC
+
+create or replace function public.emit_follower_notification(
+  p_actor_id uuid, p_type text, p_resource_id uuid,
+  p_title text, p_body text, p_link_path text
+) returns void
+language plpgsql security definer set search_path to '' as $function$
+declare
+  v_nickname text;
+  v_photo text;
+begin
+  select u.nickname, u.photo_url into v_nickname, v_photo
+  from public."user" as u where u.id = p_actor_id;
+
+  insert into public.notification
+    (recipient_id, type, actor_id, actor_nickname, actor_photo_url, title, body, link_path, resource_id)
+  select vcr.viewer_id, p_type, p_actor_id, v_nickname, v_photo, p_title, p_body, p_link_path, p_resource_id
+  from public.viewer_creator_relation as vcr
+  where vcr.creator_id = p_actor_id
+    and vcr.followed_at is not null
+    and vcr.viewer_id <> p_actor_id;
+end;
+$function$;
+
+-- 라이브 시작 트리거 (예외 무시 = 방송 생성 무영향)
+create or replace function public.notify_followers_on_live_start()
+returns trigger language plpgsql security definer set search_path to '' as $function$
+declare v_nickname text;
+begin
+  begin
+    select u.nickname into v_nickname from public."user" as u where u.id = new.creator_id;
+    perform public.emit_follower_notification(
+      new.creator_id, 'live_start', new.id,
+      coalesce(v_nickname, '크리에이터') || '님이 라이브를 시작했어요',
+      new.title,
+      '/live/' || new.creator_id::text
+    );
+  exception when others then
+    null; -- 알림 실패가 부모 INSERT를 롤백하지 않도록 무시
+  end;
+  return new;
+end;
+$function$;
+
+drop trigger if exists notify_followers_on_live_start on public.live_broadcast;
+create trigger notify_followers_on_live_start
+  after insert on public.live_broadcast
+  for each row execute function public.notify_followers_on_live_start();
+
+-- 커뮤니티 글 트리거 (예외 무시)
+create or replace function public.notify_followers_on_community_post()
+returns trigger language plpgsql security definer set search_path to '' as $function$
+declare v_nickname text;
+begin
+  begin
+    select u.nickname into v_nickname from public."user" as u where u.id = new.creator_id;
+    perform public.emit_follower_notification(
+      new.creator_id, 'community_post', new.id,
+      coalesce(v_nickname, '크리에이터') || '님이 새 글을 올렸어요',
+      left(new.content, 60),
+      '/channel/' || new.creator_id::text || '/community/' || new.id::text
+    );
+  exception when others then
+    null;
+  end;
+  return new;
+end;
+$function$;
+
+drop trigger if exists notify_followers_on_community_post on public.community_post;
+create trigger notify_followers_on_community_post
+  after insert on public.community_post
+  for each row execute function public.notify_followers_on_community_post();
+
+-- 읽음(방문 기준) 처리 RPC
+create or replace function public.mark_notifications_seen(p_actor_user_id uuid)
+returns void language plpgsql security definer set search_path to '' as $function$
+begin
+  update public."user" set notifications_last_seen_at = now() where id = p_actor_user_id;
+end;
+$function$;
+
+-- 권한 잠금: 트리거는 owner 권한으로 emit 호출, mark_seen은 service_role(서버 액션)만
+revoke all on function public.emit_follower_notification(uuid, text, uuid, text, text, text) from public, anon, authenticated;
+revoke all on function public.mark_notifications_seen(uuid) from public, anon, authenticated;
+grant execute on function public.mark_notifications_seen(uuid) to service_role;

--- a/supabase/migrations/20260608030440_add_notification_fanout_logging.sql
+++ b/supabase/migrations/20260608030440_add_notification_fanout_logging.sql
@@ -1,0 +1,40 @@
+-- 알림 fan-out 트리거: best-effort는 유지하되 실패를 RAISE WARNING으로 관측 가능하게 한다.
+-- (RAISE WARNING은 부모 트랜잭션을 롤백하지 않으므로 방송/글 INSERT에는 영향 없음)
+
+create or replace function public.notify_followers_on_live_start()
+returns trigger language plpgsql security definer set search_path to '' as $function$
+declare v_nickname text;
+begin
+  begin
+    select u.nickname into v_nickname from public."user" as u where u.id = new.creator_id;
+    perform public.emit_follower_notification(
+      new.creator_id, 'live_start', new.id,
+      coalesce(v_nickname, '크리에이터') || '님이 라이브를 시작했어요',
+      new.title,
+      '/live/' || new.creator_id::text
+    );
+  exception when others then
+    raise warning 'notify_followers_on_live_start 실패 (broadcast=%): %', new.id, sqlerrm;
+  end;
+  return new;
+end;
+$function$;
+
+create or replace function public.notify_followers_on_community_post()
+returns trigger language plpgsql security definer set search_path to '' as $function$
+declare v_nickname text;
+begin
+  begin
+    select u.nickname into v_nickname from public."user" as u where u.id = new.creator_id;
+    perform public.emit_follower_notification(
+      new.creator_id, 'community_post', new.id,
+      coalesce(v_nickname, '크리에이터') || '님이 새 글을 올렸어요',
+      left(new.content, 60),
+      '/channel/' || new.creator_id::text || '/community/' || new.id::text
+    );
+  exception when others then
+    raise warning 'notify_followers_on_community_post 실패 (post=%): %', new.id, sqlerrm;
+  end;
+  return new;
+end;
+$function$;

--- a/supabase/migrations/20260608033027_add_notification_delete_rpcs.sql
+++ b/supabase/migrations/20260608033027_add_notification_delete_rpcs.sql
@@ -1,0 +1,21 @@
+-- 알림 삭제 RPC: 서버 액션(admin client) 경유, 본인 알림만 삭제 가능
+
+create or replace function public.delete_all_notifications(p_actor_user_id uuid)
+returns void language plpgsql security definer set search_path to '' as $function$
+begin
+  delete from public.notification where recipient_id = p_actor_user_id;
+end;
+$function$;
+
+create or replace function public.delete_notification(p_actor_user_id uuid, p_notification_id uuid)
+returns void language plpgsql security definer set search_path to '' as $function$
+begin
+  delete from public.notification
+  where id = p_notification_id and recipient_id = p_actor_user_id;
+end;
+$function$;
+
+revoke all on function public.delete_all_notifications(uuid) from public, anon, authenticated;
+revoke all on function public.delete_notification(uuid, uuid) from public, anon, authenticated;
+grant execute on function public.delete_all_notifications(uuid) to service_role;
+grant execute on function public.delete_notification(uuid, uuid) to service_role;


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/notification/#99 -> dev

### ✅ 작업 내용 `기능 추가`

- 팔로우한 크리에이터가 ① 라이브를 시작하거나 ② 커뮤니티 글을 작성하면 팔로워에게 인앱 알림을 보내는 **수신함** 기능을 추가했습니다. (웹 푸시가 아닌 치지직식 인앱 알림)
- 헤더 **종 아이콘 + 안읽음 빨간 점**(Realtime 실시간 반영) + 드롭다운 수신함(오늘/최근 일주일/이전 그룹, 클릭 시 해당 글·라이브로 이동, 더보기). 수신함을 열면 **방문 기준**으로 읽음 처리되어 배지가 사라집니다.
- 헤더 우측을 치지직식 **3섹션(검색·방송하기 / 알림·테마 / 계정)** 으로 Vertical Separator 구분하고, 종·테마 버튼 스타일을 통일했습니다.
- **DB / RLS / Realtime / Trigger**: `notification` 테이블(RLS select 본인만, realtime publication) + `user.notifications_last_seen_at` 컬럼 추가. `live_broadcast`/`community_post` AFTER INSERT 트리거가 공용 `emit_follower_notification`(단일 bulk insert, 본인 제외)로 팔로워에게 fan-out하며, **best-effort(예외는 RAISE WARNING으로 로깅)** 라 방송·글 INSERT에는 영향이 없습니다. 읽음 처리 `mark_notifications_seen` RPC(서버 액션, service_role 전용). 모든 함수 `security definer` + `search_path=''`.
- 코드리뷰(.agents 컨벤션 기준) 반영: query-key factory 계층화, 알림 쿼리 `staleTime`, 그룹 라벨 공용 util화(오늘=달력 기준), 목록·안읽음 쿼리에 명시적 recipient 필터 + `(created_at, id)` 안정 정렬, 임의 Tailwind 값 제거, 트리거 실패 RAISE WARNING.

### 🎯 단독 테스트 결과

- `npm run db:types` 정상 완료(notification 테이블·읽음 컬럼·`mark_notifications_seen` RPC 반영).
- `npm run typecheck` / `npm run lint` / `npm run build` 정상 완료.
- DB 검증(execute_sql): 커뮤니티 글·라이브 시작 INSERT 시 팔로워에게 fan-out(본인 제외), 비정규화 actor 필드(닉네임·사진) 정상, `emit_follower_notification`·`mark_notifications_seen` ACL이 authenticated/anon 차단·service_role 전용임을 확인했습니다.
- 실제 계정(테스트유저)으로 커뮤니티·라이브 알림을 발생시켜 종 빨간 점·수신함 목록·읽음 처리·Realtime 반영을 브라우저에서 확인했습니다.
- 미확인: 라이브 시작 트리거는 `live_broadcast` 행 INSERT마다 발화하므로(방송 재시작 = 중복 알림, 실제 OBS 송출과는 무관) `live_broadcast` 도메인 담당자와 머지 전 동작 합의가 필요합니다.

### 🚨 연관 이슈

closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 시스템 전체 도입: 헤더에 알림 벨 추가 및 로그인 시 배지 표시
  * 팝오버 알림 센터(수신함) 추가: 그룹화된 목록, 페이지네이션, 항목별 이동 및 개별 삭제 지원
  * 알림 센터 열기 시 자동으로 읽음 처리 및 실시간 배지 갱신
  * 전체 삭제 기능(확인 모달 포함) 및 성공/실패 메시지 코드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->