### PR TITLE
refactor(#97): 시청자 수 집계 핫패스 최적화 

### DIFF
--- a/supabase/migrations/20260610150534_optimize_live_viewer_presence_hotpath.sql
+++ b/supabase/migrations/20260610150534_optimize_live_viewer_presence_hotpath.sql
@@ -1,0 +1,196 @@
+-- 라이브 시청자 수 집계 핫패스 최적화 (#97 B).
+-- 기존: 하트비트마다(시청자당 10초 주기) stale DELETE + 전체 count(*) + live_broadcast UPDATE를
+-- 전부 수행해 동시시청 N명이면 초당 N/10 RPC × O(N) 스캔(O(N²) 성격) + 같은 행 UPDATE 경합이 생겼다.
+-- 변경: 이벤트-게이트 재집계 — 단순 하트비트 갱신(대다수)은 upsert만 O(1)로 끝내고,
+-- 멤버십이 실제로 바뀌는 순간(신규 진입·만료 복귀·실제 삭제된 이탈)에만 재집계한다.
+-- 재집계는 매번 신선 윈도 전체 count(*)라 증분 카운터와 달리 drift가 구조적으로 불가능(자가 보정).
+-- stale 행 물리 삭제는 sweep_live_viewer_counts(pg_cron 30초, 보정 전담)로 일원화한다.
+-- 시그니처·반환 타입은 전부 유지되므로 클라이언트(서버 액션·훅·beacon 라우트)는 무변경이다.
+
+-- 신선 하트비트 판정 윈도의 단일 소스. recompute/sync/sweep이 공유한다(변경 시 이 한 곳만).
+create or replace function public.live_viewer_presence_window()
+returns interval
+language sql
+immutable
+set search_path to ''
+as $function$
+  select interval '20 seconds'
+$function$;
+
+revoke execute on function public.live_viewer_presence_window() from public;
+revoke execute on function public.live_viewer_presence_window() from anon;
+revoke execute on function public.live_viewer_presence_window() from authenticated;
+grant execute on function public.live_viewer_presence_window() to service_role;
+
+-- 신선한 시청자 수 재계산 + current_viewer_count 반영(공용).
+-- 핫패스에서 DELETE를 제거 — stale 행은 카운트에서 윈도 필터로 제외하고 물리 삭제는 sweep 전담.
+-- 인덱스 (broadcast_id, last_seen_at)이 윈도 필터 카운트를 그대로 커버한다.
+create or replace function public.recompute_live_viewer_count(p_broadcast_id uuid)
+returns integer
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_count integer;
+begin
+  select count(*)::integer
+  into v_count
+  from public.live_viewer_heartbeat as hb
+  where hb.broadcast_id = p_broadcast_id
+    and hb.last_seen_at >= now() - public.live_viewer_presence_window();
+
+  update public.live_broadcast as broadcast
+  set current_viewer_count = v_count
+  where broadcast.id = p_broadcast_id
+    and broadcast.current_viewer_count is distinct from v_count;
+
+  return v_count;
+end;
+$function$;
+
+-- 하트비트 upsert. 재집계는 멤버십이 바뀌는 진입 이벤트(신규/만료 복귀)에만 수행한다.
+-- now()는 트랜잭션 내 고정이므로 게이트 판정과 recompute의 윈도 기준이 항상 일치한다.
+-- 동시 첫 진입 2건이 둘 다 게이트를 통과해도 recompute는 전체 카운트라 멱등(드리프트 없음).
+create or replace function public.sync_live_viewer_presence(
+  p_broadcast_id uuid,
+  p_viewer_key text
+)
+returns integer
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_key text := btrim(coalesce(p_viewer_key, ''));
+  v_current integer;
+  v_prev timestamp with time zone;
+begin
+  if p_broadcast_id is null then
+    raise sqlstate 'PX400' using message = 'invalid broadcast';
+  end if;
+
+  if v_key = '' then
+    raise sqlstate 'PX400' using message = 'invalid viewer key';
+  end if;
+
+  select broadcast.current_viewer_count
+  into v_current
+  from public.live_broadcast as broadcast
+  where broadcast.id = p_broadcast_id
+    and broadcast.ended_at is null;
+
+  if not found then
+    raise sqlstate 'PX404' using message = 'active live broadcast not found';
+  end if;
+
+  select hb.last_seen_at
+  into v_prev
+  from public.live_viewer_heartbeat as hb
+  where hb.broadcast_id = p_broadcast_id
+    and hb.viewer_key = v_key;
+
+  insert into public.live_viewer_heartbeat as hb (broadcast_id, viewer_key, last_seen_at)
+  values (p_broadcast_id, v_key, now())
+  on conflict (broadcast_id, viewer_key) do update
+    set last_seen_at = now();
+
+  -- 이 게이트는 성능 최적화일 뿐 정확성 책임이 없다 — 게이트가 놓친 변화(예: 타임아웃 감소)는
+  -- sweep_live_viewer_counts가 보정한다. 게이트 조건을 바꿔도 sweep의 전 방송 재계산은 유지할 것.
+  if v_prev is null or v_prev < now() - public.live_viewer_presence_window() then
+    return public.recompute_live_viewer_count(p_broadcast_id);
+  end if;
+
+  -- 단순 갱신(대다수 경로): 카운트 불변이므로 재집계·UPDATE 없이 현재 값만 반환.
+  return v_current;
+end;
+$function$;
+
+-- 시청 화면 이탈. 하트비트가 실제로 삭제됐을 때만 재집계한다 —
+-- beacon(pagehide)과 React cleanup이 중복 발화해도 두 번째 호출은 no-op.
+create or replace function public.leave_live_viewer_presence(
+  p_broadcast_id uuid,
+  p_viewer_key text
+)
+returns integer
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_key text := btrim(coalesce(p_viewer_key, ''));
+  v_deleted integer;
+begin
+  if p_broadcast_id is null or v_key = '' then
+    return 0;
+  end if;
+
+  delete from public.live_viewer_heartbeat as hb
+  where hb.broadcast_id = p_broadcast_id
+    and hb.viewer_key = v_key;
+
+  get diagnostics v_deleted = row_count;
+
+  if v_deleted > 0 then
+    return public.recompute_live_viewer_count(p_broadcast_id);
+  end if;
+
+  return coalesce(
+    (
+      select broadcast.current_viewer_count
+      from public.live_broadcast as broadcast
+      where broadcast.id = p_broadcast_id
+    ),
+    0
+  );
+end;
+$function$;
+
+-- sweep은 기존 역할 그대로(전역 stale 물리 삭제 + 활성 방송 보정) — 윈도만 단일 소스로 교체.
+-- 핫패스에서 DELETE가 빠지면서 stale 행 정리는 이 함수가 유일한 소유자가 된다.
+create or replace function public.sweep_live_viewer_counts()
+returns void
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  -- 1) 전역 stale 하트비트 정리.
+  delete from public.live_viewer_heartbeat as hb
+  where hb.last_seen_at < now() - public.live_viewer_presence_window();
+
+  -- 2) 활성 방송 카운트를 신선한 하트비트 수로 재계산(하트비트 없으면 0). 값이 바뀔 때만 UPDATE.
+  update public.live_broadcast as b
+  set current_viewer_count = c.cnt
+  from (
+    select b2.id, count(hb.broadcast_id)::int as cnt
+    from public.live_broadcast as b2
+    left join public.live_viewer_heartbeat as hb on hb.broadcast_id = b2.id
+    where b2.ended_at is null
+    group by b2.id
+  ) as c
+  where b.id = c.id
+    and b.current_viewer_count is distinct from c.cnt;
+end;
+$function$;
+
+-- create or replace는 기존 ACL을 보존하지만, 미러 명시성을 위해 service_role 전용을 재선언한다.
+revoke execute on function public.recompute_live_viewer_count(uuid) from public;
+revoke execute on function public.recompute_live_viewer_count(uuid) from anon;
+revoke execute on function public.recompute_live_viewer_count(uuid) from authenticated;
+grant execute on function public.recompute_live_viewer_count(uuid) to service_role;
+
+revoke execute on function public.sync_live_viewer_presence(uuid, text) from public;
+revoke execute on function public.sync_live_viewer_presence(uuid, text) from anon;
+revoke execute on function public.sync_live_viewer_presence(uuid, text) from authenticated;
+grant execute on function public.sync_live_viewer_presence(uuid, text) to service_role;
+
+revoke execute on function public.leave_live_viewer_presence(uuid, text) from public;
+revoke execute on function public.leave_live_viewer_presence(uuid, text) from anon;
+revoke execute on function public.leave_live_viewer_presence(uuid, text) from authenticated;
+grant execute on function public.leave_live_viewer_presence(uuid, text) to service_role;
+
+revoke execute on function public.sweep_live_viewer_counts() from public;
+revoke execute on function public.sweep_live_viewer_counts() from anon;
+revoke execute on function public.sweep_live_viewer_counts() from authenticated;
+grant execute on function public.sweep_live_viewer_counts() to service_role;


