### PR TITLE
feat(#118): 채널 매니저 권한 관리 화면 추가

### DIFF
--- a/src/actions/channel/moderation.ts
+++ b/src/actions/channel/moderation.ts
@@ -1,0 +1,107 @@
+"use server";
+// 채널 운영(매니저 권한) 서버 액션. 신뢰 파라미터(actor=auth.uid())를 받는 service_role RPC를 호출한다.
+
+import { getAuthenticatedActorId } from "@/actions/common/authenticated-actor";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import type { AppActionResult } from "@/types/common/action";
+import type { ChannelUserCandidate } from "@/types/channel/moderation";
+import { parseChannelUserCandidates } from "@/utils/channel/channel-moderation";
+import { isUuid } from "@/utils/common/uuid";
+
+const USER_SEARCH_QUERY_MAX_LENGTH = 100;
+
+// 닉네임/UUID 정확일치로 매니저 후보를 검색한다(부분검색 없음, 최대 10건).
+export async function searchChannelUsersAction(
+  query: string,
+): Promise<AppActionResult<ChannelUserCandidate[]>> {
+  const trimmed = query.trim();
+
+  if (!trimmed || trimmed.length > USER_SEARCH_QUERY_MAX_LENGTH) {
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.userSearchFailed };
+  }
+
+  const actor = await getAuthenticatedActorId({
+    logLabel: "매니저 검색 중 인증 유저 조회 실패",
+  });
+
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("search_channel_users", { p_query: trimmed });
+
+  if (error) {
+    console.error("매니저 검색 RPC 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.userSearchFailed };
+  }
+
+  return { success: true, data: parseChannelUserCandidates(data) };
+}
+
+// 매니저 추가 — actor(=채널 주인)가 대상 유저에게 매니저 권한을 부여한다.
+export async function addChannelManagerAction(targetUserId: string): Promise<AppActionResult> {
+  if (!targetUserId || !isUuid(targetUserId)) {
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.managerAddFailed };
+  }
+
+  const actor = await getAuthenticatedActorId({
+    logLabel: "매니저 추가 중 인증 유저 조회 실패",
+  });
+
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("add_channel_manager", {
+    p_actor_user_id: actor.userId,
+    p_target_user_id: targetUserId,
+  });
+
+  if (error) {
+    const pgCode = (error as { code?: string }).code;
+
+    // PX409 = 선체크에서 걸린 중복, 23505 = 동시/더블서밋이 unique 제약에서 걸린 경우. 둘 다 같은 안내.
+    if (pgCode === "PX409" || pgCode === "23505") {
+      return { success: false, code: APP_MESSAGE_CODE.error.channel.managerAlreadyExists };
+    }
+    if (pgCode === "PX400") {
+      return { success: false, code: APP_MESSAGE_CODE.error.channel.managerSelfForbidden };
+    }
+
+    console.error("매니저 추가 RPC 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.managerAddFailed };
+  }
+
+  return { success: true, code: APP_MESSAGE_CODE.success.channel.managerAdded };
+}
+
+// 매니저 해제 — actor(=채널 주인)가 대상 유저의 매니저 권한을 회수한다. 멱등.
+export async function removeChannelManagerAction(targetUserId: string): Promise<AppActionResult> {
+  if (!targetUserId || !isUuid(targetUserId)) {
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.managerRemoveFailed };
+  }
+
+  const actor = await getAuthenticatedActorId({
+    logLabel: "매니저 해제 중 인증 유저 조회 실패",
+  });
+
+  if (!actor.success) {
+    return { success: false, code: actor.result.code };
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("remove_channel_manager", {
+    p_actor_user_id: actor.userId,
+    p_target_user_id: targetUserId,
+  });
+
+  if (error) {
+    console.error("매니저 해제 RPC 실패", error);
+    return { success: false, code: APP_MESSAGE_CODE.error.channel.managerRemoveFailed };
+  }
+
+  return { success: true, code: APP_MESSAGE_CODE.success.channel.managerRemoved };
+}

--- a/src/actions/live/live.ts
+++ b/src/actions/live/live.ts
@@ -20,7 +20,7 @@ import {
 import { isRecord } from "@/utils/common/json";
 import { isUuid } from "@/utils/common/uuid";
 
-// send_live_message_v2의 jsonb 응답({ messageId, moderated })을 앱 타입으로 정규화한다.
+// send_live_message_v4의 jsonb 응답({ messageId, moderated })을 앱 타입으로 정규화한다.
 // 금칙어로 가려진 경우 messageId는 null, moderated는 true다.
 function normalizeSendLiveMessageResult(data: unknown): SendLiveMessageResult | null {
   if (!isRecord(data)) return null;
@@ -45,6 +45,7 @@ interface JoinLiveDrawInput {
 
 // 채팅은 채널(creator) 단위다 — 방송 중이면 RPC가 메시지를 활성 방송에 자동 귀속시키고,
 // 방송 외 시간에는 채널 메시지(broadcast_id null)로 기록한다(#111).
+// v4는 v3 본문 + 매니저 확장(매니저 전용 채팅 통과·sender_role manager)을 담는다(#118). v3는 동결.
 export async function sendLiveMessageAction(
   creatorId: string,
   content: string,
@@ -76,7 +77,7 @@ export async function sendLiveMessageAction(
     return client.result;
   }
 
-  const { data, error } = await client.supabase.rpc("send_live_message_v3", {
+  const { data, error } = await client.supabase.rpc("send_live_message_v4", {
     p_actor_user_id: actor.userId,
     p_creator_id: creatorId,
     p_content: trimmed,

--- a/src/app/channel/(studio)/permissions/page.tsx
+++ b/src/app/channel/(studio)/permissions/page.tsx
@@ -1,0 +1,19 @@
+// 채널 권한 관리(매니저) 페이지. 크리에이터 본인만 접근하는 스튜디오 화면이라 서버에서 인증을 가드한다.
+import { ChannelPermissionsPageContent } from "@/components/channel/moderation/channel-permissions-page-content";
+import { LoadFailedState } from "@/components/common/load-failed-state";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { getCurrentProfileSnapshot } from "@/utils/profile/profile-server";
+
+export default async function ChannelPermissionsPage() {
+  const { profile } = await getCurrentProfileSnapshot();
+
+  if (!profile) {
+    return <LoadFailedState code={APP_MESSAGE_CODE.error.auth.authInfoNotFound} />;
+  }
+
+  return (
+    <ChannelPermissionsPageContent
+      creator={{ id: profile.id, nickname: profile.nickname, photoUrl: profile.photo_url }}
+    />
+  );
+}

--- a/src/components/channel/moderation/channel-manager-add-form.tsx
+++ b/src/components/channel/moderation/channel-manager-add-form.tsx
@@ -1,0 +1,142 @@
+"use client";
+// 매니저 추가 폼 — 닉네임/UUID 정확일치 검색 → 후보 선택 → 추가. 본인·기존 매니저는 추가 버튼을 막는다.
+
+import { useState } from "react";
+
+import { Search, ShieldPlus } from "lucide-react";
+
+import { searchChannelUsersAction } from "@/actions/channel/moderation";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import type { ChannelUserCandidate } from "@/types/channel/moderation";
+import { toastAppError } from "@/utils/common/toast-message";
+import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar";
+
+interface Props {
+  creatorId: string;
+  existingManagerIds: Set<string>;
+  onAdd: (targetUserId: string) => Promise<boolean>;
+  isAdding: boolean;
+}
+
+export function ChannelManagerAddForm({ creatorId, existingManagerIds, onAdd, isAdding }: Props) {
+  const [query, setQuery] = useState("");
+  const [candidates, setCandidates] = useState<ChannelUserCandidate[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [pendingAddId, setPendingAddId] = useState<string | null>(null);
+
+  async function handleSearch() {
+    if (isSearching) return;
+
+    const trimmed = query.trim();
+    // 빈 입력으로 검색하면 후보 목록을 초기화해 첫 화면 상태로 되돌린다.
+    if (!trimmed) {
+      setCandidates(null);
+      return;
+    }
+
+    setIsSearching(true);
+    const result = await searchChannelUsersAction(trimmed);
+    setIsSearching(false);
+
+    if (!result.success || !result.data) {
+      toastAppError(result.code ?? APP_MESSAGE_CODE.error.channel.userSearchFailed);
+      return;
+    }
+
+    setCandidates(result.data);
+  }
+
+  async function handleAdd(targetUserId: string) {
+    setPendingAddId(targetUserId);
+    await onAdd(targetUserId);
+    setPendingAddId(null);
+  }
+
+  return (
+    <div className="ring-foreground/10 bg-card flex flex-col gap-4 rounded-xl p-4 shadow-sm ring-1 sm:p-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-foreground font-semibold">매니저 추가</h2>
+        <p className="text-muted-foreground text-sm">
+          닉네임 또는 유저 ID를 정확히 입력해 검색한 뒤 매니저로 추가하세요.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+              event.preventDefault();
+              void handleSearch();
+            }
+          }}
+          placeholder="닉네임 또는 유저 ID"
+          aria-label="매니저 검색"
+        />
+        <Button
+          type="button"
+          className="bg-brand hover:bg-brand/85 text-brand-foreground h-auto self-stretch font-bold sm:w-auto"
+          onClick={() => void handleSearch()}
+          disabled={isSearching}
+        >
+          {isSearching ? <Spinner className="size-4" /> : <Search />}
+          검색
+        </Button>
+      </div>
+
+      {candidates !== null &&
+        (candidates.length === 0 ? (
+          <p className="text-muted-foreground py-2 text-center text-sm">
+            검색 결과가 없어요. 닉네임 또는 유저 ID를 다시 확인해 주세요.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {candidates.map((candidate) => {
+              const isSelf = candidate.userId === creatorId;
+              const isAlreadyManager = existingManagerIds.has(candidate.userId);
+              const isPending = pendingAddId === candidate.userId && isAdding;
+
+              return (
+                <li
+                  key={candidate.userId}
+                  className="border-border flex items-center gap-3 rounded-lg border p-3"
+                >
+                  <Avatar className="size-9 shrink-0">
+                    <AvatarImage src={getAvatarImageSrc(candidate.photoUrl)} alt="" />
+                    <AvatarFallback>{getAvatarFallbackText(candidate.nickname)}</AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-foreground truncate font-medium">{candidate.nickname}</p>
+                    <p className="text-muted-foreground truncate font-mono text-xs">
+                      {candidate.userId}
+                    </p>
+                  </div>
+                  {isSelf ? (
+                    <span className="text-muted-foreground shrink-0 text-xs">본인</span>
+                  ) : isAlreadyManager ? (
+                    <span className="text-muted-foreground shrink-0 text-xs">이미 매니저</span>
+                  ) : (
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="bg-brand hover:bg-brand/85 text-brand-foreground shrink-0 font-bold"
+                      onClick={() => void handleAdd(candidate.userId)}
+                      disabled={isAdding}
+                    >
+                      {isPending ? <Spinner className="size-3.5" /> : <ShieldPlus />}
+                      추가
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        ))}
+    </div>
+  );
+}

--- a/src/components/channel/moderation/channel-manager-add-form.tsx
+++ b/src/components/channel/moderation/channel-manager-add-form.tsx
@@ -39,8 +39,13 @@ export function ChannelManagerAddForm({ creatorId, existingManagerIds, onAdd, is
     }
 
     setIsSearching(true);
-    const result = await searchChannelUsersAction(trimmed);
-    setIsSearching(false);
+    let result: Awaited<ReturnType<typeof searchChannelUsersAction>>;
+    try {
+      result = await searchChannelUsersAction(trimmed);
+    } finally {
+      // 서버 액션이 전송 계층에서 reject 돼도 검색 버튼이 비활성으로 잠기지 않게 한다.
+      setIsSearching(false);
+    }
 
     if (!result.success || !result.data) {
       toastAppError(result.code ?? APP_MESSAGE_CODE.error.channel.userSearchFailed);
@@ -52,8 +57,11 @@ export function ChannelManagerAddForm({ creatorId, existingManagerIds, onAdd, is
 
   async function handleAdd(targetUserId: string) {
     setPendingAddId(targetUserId);
-    await onAdd(targetUserId);
-    setPendingAddId(null);
+    try {
+      await onAdd(targetUserId);
+    } finally {
+      setPendingAddId(null);
+    }
   }
 
   return (

--- a/src/components/channel/moderation/channel-manager-table.tsx
+++ b/src/components/channel/moderation/channel-manager-table.tsx
@@ -1,0 +1,232 @@
+"use client";
+// 권한 목록 표(데스크톱) + 카드(모바일). 스트리머 본인(크리에이터)을 맨 위에 고정하고 매니저를 아래로 나열한다
+// (위→아래 = 크리에이터 → 매니저). 해제는 파괴적 동작이라 공용 DeleteConfirmDialog로 확인받는다.
+
+import { useState } from "react";
+
+import { Crown, ShieldCheck, type LucideIcon } from "lucide-react";
+
+import DeleteConfirmDialog from "@/components/common/delete-confirm-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type { ChannelManagerItem, ChannelOwnerIdentity } from "@/types/channel/moderation";
+import { formatKstDateTimeNumeric } from "@/utils/common/date";
+import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar";
+
+type PermissionRole = "creator" | "manager";
+
+// 스트리머·매니저를 한 가지 행 모델로 통합해 데스크톱/모바일이 같은 데이터를 렌더한다.
+interface PermissionRow {
+  key: string;
+  userId: string;
+  nickname: string;
+  photoUrl: string | null;
+  registrantNickname: string | null; // 등록자(크리에이터 본인은 없음)
+  createdAt: string | null; // 등록일(크리에이터 본인은 없음)
+  role: PermissionRole;
+  removableManager: ChannelManagerItem | null; // null = 해제 불가(스트리머 본인)
+}
+
+const ROLE_META: Record<PermissionRole, { icon: LucideIcon; label: string }> = {
+  creator: { icon: Crown, label: "크리에이터" },
+  manager: { icon: ShieldCheck, label: "매니저" },
+};
+
+interface Props {
+  creator: ChannelOwnerIdentity;
+  managers: ChannelManagerItem[];
+  onRemove: (targetUserId: string) => Promise<boolean>;
+  isRemoving: boolean;
+}
+
+function PersonIdentity({
+  nickname,
+  photoUrl,
+  userId,
+}: {
+  nickname: string;
+  photoUrl: string | null;
+  userId: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <Avatar className="size-9 shrink-0">
+        <AvatarImage src={getAvatarImageSrc(photoUrl)} alt="" />
+        <AvatarFallback>{getAvatarFallbackText(nickname)}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <p className="text-foreground truncate font-medium">{nickname}</p>
+        <p className="text-muted-foreground truncate font-mono text-xs">{userId}</p>
+      </div>
+    </div>
+  );
+}
+
+function RoleTag({ role, compact = false }: { role: PermissionRole; compact?: boolean }) {
+  const { icon: Icon, label } = ROLE_META[role];
+
+  return (
+    <span
+      className={cn("text-brand inline-flex items-center gap-1 font-medium", !compact && "text-sm")}
+    >
+      <Icon className={compact ? "size-3.5" : "size-4"} />
+      {label}
+    </span>
+  );
+}
+
+export function ChannelManagerTable({ creator, managers, onRemove, isRemoving }: Props) {
+  const [removeTarget, setRemoveTarget] = useState<ChannelManagerItem | null>(null);
+
+  const rows: PermissionRow[] = [
+    {
+      key: `creator-${creator.id}`,
+      userId: creator.id,
+      nickname: creator.nickname,
+      photoUrl: creator.photoUrl,
+      registrantNickname: null,
+      createdAt: null,
+      role: "creator",
+      removableManager: null,
+    },
+    ...managers.map((manager) => ({
+      key: manager.managerRelationId,
+      userId: manager.managerId,
+      nickname: manager.managerNickname,
+      photoUrl: manager.managerPhotoUrl,
+      registrantNickname: manager.createdByNickname,
+      createdAt: manager.createdAt,
+      role: "manager" as const,
+      removableManager: manager,
+    })),
+  ];
+
+  async function handleConfirmRemove() {
+    if (!removeTarget) return;
+
+    const success = await onRemove(removeTarget.managerId);
+    if (success) {
+      setRemoveTarget(null);
+    }
+  }
+
+  return (
+    <>
+      {/* 데스크톱: 표 */}
+      <div className="ring-foreground/10 bg-card hidden overflow-hidden rounded-xl shadow-sm ring-1 md:block">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead scope="col">닉네임</TableHead>
+              <TableHead scope="col" className="text-center">
+                등록자
+              </TableHead>
+              <TableHead scope="col" className="text-center">
+                등록일
+              </TableHead>
+              <TableHead scope="col" className="text-center">
+                역할
+              </TableHead>
+              <TableHead scope="col" className="text-center">
+                관리
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => {
+              const { removableManager } = row;
+
+              return (
+                <TableRow key={row.key} className="hover:bg-transparent">
+                  <TableCell>
+                    <PersonIdentity
+                      nickname={row.nickname}
+                      photoUrl={row.photoUrl}
+                      userId={row.userId}
+                    />
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-center">
+                    {row.registrantNickname ?? "—"}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-center tabular-nums">
+                    {row.createdAt ? formatKstDateTimeNumeric(row.createdAt) : "—"}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <RoleTag role={row.role} />
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {removableManager ? (
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setRemoveTarget(removableManager)}
+                      >
+                        해제
+                      </Button>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">—</span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* 모바일: 카드 */}
+      <ul className="flex flex-col gap-3 md:hidden">
+        {rows.map((row) => {
+          const { removableManager } = row;
+
+          return (
+            <li
+              key={row.key}
+              className="ring-foreground/10 bg-card flex flex-col gap-3 rounded-xl p-4 shadow-sm ring-1"
+            >
+              <PersonIdentity nickname={row.nickname} photoUrl={row.photoUrl} userId={row.userId} />
+              <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                <RoleTag role={row.role} compact />
+                <span>등록자 {row.registrantNickname ?? "—"}</span>
+                {row.createdAt && (
+                  <span className="tabular-nums">{formatKstDateTimeNumeric(row.createdAt)}</span>
+                )}
+              </div>
+              {removableManager && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="self-end"
+                  onClick={() => setRemoveTarget(removableManager)}
+                >
+                  해제
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <DeleteConfirmDialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRemoveTarget(null);
+        }}
+        title="매니저 권한 해제"
+        description={`${removeTarget?.managerNickname ?? ""} 님의 매니저 권한을 해제할까요?\n해제하면 일반 시청자로 돌아갑니다.`}
+        isPending={isRemoving}
+        onConfirm={handleConfirmRemove}
+        confirmLabel="해제"
+      />
+    </>
+  );
+}

--- a/src/components/channel/moderation/channel-permissions-page-content.tsx
+++ b/src/components/channel/moderation/channel-permissions-page-content.tsx
@@ -9,8 +9,10 @@ import { ChannelManagerAddForm } from "@/components/channel/moderation/channel-m
 import { ChannelManagerTable } from "@/components/channel/moderation/channel-manager-table";
 import { SettingsPage } from "@/components/common/settings-page";
 import { Spinner } from "@/components/ui/spinner";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import { useChannelManagers } from "@/hooks/channel/use-channel-managers";
 import type { ChannelOwnerIdentity } from "@/types/channel/moderation";
+import { getAppMessage } from "@/utils/common/app-message";
 
 interface Props {
   creator: ChannelOwnerIdentity;
@@ -31,7 +33,7 @@ export function ChannelPermissionsPageContent({ creator }: Props) {
       title="채널 매니저를 관리해요"
       description={
         <>
-          매니저는 채팅에서 시청자를 강퇴할 수 있어요.
+          매니저는 채널 운영을 돕는 신뢰할 수 있는 시청자예요.
           <br />
           믿을 수 있는 시청자에게만 권한을 주고, 필요 없어지면 바로 해제하세요.
         </>
@@ -54,7 +56,7 @@ export function ChannelPermissionsPageContent({ creator }: Props) {
           <div className="border-destructive/20 bg-destructive/5 text-destructive flex flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center">
             <TriangleAlert className="size-6" />
             <p className="text-sm font-medium">
-              매니저 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
+              {getAppMessage(APP_MESSAGE_CODE.error.channel.managerListLoadFailed).description}
             </p>
           </div>
         ) : (

--- a/src/components/channel/moderation/channel-permissions-page-content.tsx
+++ b/src/components/channel/moderation/channel-permissions-page-content.tsx
@@ -1,0 +1,78 @@
+"use client";
+// 채널 권한 관리 화면 — 매니저 추가 폼 + 권한 목록(스트리머 본인 + 매니저). 데이터는 TanStack 캐시(useChannelManagers)가 소유한다.
+
+import { useMemo } from "react";
+
+import { TriangleAlert } from "lucide-react";
+
+import { ChannelManagerAddForm } from "@/components/channel/moderation/channel-manager-add-form";
+import { ChannelManagerTable } from "@/components/channel/moderation/channel-manager-table";
+import { SettingsPage } from "@/components/common/settings-page";
+import { Spinner } from "@/components/ui/spinner";
+import { useChannelManagers } from "@/hooks/channel/use-channel-managers";
+import type { ChannelOwnerIdentity } from "@/types/channel/moderation";
+
+interface Props {
+  creator: ChannelOwnerIdentity;
+}
+
+export function ChannelPermissionsPageContent({ creator }: Props) {
+  const { managers, isLoading, isError, addManager, isAdding, removeManager, isRemoving } =
+    useChannelManagers(creator.id);
+
+  const existingManagerIds = useMemo(
+    () => new Set(managers.map((manager) => manager.managerId)),
+    [managers],
+  );
+
+  return (
+    <SettingsPage
+      kicker="권한 관리"
+      title="채널 매니저를 관리해요"
+      description={
+        <>
+          매니저는 채팅에서 시청자를 강퇴할 수 있어요.
+          <br />
+          믿을 수 있는 시청자에게만 권한을 주고, 필요 없어지면 바로 해제하세요.
+        </>
+      }
+    >
+      <div className="flex flex-col gap-6">
+        <ChannelManagerAddForm
+          creatorId={creator.id}
+          existingManagerIds={existingManagerIds}
+          onAdd={addManager}
+          isAdding={isAdding}
+        />
+
+        {isLoading ? (
+          <div className="text-muted-foreground flex items-center justify-center gap-2 py-10 text-sm">
+            <Spinner className="size-4" />
+            매니저 목록을 불러오는 중이에요.
+          </div>
+        ) : isError ? (
+          <div className="border-destructive/20 bg-destructive/5 text-destructive flex flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center">
+            <TriangleAlert className="size-6" />
+            <p className="text-sm font-medium">
+              매니저 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <ChannelManagerTable
+              creator={creator}
+              managers={managers}
+              onRemove={removeManager}
+              isRemoving={isRemoving}
+            />
+            {managers.length === 0 && (
+              <p className="text-muted-foreground text-center text-sm">
+                아직 매니저가 없어요. 위에서 시청자를 검색해 추가해 보세요.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </SettingsPage>
+  );
+}

--- a/src/constants/channel/channel-menu.ts
+++ b/src/constants/channel/channel-menu.ts
@@ -6,6 +6,7 @@ import {
   MessageSquareText,
   ShieldCheck,
   SlidersHorizontal,
+  Users,
 } from "lucide-react";
 
 export interface ChannelMenuGroup {
@@ -48,6 +49,7 @@ export const CHANNEL_MENU_GROUPS: ChannelMenuGroup[] = [
           { id: "analytics-report", label: "지난 방송 분석", href: "/channel/analytics/report" },
         ],
       },
+      { id: "permissions", label: "권한 관리", href: "/channel/permissions", icon: Users },
       { id: "security", label: "방송 연결", href: "/channel/security", icon: ShieldCheck },
     ],
   },

--- a/src/constants/common/app-message-code.ts
+++ b/src/constants/common/app-message-code.ts
@@ -145,6 +145,7 @@ export const APP_MESSAGE_CODE = {
       bannerDeleteFailed: "error.channel.bannerDeleteFailed",
       bannerImageTooLarge: "error.channel.bannerImageTooLarge",
       bannerLimitReached: "error.channel.bannerLimitReached",
+      managerListLoadFailed: "error.channel.managerListLoadFailed",
       managerAddFailed: "error.channel.managerAddFailed",
       managerRemoveFailed: "error.channel.managerRemoveFailed",
       managerAlreadyExists: "error.channel.managerAlreadyExists",

--- a/src/constants/common/app-message-code.ts
+++ b/src/constants/common/app-message-code.ts
@@ -30,6 +30,8 @@ export const APP_MESSAGE_CODE = {
       channelProfileSaved: "success.channel.channelProfileSaved",
       bannerSaved: "success.channel.bannerSaved",
       bannerDeleted: "success.channel.bannerDeleted",
+      managerAdded: "success.channel.managerAdded",
+      managerRemoved: "success.channel.managerRemoved",
     },
     following: {
       followed: "success.following.followed",
@@ -143,6 +145,11 @@ export const APP_MESSAGE_CODE = {
       bannerDeleteFailed: "error.channel.bannerDeleteFailed",
       bannerImageTooLarge: "error.channel.bannerImageTooLarge",
       bannerLimitReached: "error.channel.bannerLimitReached",
+      managerAddFailed: "error.channel.managerAddFailed",
+      managerRemoveFailed: "error.channel.managerRemoveFailed",
+      managerAlreadyExists: "error.channel.managerAlreadyExists",
+      managerSelfForbidden: "error.channel.managerSelfForbidden",
+      userSearchFailed: "error.channel.userSearchFailed",
     },
     following: {
       failed: "error.following.failed",

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -78,6 +78,12 @@ export const APP_MESSAGE = {
       bannerDeleted: {
         title: "배너 삭제 완료",
       },
+      managerAdded: {
+        title: "매니저 추가 완료",
+      },
+      managerRemoved: {
+        title: "매니저 해제 완료",
+      },
     },
     following: {
       followed: {
@@ -423,6 +429,26 @@ export const APP_MESSAGE = {
       bannerLimitReached: {
         title: "배너 개수 초과",
         description: "배너는 최대 5개까지 등록할 수 있어요.",
+      },
+      managerAddFailed: {
+        title: "매니저 추가 실패",
+        description: "잠시 후 다시 시도해주세요.",
+      },
+      managerRemoveFailed: {
+        title: "매니저 해제 실패",
+        description: "잠시 후 다시 시도해주세요.",
+      },
+      managerAlreadyExists: {
+        title: "이미 매니저",
+        description: "이미 매니저로 등록된 유저예요.",
+      },
+      managerSelfForbidden: {
+        title: "본인 지정 불가",
+        description: "자신을 매니저로 지정할 수 없어요.",
+      },
+      userSearchFailed: {
+        title: "유저 검색 실패",
+        description: "잠시 후 다시 검색해 주세요.",
       },
     },
     following: {

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -430,6 +430,10 @@ export const APP_MESSAGE = {
         title: "배너 개수 초과",
         description: "배너는 최대 5개까지 등록할 수 있어요.",
       },
+      managerListLoadFailed: {
+        title: "매니저 목록 조회 실패",
+        description: "다시 로그인하거나 잠시 후 새로고침해주세요.",
+      },
       managerAddFailed: {
         title: "매니저 추가 실패",
         description: "잠시 후 다시 시도해주세요.",

--- a/src/constants/common/query-keys.ts
+++ b/src/constants/common/query-keys.ts
@@ -110,6 +110,8 @@ export const QUERY_KEYS = {
       [...QUERY_KEYS.channel.all, "analytics", "follow-feed", creatorId].filter(
         (v) => v !== undefined,
       ),
+    managers: (creatorId?: string) =>
+      [...QUERY_KEYS.channel.all, "managers", creatorId].filter((v) => v !== undefined),
   },
   notification: {
     all: ["notification"] as const,

--- a/src/constants/common/query-keys.ts
+++ b/src/constants/common/query-keys.ts
@@ -110,8 +110,9 @@ export const QUERY_KEYS = {
       [...QUERY_KEYS.channel.all, "analytics", "follow-feed", creatorId].filter(
         (v) => v !== undefined,
       ),
+    managersAll: () => [...QUERY_KEYS.channel.all, "managers"],
     managers: (creatorId?: string) =>
-      [...QUERY_KEYS.channel.all, "managers", creatorId].filter((v) => v !== undefined),
+      [...QUERY_KEYS.channel.managersAll(), creatorId].filter((v) => v !== undefined),
   },
   notification: {
     all: ["notification"] as const,

--- a/src/hooks/channel/use-channel-managers.ts
+++ b/src/hooks/channel/use-channel-managers.ts
@@ -1,0 +1,95 @@
+"use client";
+// 채널 매니저 목록 조회 + 추가/해제. get_channel_managers 는 authenticated grant + 내부 auth.uid()=creator
+// 검증이라 브라우저 client 로 직접 조회하고, 추가/해제는 서버 액션(service_role RPC) 후 목록을 무효화한다.
+
+import { useMemo } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { addChannelManagerAction, removeChannelManagerAction } from "@/actions/channel/moderation";
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { createClient } from "@/lib/supabase/client";
+import type { ChannelManagerItem } from "@/types/channel/moderation";
+import { parseChannelManagers } from "@/utils/channel/channel-moderation";
+import { toastAppError, toastAppSuccess } from "@/utils/common/toast-message";
+
+export function useChannelManagers(creatorId: string) {
+  const supabase = useMemo(() => createClient(), []);
+  const queryClient = useQueryClient();
+
+  const query = useQuery<ChannelManagerItem[]>({
+    queryKey: QUERY_KEYS.channel.managers(creatorId),
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc("get_channel_managers", {
+        p_creator_id: creatorId,
+      });
+
+      if (error) {
+        console.error("매니저 목록 조회 실패", error);
+        throw error;
+      }
+
+      return parseChannelManagers(data);
+    },
+    enabled: Boolean(creatorId),
+  });
+
+  const invalidateManagers = () =>
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.channel.managers(creatorId) });
+
+  const addMutation = useMutation({
+    mutationFn: (targetUserId: string) => addChannelManagerAction(targetUserId),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toastAppError(result.code ?? APP_MESSAGE_CODE.error.channel.managerAddFailed);
+        return;
+      }
+      await invalidateManagers();
+      toastAppSuccess(result.code ?? APP_MESSAGE_CODE.success.channel.managerAdded);
+    },
+    onError: (error) => {
+      console.error("매니저 추가 요청 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.channel.managerAddFailed);
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (targetUserId: string) => removeChannelManagerAction(targetUserId),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toastAppError(result.code ?? APP_MESSAGE_CODE.error.channel.managerRemoveFailed);
+        return;
+      }
+      await invalidateManagers();
+      toastAppSuccess(result.code ?? APP_MESSAGE_CODE.success.channel.managerRemoved);
+    },
+    onError: (error) => {
+      console.error("매니저 해제 요청 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.channel.managerRemoveFailed);
+    },
+  });
+
+  // 추가/해제 핸들러는 성공 여부(boolean)를 돌려줘 폼·다이얼로그가 입력 초기화/닫기를 결정한다.
+  const addManager = async (targetUserId: string): Promise<boolean> => {
+    const result = await addMutation.mutateAsync(targetUserId).catch(() => null);
+    return Boolean(result?.success);
+  };
+
+  const removeManager = async (targetUserId: string): Promise<boolean> => {
+    const result = await removeMutation.mutateAsync(targetUserId).catch(() => null);
+    return Boolean(result?.success);
+  };
+
+  return {
+    managers: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    addManager,
+    isAdding: addMutation.isPending,
+    removeManager,
+    isRemoving: removeMutation.isPending,
+  };
+}
+
+export type ChannelManagersController = ReturnType<typeof useChannelManagers>;

--- a/src/types/channel/moderation.ts
+++ b/src/types/channel/moderation.ts
@@ -1,0 +1,27 @@
+// 채널 운영(매니저 권한 / 시청자 제재) 도메인 타입.
+// RPC jsonb 응답을 정규화한 앱 도메인 모델이며, 정규화는 utils/channel/channel-moderation.ts 가 담당한다.
+
+// get_channel_managers 의 item — 활성 매니저 관계 1건(최신 닉네임/사진은 user 조인 결과).
+export interface ChannelManagerItem {
+  managerRelationId: string;
+  managerId: string;
+  managerNickname: string;
+  managerPhotoUrl: string | null;
+  createdById: string | null;
+  createdByNickname: string | null;
+  createdAt: string;
+}
+
+// search_channel_users 의 후보 — 닉네임/UUID 정확일치로 찾은 유저.
+export interface ChannelUserCandidate {
+  userId: string;
+  nickname: string;
+  photoUrl: string | null;
+}
+
+// 권한 화면 목록 맨 위에 고정하는 스트리머 본인(크리에이터) 식별 정보.
+export interface ChannelOwnerIdentity {
+  id: string;
+  nickname: string;
+  photoUrl: string | null;
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1520,6 +1520,10 @@ export type Database = {
         Args: { p_actor_user_id: string; p_liked: boolean; p_post_id: string }
         Returns: Json
       }
+      set_live_message_cleanbot_status: {
+        Args: { p_message_ids: string[]; p_status: string }
+        Returns: undefined
+      }
       start_live_broadcast: {
         Args: {
           p_actor_user_id: string

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -52,6 +52,52 @@ export type Database = {
           },
         ]
       }
+      channel_manager: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          creator_id: string
+          id: string
+          manager_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          creator_id: string
+          id?: string
+          manager_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          creator_id?: string
+          id?: string
+          manager_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "channel_manager_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "channel_manager_creator_id_fkey"
+            columns: ["creator_id"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "channel_manager_manager_id_fkey"
+            columns: ["manager_id"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       chat_room: {
         Row: {
           created_at: string
@@ -1030,6 +1076,10 @@ export type Database = {
         Args: { p_actor_user_id: string; p_creator_id: string }
         Returns: number
       }
+      add_channel_manager: {
+        Args: { p_actor_user_id: string; p_target_user_id: string }
+        Returns: Json
+      }
       anonymous_donor_alias: { Args: { p_donor_id: string }; Returns: string }
       check_email_exists: { Args: { target_email: string }; Returns: boolean }
       community_comment_to_json: {
@@ -1140,6 +1190,7 @@ export type Database = {
         Args: { p_creator_id: string; p_viewer_id?: string }
         Returns: Json
       }
+      get_channel_managers: { Args: { p_creator_id: string }; Returns: Json }
       get_channel_profile: {
         Args: { p_creator_id: string; p_viewer_id?: string }
         Returns: Json
@@ -1266,6 +1317,7 @@ export type Database = {
       }
       get_live_popular_keywords: { Args: { p_limit?: number }; Returns: Json }
       get_live_sync_cron_secret: { Args: never; Returns: string }
+      get_live_thumbnail_ingest_secret: { Args: never; Returns: string }
       get_live_watch: {
         Args: { p_creator_id: string; p_viewer_id?: string }
         Returns: Json
@@ -1330,6 +1382,10 @@ export type Database = {
         Args: { p_broadcast_id: string }
         Returns: number
       }
+      remove_channel_manager: {
+        Args: { p_actor_user_id: string; p_target_user_id: string }
+        Returns: undefined
+      }
       reorder_channel_banners: {
         Args: { p_actor_user_id: string; p_banner_ids: string[] }
         Returns: Json
@@ -1338,6 +1394,7 @@ export type Database = {
         Args: { p_actor_user_id: string; p_token_kind: string }
         Returns: Json
       }
+      search_channel_users: { Args: { p_query: string }; Returns: Json }
       search_chat_rooms: {
         Args: {
           p_limit?: number
@@ -1436,6 +1493,14 @@ export type Database = {
         Returns: Json
       }
       send_live_message_v3: {
+        Args: {
+          p_actor_user_id: string
+          p_content: string
+          p_creator_id: string
+        }
+        Returns: Json
+      }
+      send_live_message_v4: {
         Args: {
           p_actor_user_id: string
           p_content: string

--- a/src/utils/channel/channel-moderation.ts
+++ b/src/utils/channel/channel-moderation.ts
@@ -1,0 +1,80 @@
+// 채널 운영 RPC(jsonb) 응답을 화면 도메인 타입으로 정규화한다.
+// get_channel_managers / search_channel_users 는 { items: [...] } 형태를 반환한다.
+import type { ChannelManagerItem, ChannelUserCandidate } from "@/types/channel/moderation";
+import type { Json } from "@/types/database.types";
+
+function readObject(value: Json | undefined): Record<string, Json | undefined> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, Json | undefined>;
+}
+
+function readItems(value: Json): Json[] {
+  const object = readObject(value);
+  const items = object?.items;
+
+  return Array.isArray(items) ? items : [];
+}
+
+function readString(value: Json | undefined): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// get_channel_managers jsonb → ChannelManagerItem[]. managerId/닉네임/등록일이 없으면 깨진 행이라 버린다.
+export function parseChannelManagers(value: Json): ChannelManagerItem[] {
+  return readItems(value)
+    .map((item) => {
+      const object = readObject(item);
+      if (!object) {
+        return null;
+      }
+
+      const managerRelationId = readString(object.managerRelationId);
+      const managerId = readString(object.managerId);
+      const createdAt = readString(object.createdAt);
+
+      if (!managerRelationId || !managerId || !createdAt) {
+        return null;
+      }
+
+      return {
+        managerRelationId,
+        managerId,
+        managerNickname: readString(object.managerNickname) ?? "알 수 없음",
+        managerPhotoUrl: readString(object.managerPhotoUrl),
+        createdById: readString(object.createdById),
+        createdByNickname: readString(object.createdByNickname),
+        createdAt,
+      } satisfies ChannelManagerItem;
+    })
+    .filter((item): item is ChannelManagerItem => item !== null);
+}
+
+// search_channel_users jsonb → ChannelUserCandidate[]. userId/닉네임이 없으면 버린다.
+export function parseChannelUserCandidates(value: Json): ChannelUserCandidate[] {
+  return readItems(value)
+    .map((item) => {
+      const object = readObject(item);
+      if (!object) {
+        return null;
+      }
+
+      const userId = readString(object.userId);
+      const nickname = readString(object.nickname);
+
+      if (!userId || !nickname) {
+        return null;
+      }
+
+      return {
+        userId,
+        nickname,
+        photoUrl: readString(object.photoUrl),
+      } satisfies ChannelUserCandidate;
+    })
+    .filter((item): item is ChannelUserCandidate => item !== null);
+}

--- a/src/utils/channel/channel-moderation.ts
+++ b/src/utils/channel/channel-moderation.ts
@@ -35,16 +35,18 @@ export function parseChannelManagers(value: Json): ChannelManagerItem[] {
 
       const managerRelationId = readString(object.managerRelationId);
       const managerId = readString(object.managerId);
+      const managerNickname = readString(object.managerNickname);
       const createdAt = readString(object.createdAt);
 
-      if (!managerRelationId || !managerId || !createdAt) {
+      // 닉네임은 목록·해제 다이얼로그가 대상을 식별하는 필수 필드라, 누락되면 깨진 행으로 보고 버린다.
+      if (!managerRelationId || !managerId || !managerNickname || !createdAt) {
         return null;
       }
 
       return {
         managerRelationId,
         managerId,
-        managerNickname: readString(object.managerNickname) ?? "알 수 없음",
+        managerNickname,
         managerPhotoUrl: readString(object.managerPhotoUrl),
         createdById: readString(object.createdById),
         createdByNickname: readString(object.createdByNickname),

--- a/supabase/migrations/20260612090000_create_channel_manager.sql
+++ b/supabase/migrations/20260612090000_create_channel_manager.sql
@@ -1,0 +1,31 @@
+-- 채널 매니저(운영진) 관계 테이블(#118).
+-- 매니저는 "역할"이 아니라 채널(creator)↔유저(manager)의 활성 관계다.
+-- 이력 보존이 아니라 현재 상태만 필요하므로(해제=관계 삭제) 단일 active 관계 테이블로 둔다.
+-- 닉네임은 비정규화하지 않는다 — 활성 관계라 항상 최신 닉네임이 정답이고, 조회 RPC가 user를 조인한다.
+
+create table if not exists public.channel_manager (
+  id uuid primary key default gen_random_uuid(),
+  creator_id uuid not null references public."user"(id) on delete cascade,
+  manager_id uuid not null references public."user"(id) on delete cascade,
+  created_by uuid references public."user"(id) on delete set null,
+  created_at timestamp with time zone not null default now(),
+  constraint channel_manager_no_self check (creator_id <> manager_id),
+  -- 중복 부여 방지 + (creator_id, manager_id) 프리픽스로 매니저 판정/목록 조회 커버.
+  constraint channel_manager_creator_manager_unique unique (creator_id, manager_id)
+);
+
+alter table public.channel_manager enable row level security;
+
+-- 크리에이터 본인 또는 매니저 본인만 조회한다(쓰기는 security definer RPC 전용).
+drop policy if exists channel_manager_select_related on public.channel_manager;
+create policy channel_manager_select_related
+  on public.channel_manager
+  for select
+  to authenticated
+  using (creator_id = (select auth.uid()) or manager_id = (select auth.uid()));
+
+grant select on table public.channel_manager to authenticated;
+
+-- 매니저 추가 검색의 닉네임 정확일치(=) 조회용 plain btree.
+create index if not exists user_nickname_idx
+  on public."user" (nickname);

--- a/supabase/migrations/20260612090100_add_channel_manager_rpcs.sql
+++ b/supabase/migrations/20260612090100_add_channel_manager_rpcs.sql
@@ -1,0 +1,172 @@
+-- 채널 매니저 권한 관리 RPC 4종(#118).
+-- add/remove/search 는 신뢰 파라미터(p_actor_user_id)를 받는 service_role 전용(서버 액션에서만 호출).
+-- get 은 auth.uid() 기반 본인 검증이라 authenticated 에 직접 grant(브라우저 TanStack Query).
+
+-- 1) 매니저 추가 — 채널 주인(actor) 본인만. 본인 지정·중복 부여를 거부한다.
+--    (활성 밴 유저 지정 거부 가드는 channel_viewer_ban 도입 이슈 #119에서 추가한다.)
+create or replace function public.add_channel_manager(p_actor_user_id uuid, p_target_user_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_id uuid;
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  if p_target_user_id is null then
+    raise sqlstate 'PX400' using message = 'invalid target';
+  end if;
+
+  if p_actor_user_id = p_target_user_id then
+    raise sqlstate 'PX400' using message = 'cannot grant manager to self';
+  end if;
+
+  if not exists (
+    select 1 from public."user" as target_user where target_user.id = p_target_user_id
+  ) then
+    raise sqlstate 'PX404' using message = 'target user not found';
+  end if;
+
+  if exists (
+    select 1 from public.channel_manager as manager
+    where manager.creator_id = p_actor_user_id and manager.manager_id = p_target_user_id
+  ) then
+    raise sqlstate 'PX409' using message = 'already a manager';
+  end if;
+
+  insert into public.channel_manager (creator_id, manager_id, created_by)
+  values (p_actor_user_id, p_target_user_id, p_actor_user_id)
+  returning id into v_id;
+
+  return jsonb_build_object('managerRelationId', v_id);
+end;
+$function$;
+
+-- 2) 매니저 해제 — 채널 주인 본인만. 멱등(없는 관계 삭제는 no-op).
+create or replace function public.remove_channel_manager(p_actor_user_id uuid, p_target_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  delete from public.channel_manager as manager
+  where manager.creator_id = p_actor_user_id and manager.manager_id = p_target_user_id;
+end;
+$function$;
+
+-- 3) 매니저 목록 — 채널 주인 본인만(auth.uid()=p_creator_id). user 조인으로 최신 닉네임/사진 반환.
+create or replace function public.get_channel_managers(p_creator_id uuid)
+returns jsonb
+language plpgsql
+stable security definer
+set search_path to ''
+as $function$
+declare
+  v_viewer_id uuid := auth.uid();
+  v_items jsonb;
+begin
+  if v_viewer_id is null or v_viewer_id <> p_creator_id then
+    raise sqlstate 'PX403' using message = 'forbidden';
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'managerRelationId', manager.id,
+        'managerId', manager.manager_id,
+        'managerNickname', manager_user.nickname,
+        'managerPhotoUrl', manager_user.photo_url,
+        'createdById', manager.created_by,
+        'createdByNickname', creator_user.nickname,
+        'createdAt', manager.created_at
+      )
+      order by manager.created_at desc
+    ),
+    '[]'::jsonb
+  )
+  into v_items
+  from public.channel_manager as manager
+  join public."user" as manager_user on manager_user.id = manager.manager_id
+  left join public."user" as creator_user on creator_user.id = manager.created_by
+  where manager.creator_id = p_creator_id;
+
+  return jsonb_build_object('items', v_items);
+end;
+$function$;
+
+-- 4) 유저 검색 — UUID 정확일치 또는 닉네임 정확일치(최대 10). 신뢰 파라미터 없이 동작하지만
+--    전 유저 디렉토리 노출을 막으려 부분검색을 의도적으로 배제하고 service_role 전용으로 잠근다.
+create or replace function public.search_channel_users(p_query text)
+returns jsonb
+language plpgsql
+stable security definer
+set search_path to ''
+as $function$
+declare
+  v_query text := btrim(coalesce(p_query, ''));
+  v_uuid uuid;
+  v_items jsonb;
+begin
+  if char_length(v_query) = 0 then
+    return jsonb_build_object('items', '[]'::jsonb);
+  end if;
+
+  begin
+    v_uuid := v_query::uuid;
+  exception when others then
+    v_uuid := null;
+  end;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'userId', matched.id,
+        'nickname', matched.nickname,
+        'photoUrl', matched.photo_url
+      )
+      order by matched.nickname asc
+    ),
+    '[]'::jsonb
+  )
+  into v_items
+  from (
+    select target_user.id, target_user.nickname, target_user.photo_url
+    from public."user" as target_user
+    where target_user.nickname = v_query
+      or (v_uuid is not null and target_user.id = v_uuid)
+    order by target_user.nickname asc
+    limit 10
+  ) as matched;
+
+  return jsonb_build_object('items', v_items);
+end;
+$function$;
+
+-- 실행 권한: add/remove/search 는 service_role 전용, get 은 authenticated.
+revoke execute on function public.add_channel_manager(uuid, uuid) from public;
+revoke execute on function public.add_channel_manager(uuid, uuid) from anon;
+revoke execute on function public.add_channel_manager(uuid, uuid) from authenticated;
+grant execute on function public.add_channel_manager(uuid, uuid) to service_role;
+
+revoke execute on function public.remove_channel_manager(uuid, uuid) from public;
+revoke execute on function public.remove_channel_manager(uuid, uuid) from anon;
+revoke execute on function public.remove_channel_manager(uuid, uuid) from authenticated;
+grant execute on function public.remove_channel_manager(uuid, uuid) to service_role;
+
+revoke execute on function public.search_channel_users(text) from public;
+revoke execute on function public.search_channel_users(text) from anon;
+revoke execute on function public.search_channel_users(text) from authenticated;
+grant execute on function public.search_channel_users(text) to service_role;
+
+revoke execute on function public.get_channel_managers(uuid) from public;
+grant execute on function public.get_channel_managers(uuid) to authenticated;
+grant execute on function public.get_channel_managers(uuid) to service_role;

--- a/supabase/migrations/20260612090200_extend_get_live_watch_manager.sql
+++ b/supabase/migrations/20260612090200_extend_get_live_watch_manager.sql
@@ -4,12 +4,22 @@
 --   ② chat_scope='manager' 게이트에서 활성 매니저는 통과시킨다(기존엔 크리에이터만 통과).
 -- 사용처 전수 확인 결과 get_live_watch 는 use-live-view-data → live-view + chat-popout(둘 다 시청 화면)뿐이라
 -- additive 수정을 적용한다(밴 확장 isBanned/'banned' 는 이슈 #119에서 2차로 추가).
+--
+-- 보안 가드: 이 함수는 SECURITY DEFINER 이고 anon/authenticated 에 공개돼 있어, p_viewer_id 를 그대로
+-- 신뢰하면 임의 호출자가 타인의 UUID 를 넣어 팔로우/매니저 여부·채팅 규칙 동의·채팅 가능 상태를 조회할 수 있다.
+-- p_viewer_id 는 호출자 본인(auth.uid())과 일치할 때만 사용하고, 불일치 시 null 로 강등한다(viewer CTE).
+-- 정상 호출은 항상 본인 id 를 넘기므로(use-live-view-data: p_viewer_id = user.id) 무영향이고,
+-- 비로그인(anon)은 p_viewer_id=null·auth.uid()=null 이라 기존과 동일하다.
+-- MVP(20260527121136)부터 이어진 선재 패턴이라, 이 함수를 통째로 재정의하는 본 버전에 가드를 함께 넣는다.
 create or replace function public.get_live_watch(p_creator_id uuid, p_viewer_id uuid default null::uuid)
  returns jsonb
  language sql
  stable security definer
  set search_path to ''
 as $function$
+  with viewer as (
+    select case when p_viewer_id = auth.uid() then p_viewer_id else null end as id
+  )
   select coalesce(
     (
       select jsonb_build_object(
@@ -46,7 +56,7 @@ as $function$
           'donationAmountVisible', coalesce(setting.donation_amount_visible, true)
         ),
         'viewerRelation', case
-          when p_viewer_id is null then 'null'::jsonb
+          when viewer.id is null then 'null'::jsonb
           else jsonb_build_object(
             'isFollowing', relation.followed_at is not null,
             'followedAt', relation.followed_at,
@@ -56,8 +66,8 @@ as $function$
           )
         end,
         'viewerChatState', case
-          when p_viewer_id is null then jsonb_build_object('canChat', false, 'blockedReason', 'login_required', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
-          when p_viewer_id = creator.id then jsonb_build_object('canChat', true, 'blockedReason', 'null'::jsonb, 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when viewer.id is null then jsonb_build_object('canChat', false, 'blockedReason', 'login_required', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when viewer.id = creator.id then jsonb_build_object('canChat', true, 'blockedReason', 'null'::jsonb, 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
           when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'manager'::public.live_chat_scope and not coalesce(manager.is_manager, false) then jsonb_build_object('canChat', false, 'blockedReason', 'manager_only', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
           when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'follower'::public.live_chat_scope and relation.followed_at is null then jsonb_build_object('canChat', false, 'blockedReason', 'follower_required', 'remainingFollowWaitSeconds', coalesce(setting.follower_wait_seconds, 0), 'remainingSlowModeSeconds', 0)
           when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'follower'::public.live_chat_scope and relation.followed_at > now() - make_interval(secs => coalesce(setting.follower_wait_seconds, 0)) then jsonb_build_object('canChat', false, 'blockedReason', 'follower_wait_required', 'remainingFollowWaitSeconds', greatest(ceil(extract(epoch from relation.followed_at + make_interval(secs => coalesce(setting.follower_wait_seconds, 0)) - now()))::integer, 0), 'remainingSlowModeSeconds', 0)
@@ -66,7 +76,8 @@ as $function$
           else jsonb_build_object('canChat', true, 'blockedReason', 'null'::jsonb, 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
         end
       )
-      from public."user" as creator
+      from viewer
+      cross join public."user" as creator
       left join public.creator_studio_setting as setting on setting.creator_id = creator.id
       left join lateral (
         select *
@@ -75,18 +86,18 @@ as $function$
         order by active_broadcast.started_at desc
         limit 1
       ) as broadcast on true
-      left join public.viewer_creator_relation as relation on relation.creator_id = creator.id and relation.viewer_id = p_viewer_id
+      left join public.viewer_creator_relation as relation on relation.creator_id = creator.id and relation.viewer_id = viewer.id
       left join lateral (
         select exists (
           select 1
           from public.channel_manager as cm
-          where cm.creator_id = creator.id and cm.manager_id = p_viewer_id
+          where cm.creator_id = creator.id and cm.manager_id = viewer.id
         ) as is_manager
       ) as manager on true
       left join lateral (
         select message.created_at
         from public.live_message as message
-        where message.creator_id = creator.id and message.sender_id = p_viewer_id and message.message_type = 'chat'::public.live_message_type
+        where message.creator_id = creator.id and message.sender_id = viewer.id and message.message_type = 'chat'::public.live_message_type
         order by message.created_at desc
         limit 1
       ) as last_chat on true

--- a/supabase/migrations/20260612090200_extend_get_live_watch_manager.sql
+++ b/supabase/migrations/20260612090200_extend_get_live_watch_manager.sql
@@ -1,0 +1,103 @@
+-- get_live_watch 매니저 확장(#118).
+-- 최신본(20260611143709)을 기반으로 두 가지만 additive 로 추가한다.
+--   ① viewerRelation.isManager — 시청 화면이 유저관리/매니저 분기를 노출할 수 있게.
+--   ② chat_scope='manager' 게이트에서 활성 매니저는 통과시킨다(기존엔 크리에이터만 통과).
+-- 사용처 전수 확인 결과 get_live_watch 는 use-live-view-data → live-view + chat-popout(둘 다 시청 화면)뿐이라
+-- additive 수정을 적용한다(밴 확장 isBanned/'banned' 는 이슈 #119에서 2차로 추가).
+create or replace function public.get_live_watch(p_creator_id uuid, p_viewer_id uuid default null::uuid)
+ returns jsonb
+ language sql
+ stable security definer
+ set search_path to ''
+as $function$
+  select coalesce(
+    (
+      select jsonb_build_object(
+        'creator', jsonb_build_object(
+          'id', creator.id,
+          'nickname', creator.nickname,
+          'photoUrl', creator.photo_url
+        ),
+        'broadcast', case
+          when broadcast.id is null then 'null'::jsonb
+          else jsonb_build_object(
+            'id', broadcast.id,
+            'title', broadcast.title,
+            'tags', broadcast.tags,
+            'thumbnailUrl', broadcast.thumbnail_url,
+            'startedAt', broadcast.started_at,
+            'currentViewerCount', broadcast.current_viewer_count,
+            'peakViewerCount', broadcast.peak_viewer_count,
+            'chatMessageCount', broadcast.chat_message_count,
+            'donationCount', broadcast.donation_count,
+            'donationAmountTotal', broadcast.donation_amount_total
+          )
+        end,
+        'settings', jsonb_build_object(
+          'chatScope', coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope),
+          'followerWaitSeconds', coalesce(setting.follower_wait_seconds, 0),
+          'slowModeEnabled', coalesce(setting.slow_mode_enabled, false),
+          'slowModeSeconds', coalesce(setting.slow_mode_seconds, 3),
+          'linkBlocked', coalesce(setting.link_blocked, true),
+          'chatRuleText', coalesce(setting.chat_rule_text, ''),
+          'chatRuleVersion', coalesce(setting.chat_rule_version, 1),
+          'donationEnabled', coalesce(setting.donation_enabled, true),
+          'donationMinAmount', coalesce(setting.donation_min_amount, 1000),
+          'donationAmountVisible', coalesce(setting.donation_amount_visible, true)
+        ),
+        'viewerRelation', case
+          when p_viewer_id is null then 'null'::jsonb
+          else jsonb_build_object(
+            'isFollowing', relation.followed_at is not null,
+            'followedAt', relation.followed_at,
+            'chatRuleAcceptedVersion', relation.chat_rule_accepted_version,
+            'chatRuleAcceptedAt', relation.chat_rule_accepted_at,
+            'isManager', coalesce(manager.is_manager, false)
+          )
+        end,
+        'viewerChatState', case
+          when p_viewer_id is null then jsonb_build_object('canChat', false, 'blockedReason', 'login_required', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when p_viewer_id = creator.id then jsonb_build_object('canChat', true, 'blockedReason', 'null'::jsonb, 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'manager'::public.live_chat_scope and not coalesce(manager.is_manager, false) then jsonb_build_object('canChat', false, 'blockedReason', 'manager_only', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'follower'::public.live_chat_scope and relation.followed_at is null then jsonb_build_object('canChat', false, 'blockedReason', 'follower_required', 'remainingFollowWaitSeconds', coalesce(setting.follower_wait_seconds, 0), 'remainingSlowModeSeconds', 0)
+          when coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'follower'::public.live_chat_scope and relation.followed_at > now() - make_interval(secs => coalesce(setting.follower_wait_seconds, 0)) then jsonb_build_object('canChat', false, 'blockedReason', 'follower_wait_required', 'remainingFollowWaitSeconds', greatest(ceil(extract(epoch from relation.followed_at + make_interval(secs => coalesce(setting.follower_wait_seconds, 0)) - now()))::integer, 0), 'remainingSlowModeSeconds', 0)
+          when char_length(coalesce(setting.chat_rule_text, '')) > 0 and coalesce(relation.chat_rule_accepted_version, 0) < coalesce(setting.chat_rule_version, 1) then jsonb_build_object('canChat', false, 'blockedReason', 'chat_rule_acceptance_required', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+          when coalesce(setting.slow_mode_enabled, false) and last_chat.created_at is not null and last_chat.created_at > now() - make_interval(secs => coalesce(setting.slow_mode_seconds, 3)) then jsonb_build_object('canChat', false, 'blockedReason', 'slow_mode_required', 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', greatest(ceil(extract(epoch from last_chat.created_at + make_interval(secs => coalesce(setting.slow_mode_seconds, 3)) - now()))::integer, 0))
+          else jsonb_build_object('canChat', true, 'blockedReason', 'null'::jsonb, 'remainingFollowWaitSeconds', 0, 'remainingSlowModeSeconds', 0)
+        end
+      )
+      from public."user" as creator
+      left join public.creator_studio_setting as setting on setting.creator_id = creator.id
+      left join lateral (
+        select *
+        from public.live_broadcast as active_broadcast
+        where active_broadcast.creator_id = creator.id and active_broadcast.ended_at is null
+        order by active_broadcast.started_at desc
+        limit 1
+      ) as broadcast on true
+      left join public.viewer_creator_relation as relation on relation.creator_id = creator.id and relation.viewer_id = p_viewer_id
+      left join lateral (
+        select exists (
+          select 1
+          from public.channel_manager as cm
+          where cm.creator_id = creator.id and cm.manager_id = p_viewer_id
+        ) as is_manager
+      ) as manager on true
+      left join lateral (
+        select message.created_at
+        from public.live_message as message
+        where message.creator_id = creator.id and message.sender_id = p_viewer_id and message.message_type = 'chat'::public.live_message_type
+        order by message.created_at desc
+        limit 1
+      ) as last_chat on true
+      where creator.id = p_creator_id
+      limit 1
+    ),
+    'null'::jsonb
+  );
+$function$;
+
+revoke execute on function public.get_live_watch(uuid, uuid) from public;
+grant execute on function public.get_live_watch(uuid, uuid) to anon;
+grant execute on function public.get_live_watch(uuid, uuid) to authenticated;
+grant execute on function public.get_live_watch(uuid, uuid) to service_role;

--- a/supabase/migrations/20260612090300_add_send_live_message_v4.sql
+++ b/supabase/migrations/20260612090300_add_send_live_message_v4.sql
@@ -1,0 +1,202 @@
+-- send_live_message_v4 — 매니저 확장(#118).
+-- v3(20260611072513)는 시청 화면 외 스튜디오 방송 운영 채팅 패널(channel-live-chat-panel.tsx)도 호출 중이라
+-- 수정 금지 원칙에 따라 동결하고, 매니저 확장분만 담은 v4 를 새로 만든다.
+-- v3 대비 차이:
+--   ① chat_scope='manager' 에서 활성 매니저(channel_manager)도 전송 허용(기존엔 크리에이터만).
+--   ② sender_role 스냅샷에 manager 티어 추가: creator > manager > donor > viewer.
+-- 스튜디오 패널은 크리에이터 본인만 사용하므로 v4 에서도 동작은 v3 와 완전히 동일하다
+--   (매니저 분기는 모두 p_actor_user_id <> p_creator_id 가드 안쪽이라 크리에이터는 영향 없음).
+-- (활성 밴 차단 PX403 은 channel_viewer_ban 도입 이슈 #119에서 v4 에 추가한다.)
+create or replace function public.send_live_message_v4(p_actor_user_id uuid, p_creator_id uuid, p_content text)
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to ''
+as $function$
+declare
+  v_content text := btrim(coalesce(p_content, ''));
+  v_broadcast_id uuid;
+  v_setting public.creator_studio_setting%rowtype;
+  v_relation public.viewer_creator_relation%rowtype;
+  v_last_message_at timestamp with time zone;
+  v_message_id uuid;
+  v_forbidden_word text;
+  v_sender record;
+  v_is_donor boolean := false;
+  v_is_manager boolean := false;
+  v_sender_role public.live_sender_role := 'viewer';
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  if p_creator_id is null then
+    raise sqlstate 'PX400' using message = 'invalid creator';
+  end if;
+
+  if char_length(v_content) = 0 or char_length(v_content) > 2000 then
+    raise sqlstate 'PX400' using message = 'invalid message content';
+  end if;
+
+  select
+    target_user.nickname,
+    target_user.photo_url
+  into v_sender
+  from public."user" as target_user
+  where target_user.id = p_actor_user_id;
+
+  if not found then
+    raise sqlstate 'PX404' using message = 'user not found';
+  end if;
+
+  if not exists (
+    select 1
+    from public."user" as creator
+    where creator.id = p_creator_id
+  ) then
+    raise sqlstate 'PX404' using message = 'creator not found';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_creator_id::text || ':' || p_actor_user_id::text, 0));
+
+  -- 활성 방송이 있으면 메시지를 방송에 귀속시키고, 없으면 채널 메시지로 기록한다.
+  select broadcast.id
+  into v_broadcast_id
+  from public.live_broadcast as broadcast
+  where broadcast.creator_id = p_creator_id
+    and broadcast.ended_at is null
+  order by broadcast.started_at desc
+  limit 1;
+
+  select *
+  into v_setting
+  from public.creator_studio_setting as setting
+  where setting.creator_id = p_creator_id;
+
+  select *
+  into v_relation
+  from public.viewer_creator_relation as relation
+  where relation.viewer_id = p_actor_user_id
+    and relation.creator_id = p_creator_id;
+
+  -- 활성 매니저 여부 — 매니저 전용 채팅 통과와 sender_role 스냅샷에 함께 쓴다.
+  select exists (
+    select 1
+    from public.channel_manager as manager
+    where manager.creator_id = p_creator_id and manager.manager_id = p_actor_user_id
+  )
+  into v_is_manager;
+
+  if coalesce(v_setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'manager'::public.live_chat_scope
+    and p_actor_user_id <> p_creator_id
+    and not v_is_manager then
+    raise sqlstate 'PX403' using message = 'manager only chat';
+  end if;
+
+  if coalesce(v_setting.chat_scope, 'authenticated'::public.live_chat_scope) = 'follower'::public.live_chat_scope
+    and p_actor_user_id <> p_creator_id then
+    if v_relation.followed_at is null then
+      raise sqlstate 'PX403' using message = 'follower only chat';
+    end if;
+
+    if v_relation.followed_at > now() - make_interval(secs => coalesce(v_setting.follower_wait_seconds, 0)) then
+      raise sqlstate 'PX403' using message = 'follower wait time required';
+    end if;
+  end if;
+
+  if char_length(coalesce(v_setting.chat_rule_text, '')) > 0
+    and p_actor_user_id <> p_creator_id
+    and coalesce(v_relation.chat_rule_accepted_version, 0) < coalesce(v_setting.chat_rule_version, 1) then
+    raise sqlstate 'PX428' using message = 'chat rule acceptance required';
+  end if;
+
+  if coalesce(v_setting.slow_mode_enabled, false)
+    and p_actor_user_id <> p_creator_id then
+    select message.created_at
+    into v_last_message_at
+    from public.live_message as message
+    where message.creator_id = p_creator_id
+      and message.sender_id = p_actor_user_id
+      and message.message_type = 'chat'::public.live_message_type
+    order by message.created_at desc
+    limit 1;
+
+    if v_last_message_at is not null
+      and v_last_message_at > now() - make_interval(secs => coalesce(v_setting.slow_mode_seconds, 3)) then
+      raise sqlstate 'PX429' using message = 'slow mode wait required';
+    end if;
+  end if;
+
+  if coalesce(v_setting.link_blocked, true)
+    and v_content ~* '(https?://|www\.)' then
+    raise sqlstate 'PX422' using message = 'link is blocked';
+  end if;
+
+  select word
+  into v_forbidden_word
+  from unnest(coalesce(v_setting.forbidden_words, '{}'::text[])) as word
+  where btrim(word) <> ''
+    and v_content ilike '%' || btrim(word) || '%'
+  limit 1;
+
+  -- 금칙어 매칭: 어떤 행도 insert하지 않는다(Realtime fan-out 0). 작성자 본인에게만
+  -- 안내가 보이도록 moderated 플래그만 돌려준다.
+  if v_forbidden_word is not null then
+    return jsonb_build_object(
+      'messageId', null,
+      'moderated', true
+    );
+  end if;
+
+  -- 이 크리에이터에게 후원 이력이 있으면 후원자 표시용 플래그를 메시지 메타데이터에 기록한다.
+  select exists (
+    select 1
+    from public.donation as donation
+    where donation.donor_id = p_actor_user_id
+      and donation.creator_id = p_creator_id
+  )
+  into v_is_donor;
+
+  -- 전송 시점 역할 스냅샷: 방장 > 매니저 > 후원자 > 일반. (subscriber 는 추후 기능 연결 시 확장한다)
+  v_sender_role := case
+    when p_actor_user_id = p_creator_id then 'creator'::public.live_sender_role
+    when v_is_manager then 'manager'::public.live_sender_role
+    when v_is_donor then 'donor'::public.live_sender_role
+    else 'viewer'::public.live_sender_role
+  end;
+
+  insert into public.live_message (
+    broadcast_id,
+    creator_id,
+    sender_id,
+    message_type,
+    content,
+    sender_role,
+    metadata
+  )
+  values (
+    v_broadcast_id,
+    p_creator_id,
+    p_actor_user_id,
+    'chat'::public.live_message_type,
+    v_content,
+    v_sender_role,
+    jsonb_build_object(
+      'senderNickname', v_sender.nickname,
+      'senderPhotoUrl', v_sender.photo_url,
+      'isDonor', v_is_donor
+    )
+  )
+  returning id into v_message_id;
+
+  return jsonb_build_object(
+    'messageId', v_message_id,
+    'moderated', false
+  );
+end;
+$function$;
+
+revoke execute on function public.send_live_message_v4(uuid, uuid, text) from public;
+revoke execute on function public.send_live_message_v4(uuid, uuid, text) from anon;
+revoke execute on function public.send_live_message_v4(uuid, uuid, text) from authenticated;
+grant execute on function public.send_live_message_v4(uuid, uuid, text) to service_role;

--- a/supabase/migrations/20260612090300_add_send_live_message_v4.sql
+++ b/supabase/migrations/20260612090300_add_send_live_message_v4.sql
@@ -132,11 +132,13 @@ begin
     raise sqlstate 'PX422' using message = 'link is blocked';
   end if;
 
+  -- 금칙어는 리터럴 부분문자열 검사로 비교한다. ilike '%word%' 는 word 안의 % / _ 가
+  -- 와일드카드로 해석돼(예: '100%' 가 '100abc' 매칭, '_' 하나로 거의 전체 차단) 오탐을 일으킨다.
   select word
   into v_forbidden_word
   from unnest(coalesce(v_setting.forbidden_words, '{}'::text[])) as word
   where btrim(word) <> ''
-    and v_content ilike '%' || btrim(word) || '%'
+    and position(lower(btrim(word)) in lower(v_content)) > 0
   limit 1;
 
   -- 금칙어 매칭: 어떤 행도 insert하지 않는다(Realtime fan-out 0). 작성자 본인에게만


### PR DESCRIPTION
### 📌 반영 브랜치
#### feat/channel/managers/#118 -> dev

### ✅ 작업 내용 `기능 추가`
스트리머가 시청자에게 매니저 권한을 부여/해제하는 관리 화면(`/channel/permissions`)과 매니저 효과(방패 뱃지·매니저 전용 채팅)를 구현했습니다. 후속 이슈 #119(강퇴/밴)가 본 PR의 `channel_manager`에 의존합니다.

**DB** (대시보드 SQL Editor 선적용 완료 → 마이그레이션 미러 + `npm run db:types`)
- `channel_manager` 테이블 + `user_nickname_idx`(닉네임 정확일치 검색용)
- RPC 4종: `add`/`remove`/`search_channel_users`(service_role), `get_channel_managers`(authenticated, 내부 `auth.uid()=creator` 검증)
- `get_live_watch` **additive 확장**: `isManager` + 매니저 전용 채팅 통과 (사용처가 시청 화면뿐이라 수정 허용)
- `send_live_message_v4` **신설**: v3는 스튜디오 채팅 패널도 사용 중이라 동결하고, 매니저 전송 허용 + `sender_role='manager'` 확장분만 담은 v4로 fork

**화면 / 데이터**
- `/channel/permissions`: 스트리머 본인을 목록 맨 위에 고정(크리에이터 → 매니저 순) + 닉네임/UUID 정확일치 검색 → 후보 선택 → 추가 / 해제(확인 모달)
- 사이드바 "관리" 그룹에 권한 관리 메뉴 추가
- 서버 액션(`search`/`add`/`remove`) + `useChannelManagers` 훅(조회 + 추가/해제 mutation, 캐시 무효화)
- 매니저 채팅 시 방패 뱃지 자동 노출(기존 `LiveChatRoleBadge`·`parseSenderRole` 재사용)

### 🎯 단독 테스트 결과
- 계정 2개(스트리머/매니저)로 검색 → 추가 → 목록(등록자/등록일) → 해제 전체 동작 확인
- 매니저 추가/해제가 **라이브 시청 화면에 실시간 반영**되는 것까지 확인
- 본인 지정 거부 / 중복 추가 시 "이미 매니저" 안내 정상
- `npm run typecheck` / `lint` / `build` / db:types diff 0 통과

### 🚨 연관 이슈
closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채널 권한 관리 페이지 추가: 크리에이터 기준 매니저 목록 조회, 매니저 추가/제거 UI(검색·추가·해제) 제공
  * 닉네임 또는 사용자 ID로 매니저 후보 검색 및 후보 선택으로 추가 가능
  * 매니저 목록의 데스크톱/모바일 최적화된 표시(표/카드)

* **개선 사항**
  * 라이브 채팅 처리 업그레이드: 매니저 권한 반영 및 전송 로직 업데이트
  * 사용자 알림 메시지(성공/오류 코드 및 설명) 확장 및 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->