### PR TITLE
Fix/user/donations/poinr card

### DIFF
--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,7 +10,7 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_82%,white)_46%,color-mix(in_srgb,var(--brand)_82%,white)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_68%,white)_46%,color-mix(in_srgb,var(--brand)_68%,white)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span
           className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_44%)]"
           aria-hidden

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,7 +10,7 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(100deg,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span className="bg-live/10 pointer-events-none absolute inset-0" aria-hidden />
         <span className="bg-live/20 pointer-events-none absolute inset-0" aria-hidden />
 

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,13 +10,13 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--brand)_20%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,var(--brand)_46%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span
-          className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_20%)]"
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_44%)]"
           aria-hidden
         />
         <span
-          className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_10%,transparent)_0%,transparent_20%)]"
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_10%,transparent)_0%,transparent_44%)]"
           aria-hidden
         />
 

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,7 +10,7 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,var(--brand)_46%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_82%,white)_46%,color-mix(in_srgb,var(--brand)_82%,white)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span
           className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_44%)]"
           aria-hidden

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,15 +10,9 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_68%,white)_46%,color-mix(in_srgb,var(--brand)_68%,white)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
-        <span
-          className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_44%)]"
-          aria-hidden
-        />
-        <span
-          className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_10%,transparent)_0%,transparent_44%)]"
-          aria-hidden
-        />
+      <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+        <span className="bg-live/10 pointer-events-none absolute inset-0" aria-hidden />
+        <span className="bg-live/20 pointer-events-none absolute inset-0" aria-hidden />
 
         <div className="relative z-10 flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1">

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,7 +10,7 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span className="bg-live/10 pointer-events-none absolute inset-0" aria-hidden />
         <span className="bg-live/20 pointer-events-none absolute inset-0" aria-hidden />
 

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,7 +10,7 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+      <section className="from-live/20 via-live/20 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
         <span className="bg-live/10 pointer-events-none absolute inset-0" aria-hidden />
         <span className="bg-live/20 pointer-events-none absolute inset-0" aria-hidden />
 

--- a/src/components/donations/user-donation-loading-state.tsx
+++ b/src/components/donations/user-donation-loading-state.tsx
@@ -10,9 +10,15 @@ export function UserDonationLoadingState() {
       title="후원 지갑"
       description="후원 지갑 정보를 불러오는 중입니다."
     >
-      <section className="from-live/20 via-live/20 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
-        <span className="bg-live/10 pointer-events-none absolute inset-0" aria-hidden />
-        <span className="bg-live/20 pointer-events-none absolute inset-0" aria-hidden />
+      <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--brand)_20%,var(--brand)_100%)] px-5 py-7 shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+        <span
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,transparent_20%)]"
+          aria-hidden
+        />
+        <span
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_10%,transparent)_0%,transparent_20%)]"
+          aria-hidden
+        />
 
         <div className="relative z-10 flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1">

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,13 +47,13 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="from-live/20 via-live/20 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_20%,color-mix(in_srgb,var(--live)_42%,transparent)_42%,transparent_70%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,color-mix(in_srgb,var(--live)_20%,transparent)_20%,color-mix(in_srgb,var(--live)_20%,transparent)_42%,transparent_70%)]"
         aria-hidden
       />
 

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,13 +47,13 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--brand)_20%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,var(--brand)_46%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_8%,color-mix(in_srgb,var(--live)_42%,transparent)_14%,transparent_20%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_24%,color-mix(in_srgb,var(--live)_42%,transparent)_36%,transparent_44%)]"
         aria-hidden
       />
 

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,13 +47,13 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_68%,white)_46%,color-mix(in_srgb,var(--brand)_68%,white)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(98deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_24%,color-mix(in_srgb,var(--live)_42%,transparent)_36%,transparent_44%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_20%,color-mix(in_srgb,var(--live)_42%,transparent)_42%,transparent_70%)]"
         aria-hidden
       />
 

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,7 +47,7 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,var(--brand)_46%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_82%,white)_46%,color-mix(in_srgb,var(--brand)_82%,white)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,7 +47,7 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(100deg,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,13 +47,13 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="from-live/20 via-live/20 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--brand)_20%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_20%,transparent)_0%,color-mix(in_srgb,var(--live)_20%,transparent)_20%,color-mix(in_srgb,var(--live)_20%,transparent)_42%,transparent_70%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_8%,color-mix(in_srgb,var(--live)_42%,transparent)_14%,transparent_20%)]"
         aria-hidden
       />
 

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -49,7 +49,7 @@ function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
     <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(100deg,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.18)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.18)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,7 +47,7 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_82%,white)_46%,color-mix(in_srgb,var(--brand)_82%,white)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(98deg,var(--live)_0%,var(--live)_38%,color-mix(in_srgb,var(--brand)_68%,white)_46%,color-mix(in_srgb,var(--brand)_68%,white)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden

--- a/src/components/donations/user-donations-page.tsx
+++ b/src/components/donations/user-donations-page.tsx
@@ -47,13 +47,13 @@ export function UserDonationsPage({ snapshot, errorCode, paymentResultCode }: Pr
 
 function DonationBalanceHero({ snapshot }: { snapshot: UserDonationSnapshot }) {
   return (
-    <section className="from-live via-live/85 to-brand relative isolate min-h-44 overflow-hidden rounded-xl bg-gradient-to-br px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
+    <section className="relative isolate min-h-44 overflow-hidden rounded-xl bg-[linear-gradient(to_bottom_right,var(--live)_0%,var(--live)_34%,var(--brand)_48%,var(--brand)_100%)] px-5 py-7 text-white shadow-sm sm:min-h-48 sm:px-7 sm:py-9">
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.08)_18%,rgba(0,0,0,0.72)_58%,black_100%)] bg-[length:32px_32px]"
         aria-hidden
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_20%,color-mix(in_srgb,var(--live)_42%,transparent)_42%,transparent_70%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,color-mix(in_srgb,var(--live)_94%,transparent)_0%,color-mix(in_srgb,var(--live)_80%,transparent)_16%,color-mix(in_srgb,var(--live)_42%,transparent)_34%,transparent_56%)]"
         aria-hidden
       />
 


### PR DESCRIPTION
### 📌 반영 브랜치

#### fix/user/donations/poinr-card -> dev

### ✅ 작업 내용 `외형수정`

- 후원 목록 상단 후원 포인트 카드의 그라데이션 비율을 조정했습니다.
- 빨강 영역이 차지하는 범위를 줄이고 초록 영역과 자연스럽게 이어지도록 수정했습니다.
- 카드 배경의 대각선 그라데이션 각도를 조정했습니다.
- 포인트 카드 배경의 격자 선이 더 잘 보이도록 강조했습니다.

### 🎯 단독 테스트 결과

- 단순 UI/CSS 스타일 조정 작업

### 🚨 연관 이슈

closes #114 