### PR DESCRIPTION
### 📌 반영 브랜치
#### refactor/live/viewer-count-hotpath/#97 -> dev

### ✅ 작업 내용 `리팩토링`
시청자 수 집계 핫패스 최적화(#97 B 트랙). 마이그레이션 1개 — RPC 시그니처·반환 유지로 **클라이언트/TS 변경 0**.

- **이벤트-게이트 재집계**: 하트비트 갱신(대다수)은 upsert만 O(1)로 끝내고, 멤버십이 실제로 바뀌는 순간(신규 진입·만료 복귀·실제 삭제된 leave)에만 재집계. 기존엔 시청자당 10초마다 stale DELETE + 전체 count(*) + `live_broadcast` UPDATE를 전부 수행해 동시시청 N명이면 O(N²) 성격 + 같은 행 락 경합.
- **stale 정리 sweep 일원화**: 핫패스에서 DELETE 제거, 카운트는 `last_seen_at` 윈도 필터(기존 인덱스 활용). 물리 삭제는 `sweep_live_viewer_counts`(pg_cron 30초)가 단독 소유.
- **윈도 단일 소스**: 20초 윈도를 `live_viewer_presence_window()` 함수로 추출(recompute/sync/sweep 공유).
- **leave 멱등화**: 실제 삭제(ROW_COUNT>0)일 때만 재집계 → beacon+cleanup 중복 발화는 no-op.

#### ⚠️ 이슈 원안과 달라진 점
- ~"±1 증분 카운터 전환"~ → **이벤트-게이트 재집계**로 대체. 증분 카운터는 drift(중복 증감·감소 누락·타임아웃엔 이벤트 부재)가 본질적 약점이라 가드+보정이 필수인데, 이벤트 게이트는 재집계가 매번 윈도 필터 full count라 **drift가 구조적으로 불가능**(자가 보정).
- ~"sweep을 보정 용도로 재정의"~ → #103의 pagehide sendBeacon 즉시 leave 도입으로 **사실상 기충족**. 본 PR에서 stale 물리 삭제 단독 소유자로 명시.
- ~"realtime fan-out 디바운스"~ → **보류**. UPDATE 빈도가 하트비트 비례→입퇴장 비례로 감소해 필요성 자체가 줄어듦. 입퇴장 churn 폭주가 관측되면 재평가.

### 🎯 단독 테스트 결과
- SQL 정합성 9단언(트랜잭션+rollback, DB 무변경): 신규 진입 즉시 반영 / 단순 갱신 무재집계 증명 / 만료 복귀 재집계 / leave 멱등 / 빈 방 sweep 0 수렴+물리 삭제 / PX400·PX404 유지
- 고부하 벤치(동시시청 5,000명 합성, rollback): 갱신-sync **1.0ms·`live_broadcast` 행 락 0** vs 구 하트비트당 재집계 1.5ms+행 경합, 진입-sync 2.7ms
- 브라우저 E2E: 익명 시청자 진입 → `current_viewer_count` 0→1 즉시 반영(`a:` 키 하트비트 확인), 하드 종료 → sweep이 0 수렴
- `npm run typecheck` / `lint` / `build` / Supabase advisor 클린
- DB 적용 완료, 마이그레이션 파일과 실물 함수 정의 일치 검증

### 🚨 연관 이슈
Refs #97 (A 트랙 머지 후 수동 close 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 성능 개선

* 라이브 시청자 카운팅 시스템을 최적화하여 시청자 수 업데이트의 정확성과 응답 속도를 개선했습니다.
* 데이터 처리 로직을 효율화하여 라이브 방송 기능의 안정성과 신뢰성을 강화했습니다.
* 백그라운드 정리 프로세스를 통합하여 시스템의 장기적 성능을 보장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->