### PR TITLE
fix(#97): 라이브 익명 시청자 키 서버 발급 + 유휴 시청자 집계 진동 수정

### DIFF
--- a/src/actions/live/live.ts
+++ b/src/actions/live/live.ts
@@ -1,10 +1,15 @@
 "use server";
 // 라이브 채팅 메시지와 채팅 규칙 동의 RPC를 호출하는 서버 액션입니다.
 
+import { randomUUID } from "crypto";
+
+import { cookies } from "next/headers";
+
 import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import { createWriteClientForAction } from "@/actions/common/admin-client-action";
 import { getAuthenticatedActorId } from "@/actions/common/authenticated-actor";
 import {
+  ANON_VIEWER_COOKIE,
   LIVE_CHAT_MESSAGE_MAX_LENGTH,
   LIVE_DONATION_MESSAGE_MAX_LENGTH,
 } from "@/constants/live/live";
@@ -19,6 +24,7 @@ import {
 } from "@/utils/common/app-message";
 import { isRecord } from "@/utils/common/json";
 import { isUuid } from "@/utils/common/uuid";
+import { signAnonViewerKey, verifyAnonViewerKey } from "@/utils/live/live-security";
 
 // send_live_message_v2의 jsonb 응답({ messageId, moderated })을 앱 타입으로 정규화한다.
 // 금칙어로 가려진 경우 messageId는 null, moderated는 true다.
@@ -284,22 +290,46 @@ export async function sendLiveDonationAction(params: {
 }
 
 // 시청자 식별 키 — 로그인 시청자는 신뢰 가능한 user id('u:'), 익명 시청자는
-// 클라이언트가 생성한 세션 토큰('a:')을 쓴다. 로그인 여부는 서버에서 판단하므로
-// 클라이언트가 보낸 익명 키는 비로그인일 때만 채택한다(스푸핑 방어).
-const ANON_VIEWER_KEY_MAX_LENGTH = 64;
-
-async function resolveLiveViewerKey(anonViewerKey: string | undefined): Promise<string | null> {
+// 서버가 발급·검증하는 HttpOnly 쿠키('a:')를 쓴다. 서명 덕에 클라이언트가 '지정한' 익명 신원을
+// 위조할 순 없다(#97 A 트랙). 단 쿠키를 매번 비우고 신규 발급을 반복하는 부풀림은 막지 못하며,
+// 이는 후속 레이트리밋(⑤)에서 완화한다(MVP 허용). 로그인 여부는 서버에서 판단한다.
+async function resolveLiveViewerKey({
+  allowIssueAnonCookie,
+}: {
+  allowIssueAnonCookie: boolean;
+}): Promise<string | null> {
   const actor = await getAuthenticatedActorId({
     logLabel: "라이브 시청자 집계 중 인증 사용자 조회 실패",
   });
 
   if (actor.success) return `u:${actor.userId}`;
 
-  const trimmed = anonViewerKey?.trim() ?? "";
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(ANON_VIEWER_COOKIE)?.value;
 
-  if (!trimmed || trimmed.length > ANON_VIEWER_KEY_MAX_LENGTH) return null;
+  if (existing) {
+    const verifiedUuid = verifyAnonViewerKey(existing);
+    if (verifiedUuid) return `a:${verifiedUuid}`;
+  }
 
-  return `a:${trimmed}`;
+  // 쿠키가 없거나 변조됐다. 하트비트(sync)에서만 새로 발급하고, 이탈(leave)에선 발급하지 않는다 —
+  // 신원 없는 이탈은 지울 행도 없어 no-op이면 충분하고, 퇴장 순간 새 신원을 만들 이유도 없다.
+  // ⚠️ 불변식: leave 경로는 절대 쿠키를 set하지 않는다. leave는 훅 cleanup에서 서버 액션으로
+  // 직접 호출되는데, 서버 액션에서 쿠키를 set하면 라우터 캐시가 무효화돼 재생 화면이 새로고침된다
+  // (그래서 sync만 라우트 핸들러로 분리했다). 이 게이트가 그 불변식을 강제한다.
+  if (!allowIssueAnonCookie) return null;
+
+  const uuid = randomUUID();
+  // maxAge를 두지 않아 세션 쿠키로 발급한다(브라우저 종료 시 소멸). SameSite=Lax라 동일 출처
+  // fetch/sendBeacon에 자동 동봉되고, HttpOnly라 클라이언트 스크립트가 신원을 읽거나 위조할 수 없다.
+  cookieStore.set(ANON_VIEWER_COOKIE, `${uuid}.${signAnonViewerKey(uuid)}`, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+  });
+
+  return `a:${uuid}`;
 }
 
 // 시청자 하트비트 sync/leave 공통 골격 — RPC 이름에서 로그 라벨까지 도출한다.
@@ -307,11 +337,12 @@ async function resolveLiveViewerKey(anonViewerKey: string | undefined): Promise<
 async function runLiveViewerPresenceRpc(
   rpc: "sync_live_viewer_presence" | "leave_live_viewer_presence",
   broadcastId: string,
-  anonViewerKey: string | undefined,
 ): Promise<void> {
   if (!broadcastId || !isUuid(broadcastId)) return;
 
-  const viewerKey = await resolveLiveViewerKey(anonViewerKey);
+  const viewerKey = await resolveLiveViewerKey({
+    allowIssueAnonCookie: rpc === "sync_live_viewer_presence",
+  });
 
   if (!viewerKey) return;
 
@@ -332,19 +363,14 @@ async function runLiveViewerPresenceRpc(
 }
 
 // 시청 화면 하트비트 — current_viewer_count 집계용(로그인·익명 모두 집계).
-export async function syncLiveViewerPresenceAction(
-  broadcastId: string,
-  anonViewerKey?: string,
-): Promise<void> {
-  await runLiveViewerPresenceRpc("sync_live_viewer_presence", broadcastId, anonViewerKey);
+// 신원은 서버가 쿠키로 해석·발급하므로 broadcastId만 받는다.
+export async function syncLiveViewerPresenceAction(broadcastId: string): Promise<void> {
+  await runLiveViewerPresenceRpc("sync_live_viewer_presence", broadcastId);
 }
 
 // 시청 화면 이탈 시 본인 하트비트를 제거해 시청자 수를 즉시 줄인다.
-export async function leaveLiveViewerPresenceAction(
-  broadcastId: string,
-  anonViewerKey?: string,
-): Promise<void> {
-  await runLiveViewerPresenceRpc("leave_live_viewer_presence", broadcastId, anonViewerKey);
+export async function leaveLiveViewerPresenceAction(broadcastId: string): Promise<void> {
+  await runLiveViewerPresenceRpc("leave_live_viewer_presence", broadcastId);
 }
 
 export async function acceptLiveChatRuleAction(

--- a/src/app/api/live/viewer-leave/route.ts
+++ b/src/app/api/live/viewer-leave/route.ts
@@ -1,33 +1,10 @@
 // 시청 페이지를 떠날 때(탭 닫기·새로고침·외부 이동) navigator.sendBeacon이 호출하는 하트비트 제거 엔드포인트.
 // React effect cleanup은 SPA 내부 이동에서만 보장되고 hard unload에선 요청이 중단되므로, pagehide에서
 // 이 라우트로 즉시 leave를 보내 cron sweep(최대 30초) 이전에 현재 시청자 수를 줄인다(부수효과라 실패는 무시).
-import { NextResponse, type NextRequest } from "next/server";
-
+// 신원은 액션이 쿠키(로그인 세션 또는 pp_anon_viewer)로 직접 해석한다 — sendBeacon은 동일 출처라 쿠키를 포함한다.
 import { leaveLiveViewerPresenceAction } from "@/actions/live/live";
+import { createViewerPresenceRouteHandler } from "@/utils/live/live-viewer-presence-route";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(request: NextRequest) {
-  let broadcastId: unknown;
-  let anonViewerKey: unknown;
-
-  try {
-    const body: unknown = await request.json();
-    if (body && typeof body === "object") {
-      broadcastId = (body as Record<string, unknown>).broadcastId;
-      anonViewerKey = (body as Record<string, unknown>).anonViewerKey;
-    }
-  } catch {
-    // 비정상 본문은 조용히 무시한다(부수효과라 화면 영향 없음).
-  }
-
-  if (typeof broadcastId === "string") {
-    // 로그인 여부는 액션이 쿠키로 서버 검증한다(익명 키는 비로그인일 때만 채택). sendBeacon은 동일 출처라 쿠키 포함.
-    await leaveLiveViewerPresenceAction(
-      broadcastId,
-      typeof anonViewerKey === "string" ? anonViewerKey : undefined,
-    );
-  }
-
-  return new NextResponse(null, { status: 204 });
-}
+export const POST = createViewerPresenceRouteHandler(leaveLiveViewerPresenceAction);

--- a/src/app/api/live/viewer-sync/route.ts
+++ b/src/app/api/live/viewer-sync/route.ts
@@ -1,0 +1,9 @@
+// 시청 중 주기적으로(use-live-viewer-presence) 호출돼 하트비트를 갱신하는 엔드포인트.
+// 익명 시청자 식별 쿠키(pp_anon_viewer)를 서버가 발급·검증하는데, Server Action에서 쿠키를
+// set하면 라우터 캐시가 무효화돼 재생 중 화면이 새로고침되므로 그 부작용이 없는 라우트 핸들러로 처리한다.
+import { syncLiveViewerPresenceAction } from "@/actions/live/live";
+import { createViewerPresenceRouteHandler } from "@/utils/live/live-viewer-presence-route";
+
+export const dynamic = "force-dynamic";
+
+export const POST = createViewerPresenceRouteHandler(syncLiveViewerPresenceAction);

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -86,6 +86,10 @@ export const LIVE_LABEL = {
   bannedWordNotice: "금칙어가 포함되어 메시지가 전송되지 않았습니다.",
 } as const;
 
+// 익명 시청자 식별용 HttpOnly 쿠키 이름 — 서버가 발급·검증한다(#97 A 트랙).
+// 쿠키 이름 상수를 모듈 로컬에 두지 않고 여기서 관리한다(OAUTH_NEXT_COOKIE 선례).
+export const ANON_VIEWER_COOKIE = "pp_anon_viewer";
+
 // 어두운 플레이어 배경 위 아이콘 버튼 공통 스타일(컨트롤 바·음량·화질 공유).
 export const LIVE_PLAYER_ICON_BUTTON_CLASS = "text-white/80 hover:bg-white/10 hover:text-white";
 

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -90,6 +90,10 @@ export const LIVE_LABEL = {
 // 쿠키 이름 상수를 모듈 로컬에 두지 않고 여기서 관리한다(OAUTH_NEXT_COOKIE 선례).
 export const ANON_VIEWER_COOKIE = "pp_anon_viewer";
 
+// 시청자 하트비트 sync/leave 라우트 경로 — 훅(클라)과 라우트 파일 계약이 갈리지 않게 한 곳에서 관리한다.
+export const LIVE_VIEWER_SYNC_API_PATH = "/api/live/viewer-sync";
+export const LIVE_VIEWER_LEAVE_API_PATH = "/api/live/viewer-leave";
+
 // 어두운 플레이어 배경 위 아이콘 버튼 공통 스타일(컨트롤 바·음량·화질 공유).
 export const LIVE_PLAYER_ICON_BUTTON_CLASS = "text-white/80 hover:bg-white/10 hover:text-white";
 

--- a/src/hooks/live/use-live-viewer-presence.ts
+++ b/src/hooks/live/use-live-viewer-presence.ts
@@ -5,12 +5,13 @@
 
 import { useEffect } from "react";
 import { leaveLiveViewerPresenceAction } from "@/actions/live/live";
+import { LIVE_VIEWER_LEAVE_API_PATH, LIVE_VIEWER_SYNC_API_PATH } from "@/constants/live/live";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 // 하트비트 sync 엔드포인트 — 익명 식별 쿠키(pp_anon_viewer)를 서버가 발급·검증한다.
-const SYNC_URL = "/api/live/viewer-sync";
+const SYNC_URL = LIVE_VIEWER_SYNC_API_PATH;
 // pagehide 시 sendBeacon으로 leave를 보내는 동일 출처 엔드포인트.
-const LEAVE_BEACON_URL = "/api/live/viewer-leave";
+const LEAVE_BEACON_URL = LIVE_VIEWER_LEAVE_API_PATH;
 
 export function useLiveViewerPresence(broadcastId: string | null | undefined) {
   useEffect(() => {

--- a/src/hooks/live/use-live-viewer-presence.ts
+++ b/src/hooks/live/use-live-viewer-presence.ts
@@ -1,51 +1,30 @@
 "use client";
 // 시청 중인 라이브 방송에 주기적으로 하트비트를 보내 current_viewer_count 집계에 참여합니다.
-// 로그인·익명 시청자 모두 집계되며(서버가 로그인 시 user id, 아니면 익명 키 채택),
-// 진입/주기/복귀 시 하트비트, 이탈 시 즉시 제거합니다.
+// 로그인·익명 시청자 모두 집계되며(서버가 로그인이면 user id, 아니면 발급·검증한 익명 쿠키로 식별),
+// 진입/주기/복귀 시 하트비트, 이탈 시 즉시 제거합니다. 익명 식별 키는 클라이언트가 만들지 않습니다.
 
 import { useEffect } from "react";
-import { leaveLiveViewerPresenceAction, syncLiveViewerPresenceAction } from "@/actions/live/live";
+import { leaveLiveViewerPresenceAction } from "@/actions/live/live";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
-const ANON_VIEWER_KEY_STORAGE = "live-anon-viewer-key";
+// 하트비트 sync 엔드포인트 — 익명 식별 쿠키(pp_anon_viewer)를 서버가 발급·검증한다.
+const SYNC_URL = "/api/live/viewer-sync";
 // pagehide 시 sendBeacon으로 leave를 보내는 동일 출처 엔드포인트.
 const LEAVE_BEACON_URL = "/api/live/viewer-leave";
-
-// sessionStorage가 막힌 환경(프라이빗 모드 등)을 위한 비영속 폴백 키.
-let inMemoryAnonKey: string | null = null;
-
-function generateAnonKey(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  // 비보안(non-HTTPS) 컨텍스트 등 crypto.randomUUID 미지원 시 폴백.
-  return `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-// 익명 시청자 식별용 키 — 탭 세션 동안 안정적으로 유지해 같은 시청자가 중복 집계되지 않게 한다.
-function getAnonViewerKey(): string {
-  try {
-    const stored = sessionStorage.getItem(ANON_VIEWER_KEY_STORAGE);
-    if (stored) return stored;
-
-    const generated = generateAnonKey();
-    sessionStorage.setItem(ANON_VIEWER_KEY_STORAGE, generated);
-    return generated;
-  } catch {
-    // sessionStorage 접근 불가 — 모듈 메모리에 한 번 생성해 세션 동안 재사용.
-    if (!inMemoryAnonKey) inMemoryAnonKey = generateAnonKey();
-    return inMemoryAnonKey;
-  }
-}
 
 export function useLiveViewerPresence(broadcastId: string | null | undefined) {
   useEffect(() => {
     if (!broadcastId) return;
 
-    const anonViewerKey = getAnonViewerKey();
-
     const sendHeartbeat = () => {
-      void syncLiveViewerPresenceAction(broadcastId, anonViewerKey);
+      // 동일 출처 fetch라 쿠키가 자동 동봉된다(서버가 익명 식별 쿠키를 읽거나 첫 요청에 발급).
+      void fetch(SYNC_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ broadcastId }),
+      }).catch(() => {
+        // 부수효과라 실패는 무시한다(다음 주기·복귀 하트비트가 보정).
+      });
     };
 
     sendHeartbeat();
@@ -63,7 +42,7 @@ export function useLiveViewerPresence(broadcastId: string | null | undefined) {
       // 끝내 안 돌아오면 cron sweep이 정리). 실제 unload에서만 즉시 leave를 보낸다.
       if (event.persisted) return;
       if (typeof navigator === "undefined" || typeof navigator.sendBeacon !== "function") return;
-      const payload = JSON.stringify({ broadcastId, anonViewerKey });
+      const payload = JSON.stringify({ broadcastId });
       navigator.sendBeacon(LEAVE_BEACON_URL, new Blob([payload], { type: "application/json" }));
     };
     window.addEventListener("pagehide", handlePageHide);
@@ -72,7 +51,7 @@ export function useLiveViewerPresence(broadcastId: string | null | undefined) {
       window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("pagehide", handlePageHide);
-      void leaveLiveViewerPresenceAction(broadcastId, anonViewerKey);
+      void leaveLiveViewerPresenceAction(broadcastId);
     };
   }, [broadcastId]);
 }

--- a/src/utils/live/live-security.ts
+++ b/src/utils/live/live-security.ts
@@ -1,10 +1,16 @@
 // 라이브 스트림키와 OBS 오버레이 보안 key를 생성합니다.
 import "server-only";
 
-import { createHmac } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
+
+import { isUuid } from "@/utils/common/uuid";
 
 const LIVE_STREAM_KEY_LENGTH = 40;
 const LIVE_OVERLAY_KEY_LENGTH = 32;
+// hex 문자 32개 = 128비트 — 위조 방어에 충분하다(더 줄이지 말 것).
+const LIVE_ANON_VIEWER_SIGNATURE_LENGTH = 32;
+// 검증 시 서명이 정확히 이 형식(소문자 hex N자)인지 먼저 거른다(timingSafeEqual throw 방지).
+const ANON_VIEWER_SIGNATURE_REGEX = new RegExp(`^[0-9a-f]{${LIVE_ANON_VIEWER_SIGNATURE_LENGTH}}$`);
 
 export function buildLiveStreamKey(creatorId: string, version: number) {
   const secret = readLiveOverlayTokenSecret();
@@ -23,6 +29,39 @@ export function buildLiveOverlayKey(kind: "chat" | "donation", creatorId: string
     .update(`${kind}:${creatorId}:${version}`)
     .digest("hex")
     .slice(0, LIVE_OVERLAY_KEY_LENGTH);
+}
+
+// 익명 시청자 식별 쿠키(pp_anon_viewer)의 서명 — 값은 `<uuid>.<서명>` 형태로 클라이언트에
+// 전달되며, 서버만 시크릿을 알기에 클라이언트가 임의의 익명 신원을 위조할 수 없다(#97 A 트랙).
+export function signAnonViewerKey(uuid: string): string {
+  const secret = readLiveOverlayTokenSecret();
+
+  return createHmac("sha256", secret)
+    .update(`anon-viewer:${uuid}`)
+    .digest("hex")
+    .slice(0, LIVE_ANON_VIEWER_SIGNATURE_LENGTH);
+}
+
+// 쿠키 값(`<uuid>.<서명>`)을 검증해 유효하면 uuid를, 변조·형식 오류면 null을 반환한다.
+export function verifyAnonViewerKey(cookieValue: string): string | null {
+  const separatorIndex = cookieValue.lastIndexOf(".");
+  if (separatorIndex <= 0) return null;
+
+  const uuid = cookieValue.slice(0, separatorIndex);
+  const signature = cookieValue.slice(separatorIndex + 1);
+
+  if (!isUuid(uuid)) return null;
+
+  // 서명은 항상 소문자 hex 32자다. 형식을 먼저 검증해 거른다 — 이렇게 하면 두 utf8 버퍼의
+  // 바이트 길이가 반드시 같아져, 멀티바이트 문자로 코드유닛 길이만 맞춘 변조에도 timingSafeEqual이
+  // throw하지 않는다(문자열 길이 비교만으론 바이트 길이 불일치를 못 걸러 RangeError가 날 수 있다).
+  if (!ANON_VIEWER_SIGNATURE_REGEX.test(signature)) return null;
+
+  const expected = signAnonViewerKey(uuid);
+
+  if (!timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
+
+  return uuid;
 }
 
 function readLiveOverlayTokenSecret() {

--- a/src/utils/live/live-viewer-presence-route.ts
+++ b/src/utils/live/live-viewer-presence-route.ts
@@ -1,6 +1,10 @@
 // 시청자 하트비트 sync/leave 라우트의 공통 골격 — fetch/sendBeacon이 보낸 { broadcastId }를
 // 관대하게 파싱해 주어진 액션에 위임하고 204를 반환한다. 신원(로그인 세션·익명 쿠키)은 액션이
 // 서버에서 직접 해석·발급하므로 라우트는 broadcastId만 다룬다(비정상 본문은 부수효과라 무시).
+//
+// TODO(#97 후속): 두 라우트는 비인증 공개 POST라 쿠키를 비우는 클라이언트의 윈도 내 과집계나
+// 단순 POST flood가 service-role RPC write를 그대로 증폭시킬 수 있다. per-IP/origin 레이트리밋·
+// edge-level shedding은 MVP 범위 밖 별도 인프라 작업으로 둔다(여기 공용 유틸이 아닌 인프라 계층 담당).
 import { NextResponse, type NextRequest } from "next/server";
 
 export function createViewerPresenceRouteHandler(action: (broadcastId: string) => Promise<void>) {

--- a/src/utils/live/live-viewer-presence-route.ts
+++ b/src/utils/live/live-viewer-presence-route.ts
@@ -1,0 +1,25 @@
+// 시청자 하트비트 sync/leave 라우트의 공통 골격 — fetch/sendBeacon이 보낸 { broadcastId }를
+// 관대하게 파싱해 주어진 액션에 위임하고 204를 반환한다. 신원(로그인 세션·익명 쿠키)은 액션이
+// 서버에서 직접 해석·발급하므로 라우트는 broadcastId만 다룬다(비정상 본문은 부수효과라 무시).
+import { NextResponse, type NextRequest } from "next/server";
+
+export function createViewerPresenceRouteHandler(action: (broadcastId: string) => Promise<void>) {
+  return async function POST(request: NextRequest) {
+    let broadcastId: unknown;
+
+    try {
+      const body: unknown = await request.json();
+      if (body && typeof body === "object") {
+        broadcastId = (body as Record<string, unknown>).broadcastId;
+      }
+    } catch {
+      // 비정상 본문은 조용히 무시한다(부수효과라 화면 영향 없음).
+    }
+
+    if (typeof broadcastId === "string") {
+      await action(broadcastId);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  };
+}

--- a/supabase/migrations/20260611120000_widen_live_viewer_presence_window.sql
+++ b/supabase/migrations/20260611120000_widen_live_viewer_presence_window.sql
@@ -1,0 +1,20 @@
+-- 라이브 시청자 신선도 윈도 20s → 90s (#97 후속, 유휴 탭 타이머 스로틀링 대응).
+-- 크롬은 백그라운드(hidden) 탭의 setInterval을 분당 1회로 스로틀하므로, 20초 윈도에서는
+-- 아무 조작 없이 시청만 하는 유휴 시청자의 하트비트가 늦어 sweep마다 카운트에서 탈락→재진입을
+-- 반복했다(메인 목록에서 인원이 늘었다 0이 되는 진동). 90s = 스로틀 주기(60s) + 여유(30s)로
+-- 늦은 하트비트가 윈도를 벗어나지 않아 진동이 사라진다. 일반 퇴장(언마운트 leave·pagehide beacon)은
+-- 즉시 반영이라 영향 없고, 비정상 종료 고스트만 sweep까지 최대 ~2분 잔존한다(수용).
+-- sync/recompute/sweep이 공유하는 단일 소스라 이 함수 한 곳만 바꾼다(다른 RPC·cron·인덱스 무변경).
+create or replace function public.live_viewer_presence_window()
+returns interval
+language sql
+immutable
+set search_path to ''
+as $function$
+  select interval '90 seconds'
+$function$;
+
+revoke execute on function public.live_viewer_presence_window() from public;
+revoke execute on function public.live_viewer_presence_window() from anon;
+revoke execute on function public.live_viewer_presence_window() from authenticated;
+grant execute on function public.live_viewer_presence_window() to service_role;


### PR DESCRIPTION
### 📌 반영 브랜치
#### fix/live/viewer-presence/#97 -> dev

### ✅ 작업 내용 `버그 수정` `기능 개선`
이슈 #97의 남은 A 트랙(익명 viewer key 보안) 구현과 사용자 보고 유휴 시청자 드롭 버그 수정
 (B 트랙 집계 성능은 #108로 머지 완료)

**1. 익명 시청자 키 서버 발급 전환**
- 클라이언트가 sessionStorage에서 생성하던 익명 viewer key를 서버가 HMAC 서명·검증하는 HttpOnly 쿠키(pp_anon_viewer)로 교체 → 클라이언트가 지정한 익명 신원을 위조할 수 없게 차단
- resolveLiveViewerKey: 로그인 우선(u:) → 비로그인은 쿠키 검증(a:uuid), 발급은 sync에서만(leave는 쿠키 set 금지)
- sync를 라우트 핸들러(/api/live/viewer-sync)로 분리 → Server Action에서 쿠키 set 시 발생하는 라우터 캐시 무효화(재생 중 새로고침) 회피
- sync/leave 라우트는 createViewerPresenceRouteHandler 팩토리로 공통 골격 공유

**2. 유휴 시청자 집계 진동 수정**
- 크롬이 백그라운드 탭 setInterval을 분당 1회로 스로틀 → 윈도 20초로는 유휴 시청자가 sweep마다 탈락·재진입하며 카운트가 진동(메인 목록에서 인원이 늘었다 0이 되던 증상)
- 신선도 윈도 20s → 90s(스로틀 주기 60s + 여유 30s). sync/recompute/sweep 공유 단일 소스 함수 한 곳만 변경

**알려진 한계(의도)**
쿠키를 매 요청 비우거나 쿠키를 거부하는 환경에선 윈도 내 과집계가 가능합니다. 

### 🎯 단독 테스트 결과
- typecheck / lint / build 클린, Supabase advisor 신규 이슈 0
- HTTP 실증: 라우트 핸들러에서 호출된 액션의 cookies().set()이 Set-Cookie 정상 발급 / 유효 쿠키 재사용 시 재발급 안 함 / 변조(잘못된 HMAC·멀티바이트) 시 500 없이 204 재발급 확인
- DB: 윈도 함수(live_viewer_presence_window 20s→90s)는 대시보드 선적용 완료, 본 PR은 미러 마이그레이션

### 🚨 연관 이슈
closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 라이브 시청자 식별을 HttpOnly 쿠키 기반으로 개선하여 보안 강화
  * 새로운 시청자 동기화 API 엔드포인트 추가

* **Bug Fixes**
  * 시청자 프레즌스 윈도우를 90초로 확대하여 네트워크 지연 시 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->