### PR TITLE
feat(#129): 라이브 시청 화면의 후원 TossPayments 연동

### DIFF
--- a/src/app/live/[creatorId]/page.tsx
+++ b/src/app/live/[creatorId]/page.tsx
@@ -3,18 +3,26 @@
 
 import { getLivePlaybackUrl } from "@/app/live/[creatorId]/_data/live-playback-data";
 import LiveShell from "@/components/live/live-shell";
+import { PaymentResultToast } from "@/components/donations/payment-result-toast";
 import { LiveView } from "@/components/live/view/live-view";
+import { getPaymentResultCode } from "@/utils/payments/payment-result-code";
 
 interface Props {
   params: Promise<{ creatorId: string }>;
+  // 후원금 충전 결제 후 라이브 화면으로 복귀할 때 결과 토스트를 띄우기 위한 쿼리.
+  searchParams: Promise<{ paymentStatus?: string | string[] }>;
 }
 
-export default async function LiveWatchPage({ params }: Props) {
+export default async function LiveWatchPage({ params, searchParams }: Props) {
   const { creatorId } = await params;
+  const { paymentStatus } = await searchParams;
   const hlsSrc = await getLivePlaybackUrl(creatorId);
+  const paymentResultCode = getPaymentResultCode(paymentStatus);
 
   return (
     <LiveShell contentClassName="overflow-y-auto md:overflow-hidden">
+      {/* 충전 결제 후 복귀 시 결과 토스트(후원 지갑 화면과 동일 컴포넌트 재사용) — 표시 후 쿼리를 정리한다. */}
+      {paymentResultCode ? <PaymentResultToast code={paymentResultCode} /> : null}
       {/*
         key로 creatorId를 묶어, 같은 라우트(/live/[creatorId]) 안에서 다른 크리에이터로
         소프트 내비게이션할 때 LiveView를 재마운트해 시청 상태(sticky broadcastId·optimistic

--- a/src/app/user/donations/page.tsx
+++ b/src/app/user/donations/page.tsx
@@ -1,8 +1,7 @@
 // 사용자 후원 지갑 페이지를 렌더링합니다.
 import { getUserDonationSnapshot } from "@/app/user/donations/_data/user-donation-data";
 import { UserDonationsPage } from "@/components/donations/user-donations-page";
-import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
-import type { AppMessageCode } from "@/constants/common/app-message-code";
+import { getPaymentResultCode } from "@/utils/payments/payment-result-code";
 import type { Metadata } from "next";
 
 interface Props {
@@ -14,12 +13,6 @@ interface Props {
     paymentStatus?: string | string[];
   }>;
 }
-
-const PAYMENT_STATUS_MESSAGE_CODE: Record<string, AppMessageCode> = {
-  charge_success: APP_MESSAGE_CODE.success.donation.chargeConfirmed,
-  charge_failed: APP_MESSAGE_CODE.error.donation.chargeFailed,
-  charge_canceled: APP_MESSAGE_CODE.error.donation.chargeCanceled,
-};
 
 export const metadata: Metadata = {
   title: "후원 지갑",
@@ -37,12 +30,4 @@ export default async function UserDonationsRoutePage({ searchParams }: Props) {
       paymentResultCode={getPaymentResultCode(params.paymentStatus)}
     />
   );
-}
-
-function getPaymentResultCode(value: string | string[] | undefined) {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  return PAYMENT_STATUS_MESSAGE_CODE[value];
 }

--- a/src/app/user/donations/toss/fail/page.tsx
+++ b/src/app/user/donations/toss/fail/page.tsx
@@ -1,5 +1,5 @@
 // Toss Payments 결제 실패 리다이렉트를 안전한 후원 지갑 상태 메시지로 변환합니다.
-import { resolvePaymentReturnPath } from "@/utils/payments/payment-return-path";
+import { buildPaymentReturnRedirect } from "@/utils/payments/payment-return-path";
 import { markTossWalletChargeFailure } from "@/utils/payments/toss-wallet-charge";
 import { redirect } from "next/navigation";
 
@@ -37,9 +37,7 @@ export default async function TossPaymentFailRedirectPage({ searchParams }: Prop
       }),
   });
 
-  const returnPath = resolvePaymentReturnPath(params.returnTo);
-
-  redirect(`${returnPath}?paymentStatus=${paymentStatus}`);
+  redirect(buildPaymentReturnRedirect(params.returnTo, paymentStatus));
 }
 
 function readSingleValue(value: string | string[] | undefined) {

--- a/src/app/user/donations/toss/fail/page.tsx
+++ b/src/app/user/donations/toss/fail/page.tsx
@@ -1,4 +1,5 @@
 // Toss Payments 결제 실패 리다이렉트를 안전한 후원 지갑 상태 메시지로 변환합니다.
+import { resolvePaymentReturnPath } from "@/utils/payments/payment-return-path";
 import { markTossWalletChargeFailure } from "@/utils/payments/toss-wallet-charge";
 import { redirect } from "next/navigation";
 
@@ -9,6 +10,7 @@ interface Props {
     code?: string | string[];
     message?: string | string[];
     orderId?: string | string[];
+    returnTo?: string | string[];
   }>;
 }
 
@@ -35,7 +37,9 @@ export default async function TossPaymentFailRedirectPage({ searchParams }: Prop
       }),
   });
 
-  redirect(`/user/donations?paymentStatus=${paymentStatus}`);
+  const returnPath = resolvePaymentReturnPath(params.returnTo);
+
+  redirect(`${returnPath}?paymentStatus=${paymentStatus}`);
 }
 
 function readSingleValue(value: string | string[] | undefined) {

--- a/src/app/user/donations/toss/success/page.tsx
+++ b/src/app/user/donations/toss/success/page.tsx
@@ -1,4 +1,5 @@
 // Toss Payments 결제 성공 리다이렉트에서 서버 승인 처리를 수행합니다.
+import { resolvePaymentReturnPath } from "@/utils/payments/payment-return-path";
 import { confirmTossWalletCharge } from "@/utils/payments/toss-wallet-charge";
 import { redirect } from "next/navigation";
 
@@ -9,6 +10,7 @@ interface Props {
     amount?: string | string[];
     orderId?: string | string[];
     paymentKey?: string | string[];
+    returnTo?: string | string[];
   }>;
 }
 
@@ -21,11 +23,12 @@ export default async function TossPaymentSuccessRedirectPage({ searchParams }: P
       paymentKey: readSingleValue(params.paymentKey),
     }),
   );
+  const returnPath = resolvePaymentReturnPath(params.returnTo);
   const nextParams = new URLSearchParams({
     paymentStatus,
   });
 
-  redirect(`/user/donations?${nextParams.toString()}`);
+  redirect(`${returnPath}?${nextParams.toString()}`);
 }
 
 function readSingleValue(value: string | string[] | undefined) {

--- a/src/app/user/donations/toss/success/page.tsx
+++ b/src/app/user/donations/toss/success/page.tsx
@@ -1,5 +1,5 @@
 // Toss Payments 결제 성공 리다이렉트에서 서버 승인 처리를 수행합니다.
-import { resolvePaymentReturnPath } from "@/utils/payments/payment-return-path";
+import { buildPaymentReturnRedirect } from "@/utils/payments/payment-return-path";
 import { confirmTossWalletCharge } from "@/utils/payments/toss-wallet-charge";
 import { redirect } from "next/navigation";
 
@@ -23,12 +23,7 @@ export default async function TossPaymentSuccessRedirectPage({ searchParams }: P
       paymentKey: readSingleValue(params.paymentKey),
     }),
   );
-  const returnPath = resolvePaymentReturnPath(params.returnTo);
-  const nextParams = new URLSearchParams({
-    paymentStatus,
-  });
-
-  redirect(`${returnPath}?${nextParams.toString()}`);
+  redirect(buildPaymentReturnRedirect(params.returnTo, paymentStatus));
 }
 
 function readSingleValue(value: string | string[] | undefined) {

--- a/src/components/donations/wallet-charge-card.tsx
+++ b/src/components/donations/wallet-charge-card.tsx
@@ -22,13 +22,19 @@ import {
   WALLET_CHARGE_STEP_AMOUNT,
 } from "@/constants/payments/wallet-charge";
 import { cn } from "@/lib/utils";
-import type { TossPaymentPrepareResponse } from "@/types/payments/toss-payment-api";
 import type {
   TossPaymentsPaymentWindow,
   TossPaymentsWidgets,
 } from "@/types/payments/toss-payments";
 import { getAppMessage } from "@/utils/common/app-message";
+import { toastAppError, toastAppInfo } from "@/utils/common/toast-message";
 import { formatPoint } from "@/utils/donations/format";
+import { TOSS_PAYMENTS_SDK_URL } from "@/utils/payments/toss-sdk";
+import {
+  isTossPaymentCancelError,
+  isValidChargeAmount,
+  prepareTossWalletCharge,
+} from "@/utils/payments/toss-wallet-charge-client";
 import { CreditCard, Loader2 } from "lucide-react";
 import Script from "next/script";
 import { FormEvent, useEffect, useId, useMemo, useRef, useState } from "react";
@@ -44,8 +50,6 @@ interface WalletChargeDialogProps {
 }
 
 type PaymentWindowState = "idle" | "initializing" | "ready" | "opening" | "failed";
-
-const TOSS_PAYMENTS_SDK_URL = "https://js.tosspayments.com/v2/standard";
 
 export function WalletChargeDialog({ customerKey, className }: WalletChargeDialogProps) {
   const trigger = (
@@ -213,9 +217,17 @@ export function WalletChargeCard({ customerKey, variant = "card" }: Props) {
             failUrl: `${window.location.origin}/user/donations/toss/fail`,
           });
         } catch (error) {
-          console.error("Toss Payments 결제위젯 결제 요청 실패", error);
+          // 사용자가 결제창을 닫으면(취소) requestPayment가 reject한다 — 에러가 아니므로
+          // 콘솔 에러/실패 상태 대신 안내 토스트만 띄우고 다시 결제할 수 있게 ready로 되돌린다.
           hasRequestedPayment = false;
+          if (isTossPaymentCancelError(error)) {
+            toastAppInfo(APP_MESSAGE_CODE.error.donation.chargeCanceled);
+            setPaymentWindowState("ready");
+            return;
+          }
+          console.error("Toss Payments 결제위젯 결제 요청 실패", error);
           setPaymentWindowState("failed");
+          toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
         }
       });
 
@@ -223,6 +235,7 @@ export function WalletChargeCard({ customerKey, variant = "card" }: Props) {
     } catch (error) {
       console.error("Toss Payments 결제창 요청 실패", error);
       setPaymentWindowState("failed");
+      toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
     }
   };
 
@@ -375,50 +388,4 @@ function getPaymentStateMessage(clientKey: string | undefined, state: PaymentWin
   }
 
   return "";
-}
-
-async function prepareTossWalletCharge(amount: number) {
-  const response = await fetch("/api/payments/toss/prepare", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ amount }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Toss 결제 준비 실패");
-  }
-
-  const data = (await response.json()) as unknown;
-
-  if (!isTossPaymentPrepareResponse(data)) {
-    throw new Error("Toss 결제 준비 응답 형식 오류");
-  }
-
-  return data;
-}
-
-function isTossPaymentPrepareResponse(value: unknown): value is TossPaymentPrepareResponse {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const response = value as Partial<TossPaymentPrepareResponse>;
-
-  return (
-    typeof response.orderId === "string" &&
-    typeof response.orderName === "string" &&
-    isValidChargeAmount(response.amount)
-  );
-}
-
-function isValidChargeAmount(value: number | undefined) {
-  return (
-    typeof value === "number" &&
-    Number.isInteger(value) &&
-    value >= WALLET_CHARGE_MIN_AMOUNT &&
-    value <= WALLET_CHARGE_MAX_AMOUNT &&
-    value % WALLET_CHARGE_STEP_AMOUNT === 0
-  );
 }

--- a/src/components/live/chat/live-chat-body.tsx
+++ b/src/components/live/chat/live-chat-body.tsx
@@ -39,6 +39,9 @@ interface Props {
   walletBalance: number;
   isWalletLoading?: boolean;
   isWalletError?: boolean;
+  // 후원금 충전(TossPayments) — 로그인 유저 id와 결제 후 복귀 경로.
+  customerKey?: string;
+  chargeReturnTo?: string;
   donationEnabled: boolean;
   donationMinAmount: number;
   onLoginPrompt: () => void;
@@ -97,6 +100,8 @@ export function LiveChatBody({
   walletBalance,
   isWalletLoading,
   isWalletError,
+  customerKey,
+  chargeReturnTo,
   donationEnabled,
   donationMinAmount,
   onLoginPrompt,
@@ -221,6 +226,8 @@ export function LiveChatBody({
         walletBalance={walletBalance}
         isWalletLoading={isWalletLoading}
         isWalletError={isWalletError}
+        customerKey={customerKey}
+        chargeReturnTo={chargeReturnTo}
         donationEnabled={donationEnabled}
         donationMinAmount={donationMinAmount}
         onLoginPrompt={onLoginPrompt}

--- a/src/components/live/chat/live-chat-popout.tsx
+++ b/src/components/live/chat/live-chat-popout.tsx
@@ -34,6 +34,7 @@ export function LiveChatPopout({ creatorId }: Props) {
     walletBalance,
     isWalletLoading,
     isWalletError,
+    viewerId,
     donationEnabled,
     donationMinAmount,
     chatState,
@@ -98,6 +99,8 @@ export function LiveChatPopout({ creatorId }: Props) {
         walletBalance={walletBalance}
         isWalletLoading={isWalletLoading}
         isWalletError={isWalletError}
+        customerKey={viewerId ?? undefined}
+        chargeReturnTo={`/live/${creatorId}`}
         donationEnabled={donationEnabled}
         donationMinAmount={donationMinAmount}
         onLoginPrompt={moveToLogin}

--- a/src/components/live/view/live-chat-input-bar.tsx
+++ b/src/components/live/view/live-chat-input-bar.tsx
@@ -37,6 +37,9 @@ interface Props {
   walletBalance: number;
   isWalletLoading?: boolean;
   isWalletError?: boolean;
+  // 후원금 충전(TossPayments) — 로그인 유저 id와 결제 후 복귀 경로.
+  customerKey?: string;
+  chargeReturnTo?: string;
   donationEnabled: boolean;
   donationMinAmount: number;
   onLoginPrompt: () => void;
@@ -118,6 +121,8 @@ export function LiveChatInputBar({
   walletBalance,
   isWalletLoading,
   isWalletError,
+  customerKey,
+  chargeReturnTo,
   donationEnabled,
   donationMinAmount,
   onLoginPrompt,
@@ -417,6 +422,8 @@ export function LiveChatInputBar({
             walletBalance={walletBalance}
             isWalletLoading={isWalletLoading}
             isWalletError={isWalletError}
+            customerKey={customerKey}
+            chargeReturnTo={chargeReturnTo}
             donationEnabled={donationEnabled}
             donationMinAmount={donationMinAmount}
             onLoginPrompt={onLoginPrompt}

--- a/src/components/live/view/live-chat-panel.tsx
+++ b/src/components/live/view/live-chat-panel.tsx
@@ -31,6 +31,9 @@ interface Props {
   walletBalance: number;
   isWalletLoading?: boolean;
   isWalletError?: boolean;
+  // 후원금 충전(TossPayments) — 로그인 유저 id와 결제 후 복귀 경로.
+  customerKey?: string;
+  chargeReturnTo?: string;
   donationEnabled: boolean;
   donationMinAmount: number;
   onLoginPrompt: () => void;
@@ -77,6 +80,8 @@ export function LiveChatPanel({
   walletBalance,
   isWalletLoading,
   isWalletError,
+  customerKey,
+  chargeReturnTo,
   donationEnabled,
   donationMinAmount,
   onLoginPrompt,
@@ -185,6 +190,8 @@ export function LiveChatPanel({
           walletBalance={walletBalance}
           isWalletLoading={isWalletLoading}
           isWalletError={isWalletError}
+          customerKey={customerKey}
+          chargeReturnTo={chargeReturnTo}
           donationEnabled={donationEnabled}
           donationMinAmount={donationMinAmount}
           onLoginPrompt={onLoginPrompt}

--- a/src/components/live/view/live-donation-popover.tsx
+++ b/src/components/live/view/live-donation-popover.tsx
@@ -86,7 +86,7 @@ export function LiveDonationPopover({
   // 사용자가 직접 닫은 게 아니므로 이 동안엔 resetForm/외부 정산을 보류한다.
   const isChargeFlowActiveRef = useRef(false);
   // TossPayments 충전(PC=Promise·리로드 없음 / 모바일=리다이렉트 폴백). 성공 시 잔액은 훅이 재조회한다.
-  const { requestCharge, isCharging, isConfigured } = useTossWalletCharge({
+  const { requestCharge, cancelCharge, isCharging, isConfigured } = useTossWalletCharge({
     customerKey,
     returnTo: chargeReturnTo,
     // 충전 승인되면 후원 모달을 다시 띄워(또는 유지) 갱신된 잔액을 보여준다.
@@ -124,10 +124,11 @@ export function LiveDonationPopover({
 
   function closeWith(reason: LiveDonationCloseReason) {
     setOpen(false);
-    // 충전 결제창 때문에 닫히는 경우엔 입력값을 보존하고 외부 정산도 보류한다(결제 성공 시 다시 연다).
-    if (isChargeFlowActiveRef.current) {
-      return;
-    }
+    // 충전 플로우를 정리한다(보존 플래그 해제 + 떠 있는 결제창 닫기). 결제 진행 중(isCharging) 닫기는
+    // handleOpenChange/취소 버튼에서 막으므로 여기 도달하면 진행 중이 아니어서 안전하게 정산한다.
+    // (보류만 하면 결제수단 선택 전에 결제창을 닫았을 때 외부 열기 latch가 고착돼 전체화면 후원 버튼이 죽는다.)
+    isChargeFlowActiveRef.current = false;
+    cancelCharge();
     resetForm();
     if (isExternallyOpenedRef.current) {
       isExternallyOpenedRef.current = false;
@@ -141,8 +142,9 @@ export function LiveDonationPopover({
 
   function handleOpenChange(next: boolean) {
     if (!next) {
-      // 충전 결제창이 떠 있는 동안엔 popover를 닫지 않는다(결제 후 갱신된 잔액을 그대로 보여주기 위함).
-      if (isCharging) {
+      // 결제 진행 중이거나 충전 플로우가 떠 있는 동안엔 바깥클릭/ESC로 닫지 않는다(결제 후 갱신 잔액·입력값 유지).
+      // 닫으려면 취소 버튼을 쓴다 — 취소 버튼의 closeWith가 충전 플로우(결제창·플래그)를 명시적으로 정리한다.
+      if (isCharging || isChargeFlowActiveRef.current) {
         return;
       }
       closeWith("dismissed");
@@ -180,22 +182,35 @@ export function LiveDonationPopover({
   }, [openRequested, disabled, donationEnabled, isLoggedIn, onLoginPrompt, onOpenRequestSettled]);
 
   const remaining = walletBalance - amount;
+  // 부족분(후원액 − 잔액). needsCharge/requiredCharge가 모두 이 값을 기준으로 삼는 단일 소스.
+  const shortfall = Math.max(amount - walletBalance, 0);
   const isBelowMin = amount < minimumAmount;
   const minAmountLabel = `${formatDonationAmount(minimumAmount)}${LIVE_DONATION_LABEL.unit}`;
+  const maxChargeLabel = `${formatDonationAmount(WALLET_CHARGE_MAX_AMOUNT)}${LIVE_DONATION_LABEL.unit}`;
   const hasBalanceInfo = !isWalletLoading && !isWalletError;
-  // 잔액이 부족할 때만(유효 금액·조회 완료 전제) 하단 버튼을 후원하기 대신 자동 충전으로 전환한다.
-  const needsCharge = hasBalanceInfo && !isBelowMin && amount > 0 && remaining < 0;
+  // 부족분이 1회 충전 한도를 넘으면 충전해도 한 번에 못 메워(클램프) 무한 충전 루프가 되므로, 충전을 제안하지 않는다.
+  const exceedsChargeLimit = shortfall > WALLET_CHARGE_MAX_AMOUNT;
+  // 잔액이 부족할 때만(유효 금액·조회 완료·한도 내 전제) 하단 버튼을 후원하기 대신 자동 충전으로 전환한다.
+  const needsCharge = hasBalanceInfo && !isBelowMin && amount > 0 && remaining < 0 && !exceedsChargeLimit;
   // 충전액 = 부족분을 1,000P 단위로 올림(치지직식). 최소/최대 한도로 클램프한다.
   const requiredCharge = Math.min(
     Math.max(
-      Math.ceil(Math.max(amount - walletBalance, 0) / WALLET_CHARGE_STEP_AMOUNT) *
-        WALLET_CHARGE_STEP_AMOUNT,
+      Math.ceil(shortfall / WALLET_CHARGE_STEP_AMOUNT) * WALLET_CHARGE_STEP_AMOUNT,
       WALLET_CHARGE_MIN_AMOUNT,
     ),
     WALLET_CHARGE_MAX_AMOUNT,
   );
   // 미로그인(customerKey 없음)·키 미설정이면 충전 불가 → 후원하기(비활성)로 폴백한다.
   const canCharge = needsCharge && Boolean(customerKey) && isConfigured;
+  // 충전 자체는 가능한 상태지만 부족분이 1회 한도를 초과해 충전으로 못 메우는 경우 안내한다.
+  const showChargeLimitNotice =
+    hasBalanceInfo &&
+    !isBelowMin &&
+    amount > 0 &&
+    remaining < 0 &&
+    exceedsChargeLimit &&
+    Boolean(customerKey) &&
+    isConfigured;
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -340,9 +355,14 @@ export function LiveDonationPopover({
           </div>
         </div>
 
-        {/* 잔액이 부족하면 후원은 사용자 확인이 필요하므로, 충전 후 동작을 한 줄로 안내한다. */}
+        {/* 잔액이 부족하면 후원은 사용자 확인이 필요하므로 충전 후 동작을 안내하고,
+            부족분이 1회 충전 한도를 넘으면 금액을 낮추도록 안내한다. */}
         {canCharge ? (
           <p className="text-muted-foreground text-xs">{LIVE_DONATION_LABEL.chargeNotice}</p>
+        ) : showChargeLimitNotice ? (
+          <p className="text-destructive text-xs">
+            {LIVE_DONATION_LABEL.chargeLimitExceeded.replace("{amount}", maxChargeLabel)}
+          </p>
         ) : null}
 
         <div className="flex items-center justify-end gap-2">

--- a/src/components/live/view/live-donation-popover.tsx
+++ b/src/components/live/view/live-donation-popover.tsx
@@ -3,7 +3,7 @@
 // 전체화면 후원 버튼은 openRequested로 외부에서 열기를 요청하고, 닫힐 때 사유(donated/dismissed)를 돌려받는다.
 
 import { useEffect, useRef, useState, type RefObject } from "react";
-import { HandCoins } from "lucide-react";
+import { CreditCard, HandCoins, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -22,8 +22,15 @@ import {
   LIVE_DONATION_MIN_AMOUNT,
   LIVE_LABEL,
 } from "@/constants/live/live";
+import {
+  WALLET_CHARGE_MAX_AMOUNT,
+  WALLET_CHARGE_MIN_AMOUNT,
+  WALLET_CHARGE_STEP_AMOUNT,
+} from "@/constants/payments/wallet-charge";
+import { useTossWalletCharge } from "@/hooks/donations/use-toss-wallet-charge";
 import { cn } from "@/lib/utils";
 import { formatDonationAmount } from "@/utils/live/live-chat";
+import { isValidChargeAmount } from "@/utils/payments/toss-wallet-charge-client";
 
 export type LiveDonationCloseReason = "donated" | "dismissed";
 
@@ -33,6 +40,9 @@ interface Props {
   walletBalance: number;
   isWalletLoading?: boolean;
   isWalletError?: boolean;
+  // 후원금 충전(TossPayments) — customerKey는 로그인 유저 id, chargeReturnTo는 결제 후 복귀 경로.
+  customerKey?: string;
+  chargeReturnTo?: string;
   donationEnabled: boolean;
   donationMinAmount: number;
   onDonate: (params: {
@@ -59,6 +69,8 @@ export function LiveDonationPopover({
   walletBalance,
   isWalletLoading,
   isWalletError,
+  customerKey,
+  chargeReturnTo,
   donationEnabled,
   donationMinAmount,
   onDonate,
@@ -70,6 +82,20 @@ export function LiveDonationPopover({
 }: Props) {
   const minimumAmount = donationMinAmount > 0 ? donationMinAmount : LIVE_DONATION_MIN_AMOUNT;
   const [open, setOpen] = useState(false);
+  // 충전 결제창 때문에 popover가 닫히는 동안 입력값(후원 금액·메시지)을 보존하기 위한 플래그.
+  // 사용자가 직접 닫은 게 아니므로 이 동안엔 resetForm/외부 정산을 보류한다.
+  const isChargeFlowActiveRef = useRef(false);
+  // TossPayments 충전(PC=Promise·리로드 없음 / 모바일=리다이렉트 폴백). 성공 시 잔액은 훅이 재조회한다.
+  const { requestCharge, isCharging, isConfigured } = useTossWalletCharge({
+    customerKey,
+    returnTo: chargeReturnTo,
+    // 충전 승인되면 후원 모달을 다시 띄워(또는 유지) 갱신된 잔액을 보여준다.
+    onChargeSuccess: () => setOpen(true),
+    // 결제가 끝나면(성공/취소/실패) 보존 플래그를 해제해 이후 사용자 닫기 시 입력값이 정상 초기화되게 한다.
+    onChargeSettled: () => {
+      isChargeFlowActiveRef.current = false;
+    },
+  });
   // 후원 금액은 직접 입력값(숫자 문자열) 하나를 단일 소스로 둔다. 금액 버튼은 이 값에 더한다.
   const [amountInput, setAmountInput] = useState("");
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -83,6 +109,13 @@ export function LiveDonationPopover({
 
   const amount = Number(amountInput) || 0;
 
+  function handleCharge(chargeValue: number) {
+    // 결제창이 뜨면서 popover가 닫혀도 입력값을 보존하도록 플래그를 세운다(결제 성공 시 다시 연다).
+    // 충전만 자동 처리하고, 잔액이 채워지면 버튼이 후원하기로 바뀌어 사용자가 후원을 확정한다.
+    isChargeFlowActiveRef.current = true;
+    void requestCharge(chargeValue);
+  }
+
   function resetForm() {
     setAmountInput("");
     setIsAnonymous(false);
@@ -91,6 +124,10 @@ export function LiveDonationPopover({
 
   function closeWith(reason: LiveDonationCloseReason) {
     setOpen(false);
+    // 충전 결제창 때문에 닫히는 경우엔 입력값을 보존하고 외부 정산도 보류한다(결제 성공 시 다시 연다).
+    if (isChargeFlowActiveRef.current) {
+      return;
+    }
     resetForm();
     if (isExternallyOpenedRef.current) {
       isExternallyOpenedRef.current = false;
@@ -104,6 +141,10 @@ export function LiveDonationPopover({
 
   function handleOpenChange(next: boolean) {
     if (!next) {
+      // 충전 결제창이 떠 있는 동안엔 popover를 닫지 않는다(결제 후 갱신된 잔액을 그대로 보여주기 위함).
+      if (isCharging) {
+        return;
+      }
       closeWith("dismissed");
       return;
     }
@@ -116,6 +157,8 @@ export function LiveDonationPopover({
       onLoginPrompt();
       return;
     }
+    // 사용자가 직접 새로 여는 경우이므로 충전 보존 플래그를 초기화한다.
+    isChargeFlowActiveRef.current = false;
     setOpen(true);
   }
 
@@ -131,6 +174,7 @@ export function LiveDonationPopover({
       return;
     }
     isExternallyOpenedRef.current = true;
+    isChargeFlowActiveRef.current = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setOpen(true);
   }, [openRequested, disabled, donationEnabled, isLoggedIn, onLoginPrompt, onOpenRequestSettled]);
@@ -138,6 +182,20 @@ export function LiveDonationPopover({
   const remaining = walletBalance - amount;
   const isBelowMin = amount < minimumAmount;
   const minAmountLabel = `${formatDonationAmount(minimumAmount)}${LIVE_DONATION_LABEL.unit}`;
+  const hasBalanceInfo = !isWalletLoading && !isWalletError;
+  // 잔액이 부족할 때만(유효 금액·조회 완료 전제) 하단 버튼을 후원하기 대신 자동 충전으로 전환한다.
+  const needsCharge = hasBalanceInfo && !isBelowMin && amount > 0 && remaining < 0;
+  // 충전액 = 부족분을 1,000P 단위로 올림(치지직식). 최소/최대 한도로 클램프한다.
+  const requiredCharge = Math.min(
+    Math.max(
+      Math.ceil(Math.max(amount - walletBalance, 0) / WALLET_CHARGE_STEP_AMOUNT) *
+        WALLET_CHARGE_STEP_AMOUNT,
+      WALLET_CHARGE_MIN_AMOUNT,
+    ),
+    WALLET_CHARGE_MAX_AMOUNT,
+  );
+  // 미로그인(customerKey 없음)·키 미설정이면 충전 불가 → 후원하기(비활성)로 폴백한다.
+  const canCharge = needsCharge && Boolean(customerKey) && isConfigured;
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -169,8 +227,13 @@ export function LiveDonationPopover({
         sideOffset={0}
         // 기본 collisionPadding(5px)이 popover를 패널 밖으로 밀어내므로 0으로 고정해 패널 안에 둔다.
         collisionPadding={0}
+        // 메시지 입력 등으로 popover가 길어져 위아래 공간이 부족하면 base-ui가 좌/우 축으로
+        // 뒤집어(fallbackAxisSide) 채팅 패널 밖(비디오 위)으로 튀어나간다. 이를 막아 입력바 위/아래에만
+        // 고정하고, 높이는 아래 max-h(--available-height)로 줄여 내부 스크롤로 처리한다.
+        collisionAvoidance={{ fallbackAxisSide: "none" }}
         // 입력바(anchor) 풀폭 + 하단 직각으로 입력 섹션과 한 덩어리처럼 이어 붙인다.
-        className="max-h-[calc(100vh-1rem)] w-(--anchor-width) overflow-y-auto rounded-b-none"
+        // 높이는 base-ui가 계산한 가용 높이로 캡해, 길어져도 패널을 벗어나지 않고 내부 스크롤된다.
+        className="max-h-(--available-height) w-(--anchor-width) overflow-y-auto rounded-b-none"
       >
         {/* 브랜드 무드 — 마크·후원 카드와 같은 brand→live 그라디언트 라인으로 후원 영역임을 드러낸다. */}
         <div className="from-brand to-live h-1 shrink-0 rounded-full bg-linear-to-r" />
@@ -277,49 +340,76 @@ export function LiveDonationPopover({
           </div>
         </div>
 
-        <div className="flex justify-end gap-2">
+        {/* 잔액이 부족하면 후원은 사용자 확인이 필요하므로, 충전 후 동작을 한 줄로 안내한다. */}
+        {canCharge ? (
+          <p className="text-muted-foreground text-xs">{LIVE_DONATION_LABEL.chargeNotice}</p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
           <Button
             size="sm"
             variant="outline"
-            disabled={isSubmitting}
+            disabled={isSubmitting || isCharging}
             onClick={() => closeWith("dismissed")}
           >
             {LIVE_DONATION_LABEL.cancel}
           </Button>
-          <Button
-            type="button"
-            size="sm"
-            disabled={
-              disabled ||
-              !donationEnabled ||
-              isBelowMin ||
-              remaining < 0 ||
-              isSubmitting ||
-              !!isWalletLoading ||
-              !!isWalletError
-            }
-            className="bg-live hover:bg-live/90 text-live-foreground"
-            onClick={() => {
-              void (async () => {
-                setIsSubmitting(true);
-                try {
-                  const success = await onDonate({
-                    amount,
-                    message,
-                    isAnonymous,
-                    idempotencyKey: crypto.randomUUID(),
-                  });
-                  if (success) {
-                    closeWith("donated");
+          {/* 잔액이 모자라면(로그인·키 설정 전제) 후원하기 대신 부족분 자동 충전 버튼으로 전환한다.
+              충전만 자동 처리하고, 잔액이 채워지면 다시 후원하기로 바뀌어 사용자가 후원을 확정한다. */}
+          {canCharge ? (
+            <Button
+              type="button"
+              size="sm"
+              disabled={isCharging || isSubmitting || !isValidChargeAmount(requiredCharge)}
+              className="bg-live hover:bg-live/90 text-live-foreground"
+              onClick={() => handleCharge(requiredCharge)}
+            >
+              {isCharging ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <CreditCard className="size-4" />
+              )}
+              {LIVE_DONATION_LABEL.chargeSubmit.replace(
+                "{amount}",
+                `${formatDonationAmount(requiredCharge)}${LIVE_DONATION_LABEL.unit}`,
+              )}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              disabled={
+                disabled ||
+                !donationEnabled ||
+                isBelowMin ||
+                remaining < 0 ||
+                isSubmitting ||
+                !!isWalletLoading ||
+                !!isWalletError
+              }
+              className="bg-live hover:bg-live/90 text-live-foreground"
+              onClick={() => {
+                void (async () => {
+                  setIsSubmitting(true);
+                  try {
+                    const success = await onDonate({
+                      amount,
+                      message,
+                      isAnonymous,
+                      idempotencyKey: crypto.randomUUID(),
+                    });
+                    if (success) {
+                      closeWith("donated");
+                    }
+                  } finally {
+                    setIsSubmitting(false);
                   }
-                } finally {
-                  setIsSubmitting(false);
-                }
-              })();
-            }}
-          >
-            {LIVE_DONATION_LABEL.submit}
-          </Button>
+                })();
+              }}
+            >
+              {LIVE_DONATION_LABEL.submit}
+            </Button>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/live/view/live-fullscreen-chat-overlay.tsx
+++ b/src/components/live/view/live-fullscreen-chat-overlay.tsx
@@ -39,6 +39,9 @@ interface Props {
   walletBalance: number;
   isWalletLoading?: boolean;
   isWalletError?: boolean;
+  // 후원금 충전(TossPayments) — 로그인 유저 id와 결제 후 복귀 경로.
+  customerKey?: string;
+  chargeReturnTo?: string;
   donationEnabled: boolean;
   donationMinAmount: number;
   onLoginPrompt: () => void;
@@ -86,6 +89,8 @@ export function LiveFullscreenChatOverlay({
   walletBalance,
   isWalletLoading,
   isWalletError,
+  customerKey,
+  chargeReturnTo,
   donationEnabled,
   donationMinAmount,
   onLoginPrompt,
@@ -161,6 +166,8 @@ export function LiveFullscreenChatOverlay({
         walletBalance={walletBalance}
         isWalletLoading={isWalletLoading}
         isWalletError={isWalletError}
+        customerKey={customerKey}
+        chargeReturnTo={chargeReturnTo}
         donationEnabled={donationEnabled}
         donationMinAmount={donationMinAmount}
         onLoginPrompt={onLoginPrompt}

--- a/src/components/live/view/live-view.tsx
+++ b/src/components/live/view/live-view.tsx
@@ -61,6 +61,7 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
     walletBalance,
     isWalletLoading,
     isWalletError,
+    viewerId,
     donationEnabled,
     donationMinAmount,
     votePoll,
@@ -296,6 +297,8 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
                       walletBalance={walletBalance}
                       isWalletLoading={isWalletLoading}
                       isWalletError={isWalletError}
+                      customerKey={viewerId ?? undefined}
+                      chargeReturnTo={`/live/${creatorId}`}
                       donationEnabled={donationEnabled}
                       donationMinAmount={donationMinAmount}
                       onLoginPrompt={openLoginPrompt}
@@ -414,6 +417,8 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
               walletBalance={walletBalance}
               isWalletLoading={isWalletLoading}
               isWalletError={isWalletError}
+              customerKey={viewerId ?? undefined}
+              chargeReturnTo={`/live/${creatorId}`}
               donationEnabled={donationEnabled}
               donationMinAmount={donationMinAmount}
               onLoginPrompt={openLoginPrompt}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -21,12 +21,19 @@ function PopoverContent({
   sideOffset = 4,
   anchor,
   collisionPadding,
+  collisionAvoidance,
   container,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset" | "anchor" | "collisionPadding"
+    | "align"
+    | "alignOffset"
+    | "side"
+    | "sideOffset"
+    | "anchor"
+    | "collisionPadding"
+    | "collisionAvoidance"
   > & {
     // 포털 대상 컨테이너. 미지정 시 기본 body. 전체화면 요소 안에 띄울 때만 지정한다.
     container?: PopoverPrimitive.Portal.Props["container"];
@@ -40,6 +47,7 @@ function PopoverContent({
         side={side}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
+        collisionAvoidance={collisionAvoidance}
         className="isolate z-50"
       >
         <PopoverPrimitive.Popup

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -154,6 +154,8 @@ export const LIVE_DONATION_LABEL = {
   chargeSubmit: "{amount} 충전",
   // 충전만 자동 처리하고 후원은 사용자가 한 번 더 확인하므로, 충전 후 동작을 안내한다.
   chargeNotice: "충전 후 후원하기 버튼으로 후원을 완료해 주세요.",
+  // 부족분이 1회 충전 한도를 넘으면 충전으로 한 번에 못 메우므로 금액을 낮추도록 안내한다.
+  chargeLimitExceeded: "1회 최대 {amount}까지 충전할 수 있어요. 후원 금액을 낮춰 주세요.",
   disabled: "후원이 비활성화된 방송입니다.",
   unit: "P",
 } as const;

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -150,6 +150,10 @@ export const LIVE_DONATION_LABEL = {
   balanceError: "조회 실패",
   submit: "후원하기",
   cancel: "취소",
+  // 보유 후원금이 모자랄 때 하단 버튼이 후원하기 대신 부족분(1,000P 단위 올림) 자동 충전으로 바뀐다.
+  chargeSubmit: "{amount} 충전",
+  // 충전만 자동 처리하고 후원은 사용자가 한 번 더 확인하므로, 충전 후 동작을 안내한다.
+  chargeNotice: "충전 후 후원하기 버튼으로 후원을 완료해 주세요.",
   disabled: "후원이 비활성화된 방송입니다.",
   unit: "P",
 } as const;

--- a/src/hooks/donations/use-toss-wallet-charge.ts
+++ b/src/hooks/donations/use-toss-wallet-charge.ts
@@ -1,0 +1,184 @@
+"use client";
+// 라이브 후원 모달에서 후원금을 충전하기 위한 TossPayments 결제 훅입니다.
+// PC는 Promise 방식(리다이렉트 없이 결제창 → 직접 승인 확정)으로 모달을 유지하고,
+// 모바일은 토스 제약상 Promise를 못 받으므로 successUrl/failUrl 리다이렉트로 폴백합니다.
+//
+// ⚠️ 토스 결제창(renderPaymentWindow)은 `paymentRequest`/`destroy`만 노출하고 "닫힘/취소" 이벤트가
+// 없다. 따라서 결제창을 await로 기다리면 사용자가 결제수단을 고르지 않고 X로 닫을 때 영원히 멈춘다
+// (= 모달 프리즈). 지갑 충전 카드와 동일하게 fire-and-forget으로 짠다: requestCharge는 결제창만 열고
+// 즉시 반환하며, isCharging은 실제 requestPayment가 진행되는 구간(결제수단 선택 후)에만 true가 된다.
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import { QUERY_KEYS } from "@/constants/common/query-keys";
+import { useIsMobile } from "@/hooks/common/use-mobile";
+import type {
+  TossPaymentsPaymentWindow,
+  TossPaymentsWidgets,
+} from "@/types/payments/toss-payments";
+import { toastAppError, toastAppInfo, toastAppSuccess } from "@/utils/common/toast-message";
+import { loadTossPayments } from "@/utils/payments/toss-sdk";
+import {
+  isTossPaymentCancelError,
+  isValidChargeAmount,
+  prepareTossWalletCharge,
+} from "@/utils/payments/toss-wallet-charge-client";
+
+interface UseTossWalletChargeParams {
+  // 결제 customerKey(=로그인 유저 id). 없으면 충전 불가.
+  customerKey?: string;
+  // 모바일 리다이렉트 폴백 시 결제 후 돌아올 내부 경로.
+  returnTo?: string;
+  // 충전 승인 확정 후(잔액 재조회 완료) 호출. 후원 모달을 다시 띄워 갱신된 잔액을 보여주는 용도.
+  onChargeSuccess?: () => void;
+  // 결제 진행(requestPayment)이 성공/취소/실패로 끝났을 때 호출. 입력값 보존 플래그 해제 용도.
+  onChargeSettled?: () => void;
+}
+
+type PreparedCharge = Awaited<ReturnType<typeof prepareTossWalletCharge>>;
+
+export function useTossWalletCharge({
+  customerKey,
+  returnTo,
+  onChargeSuccess,
+  onChargeSettled,
+}: UseTossWalletChargeParams) {
+  const clientKey = process.env.NEXT_PUBLIC_TOSS_PAYMENTS_CLIENT_KEY;
+  const isMobile = useIsMobile();
+  const queryClient = useQueryClient();
+  const [isCharging, setIsCharging] = useState(false);
+  const paymentWindowRef = useRef<TossPaymentsPaymentWindow | null>(null);
+
+  // 언마운트 시 떠 있던 결제창을 정리한다(닫힘 이벤트가 없어 직접 destroy해야 한다).
+  useEffect(
+    () => () => {
+      destroyPaymentWindow(paymentWindowRef.current);
+      paymentWindowRef.current = null;
+    },
+    [],
+  );
+
+  // 결제창만 열고 즉시 반환한다. 결제수단 선택(paymentRequest) 시 confirmCharge가 실제 승인을 진행한다.
+  async function requestCharge(amount: number) {
+    if (isCharging) {
+      return;
+    }
+    if (!clientKey) {
+      toastAppError(APP_MESSAGE_CODE.error.donation.paymentWindowConfigMissing);
+      return;
+    }
+    if (!customerKey || !isValidChargeAmount(amount)) {
+      toastAppError(APP_MESSAGE_CODE.error.donation.invalidChargeAmount);
+      return;
+    }
+
+    try {
+      const prepared = await prepareTossWalletCharge(amount);
+      // 지갑 충전 카드와 동일하게 결제위젯(widgets) 키를 사용한다. payment()(API 개별 연동)는 다른 키를
+      // 요구해 "결제위젯 연동 키는 지원하지 않습니다" 오류가 난다.
+      const widgets = (await loadTossPayments())(clientKey).widgets({ customerKey });
+      await widgets.setAmount({ currency: "KRW", value: prepared.amount });
+
+      destroyPaymentWindow(paymentWindowRef.current);
+      paymentWindowRef.current = null;
+
+      const paymentWindow = await widgets.renderPaymentWindow();
+      paymentWindowRef.current = paymentWindow;
+
+      let requested = false;
+      paymentWindow.on("paymentRequest", () => {
+        if (requested) {
+          return;
+        }
+        requested = true;
+        void confirmCharge(widgets, prepared);
+      });
+    } catch (error) {
+      console.error("라이브 후원 충전 결제창 생성 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
+    }
+  }
+
+  // 결제수단 선택 후 실제 승인. PC는 Promise로 결과를 받아 직접 confirm, 모바일은 리다이렉트로 폴백한다.
+  async function confirmCharge(widgets: TossPaymentsWidgets, prepared: PreparedCharge) {
+    setIsCharging(true);
+    try {
+      if (isMobile) {
+        // 모바일: 카드사 앱으로 리다이렉트되어 Promise를 받을 수 없으므로 successUrl/failUrl로 복귀한다.
+        const returnToQuery = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : "";
+        await widgets.requestPayment({
+          orderId: prepared.orderId,
+          orderName: prepared.orderName,
+          windowTarget: "self",
+          successUrl: `${window.location.origin}/user/donations/toss/success${returnToQuery}`,
+          failUrl: `${window.location.origin}/user/donations/toss/fail${returnToQuery}`,
+        });
+        // 위 호출이 현재 페이지를 결제창으로 이동시키므로 여기 도달하면 곧 언로드된다.
+        return;
+      }
+
+      // PC: Promise 방식 — 리다이렉트 없이 결과(paymentKey/orderId)를 받아 직접 승인 확정한다.
+      const result = await widgets.requestPayment({
+        orderId: prepared.orderId,
+        orderName: prepared.orderName,
+        windowTarget: "iframe",
+      });
+
+      const confirmResponse = await fetch("/api/payments/toss/confirm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          paymentKey: result.paymentKey,
+          orderId: result.orderId,
+          // 금액은 우리가 prepare한 값을 그대로 보내 서버 검증과 일치시킨다.
+          amount: prepared.amount,
+        }),
+      });
+
+      if (!confirmResponse.ok) {
+        console.error("Toss 결제 승인 실패", confirmResponse.status);
+        toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
+        return;
+      }
+
+      // 잔액 재조회 → 후원 모달의 보유 후원금이 충전분만큼 갱신된다(페이지 리로드 없이).
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.donations.walletBalance(customerKey),
+      });
+      toastAppSuccess(APP_MESSAGE_CODE.success.donation.chargeConfirmed);
+      onChargeSuccess?.();
+    } catch (error) {
+      // 사용자가 결제창/QR을 닫으면 reject — 취소는 실패가 아니므로 안내 토스트만 띄운다.
+      if (isTossPaymentCancelError(error)) {
+        toastAppInfo(APP_MESSAGE_CODE.error.donation.chargeCanceled);
+        return;
+      }
+      console.error("라이브 후원 충전 실패", error);
+      toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
+    } finally {
+      setIsCharging(false);
+      destroyPaymentWindow(paymentWindowRef.current);
+      paymentWindowRef.current = null;
+      onChargeSettled?.();
+    }
+  }
+
+  return { requestCharge, isCharging, isConfigured: Boolean(clientKey) };
+}
+
+function destroyPaymentWindow(paymentWindow: TossPaymentsPaymentWindow | null) {
+  if (!paymentWindow) {
+    return;
+  }
+
+  try {
+    const result = paymentWindow.destroy();
+    if (result instanceof Promise) {
+      void result.catch(() => undefined);
+    }
+  } catch {
+    // 이미 정리되었거나 destroy 미지원이면 무시한다.
+  }
+}

--- a/src/hooks/donations/use-toss-wallet-charge.ts
+++ b/src/hooks/donations/use-toss-wallet-charge.ts
@@ -50,6 +50,9 @@ export function useTossWalletCharge({
   const queryClient = useQueryClient();
   const [isCharging, setIsCharging] = useState(false);
   const paymentWindowRef = useRef<TossPaymentsPaymentWindow | null>(null);
+  // 결제창을 여는 중(prepare→render)인지 추적한다. isCharging은 결제수단 선택(requestPayment) 후에야
+  // true가 되므로, 그 전 구간의 더블클릭으로 prepare가 중복 호출돼 고아 거래가 쌓이는 것을 막는다.
+  const isOpeningRef = useRef(false);
 
   // 언마운트 시 떠 있던 결제창을 정리한다(닫힘 이벤트가 없어 직접 destroy해야 한다).
   useEffect(
@@ -62,7 +65,7 @@ export function useTossWalletCharge({
 
   // 결제창만 열고 즉시 반환한다. 결제수단 선택(paymentRequest) 시 confirmCharge가 실제 승인을 진행한다.
   async function requestCharge(amount: number) {
-    if (isCharging) {
+    if (isCharging || isOpeningRef.current) {
       return;
     }
     if (!clientKey) {
@@ -74,6 +77,7 @@ export function useTossWalletCharge({
       return;
     }
 
+    isOpeningRef.current = true;
     try {
       const prepared = await prepareTossWalletCharge(amount);
       // 지갑 충전 카드와 동일하게 결제위젯(widgets) 키를 사용한다. payment()(API 개별 연동)는 다른 키를
@@ -98,7 +102,15 @@ export function useTossWalletCharge({
     } catch (error) {
       console.error("라이브 후원 충전 결제창 생성 실패", error);
       toastAppError(APP_MESSAGE_CODE.error.donation.chargeFailed);
+    } finally {
+      isOpeningRef.current = false;
     }
+  }
+
+  // 결제수단 선택 전에 후원 모달을 닫을 때 떠 있는 결제창을 정리한다(닫힘 이벤트가 없어 직접 destroy).
+  function cancelCharge() {
+    destroyPaymentWindow(paymentWindowRef.current);
+    paymentWindowRef.current = null;
   }
 
   // 결제수단 선택 후 실제 승인. PC는 Promise로 결과를 받아 직접 confirm, 모바일은 리다이렉트로 폴백한다.
@@ -165,7 +177,7 @@ export function useTossWalletCharge({
     }
   }
 
-  return { requestCharge, isCharging, isConfigured: Boolean(clientKey) };
+  return { requestCharge, cancelCharge, isCharging, isConfigured: Boolean(clientKey) };
 }
 
 function destroyPaymentWindow(paymentWindow: TossPaymentsPaymentWindow | null) {

--- a/src/hooks/live/use-live-broadcast-view.ts
+++ b/src/hooks/live/use-live-broadcast-view.ts
@@ -259,6 +259,8 @@ export function useLiveBroadcastView(creatorId: string) {
     walletBalance,
     isWalletLoading,
     isWalletError,
+    // 후원금 충전(TossPayments)의 customerKey로 쓰는 로그인 유저 id.
+    viewerId: user?.id ?? null,
     donationEnabled,
     donationMinAmount,
     votePoll,

--- a/src/types/payments/toss-payments.ts
+++ b/src/types/payments/toss-payments.ts
@@ -18,10 +18,19 @@ export interface TossPaymentsPayment {
   destroy(): Promise<void> | void;
 }
 
+// Promise 방식(PC) 결제 성공 시 돌아오는 결과(승인 확정에 필요한 키). amount는 우리가 prepare한 값을 그대로 쓴다.
+export interface TossPaymentsPaymentResult {
+  paymentKey: string;
+  orderId: string;
+}
+
 export interface TossPaymentsWidgets {
   setAmount(amount: TossPaymentsAmount): Promise<void>;
   renderPaymentWindow(): Promise<TossPaymentsPaymentWindow>;
-  requestPayment(paymentRequest: TossPaymentsWidgetPaymentRequest): Promise<void>;
+  // successUrl/failUrl을 생략하면 Promise 방식으로 결과를 받는다(PC 한정). 지정하면 Redirect 방식.
+  requestPayment(
+    paymentRequest: TossPaymentsWidgetPaymentRequest,
+  ): Promise<TossPaymentsPaymentResult>;
 }
 
 export interface TossPaymentsPaymentWindow {
@@ -49,8 +58,11 @@ export interface TossPaymentsDirectPaymentRequest {
 export interface TossPaymentsWidgetPaymentRequest {
   orderId: string;
   orderName: string;
-  successUrl: string;
-  failUrl: string;
+  // Redirect 방식에서만 필요. Promise 방식(PC)에선 생략한다.
+  successUrl?: string;
+  failUrl?: string;
+  // PC 기본 "iframe"(리다이렉트 없이 결제창), 모바일은 "self"로 강제 리다이렉트해야 한다.
+  windowTarget?: "self" | "iframe";
   customerEmail?: string;
   customerName?: string;
   metadata?: Record<string, string>;

--- a/src/utils/payments/payment-result-code.ts
+++ b/src/utils/payments/payment-result-code.ts
@@ -1,0 +1,21 @@
+// 결제 결과 쿼리 파라미터(paymentStatus)를 앱 메시지 코드로 매핑합니다.
+// 후원 지갑 화면과 라이브 시청 화면이 같은 결제 결과 토스트를 공유하기 위해 분리했습니다.
+
+import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
+import type { AppMessageCode } from "@/constants/common/app-message-code";
+
+const PAYMENT_STATUS_MESSAGE_CODE: Record<string, AppMessageCode> = {
+  charge_success: APP_MESSAGE_CODE.success.donation.chargeConfirmed,
+  charge_failed: APP_MESSAGE_CODE.error.donation.chargeFailed,
+  charge_canceled: APP_MESSAGE_CODE.error.donation.chargeCanceled,
+};
+
+export function getPaymentResultCode(
+  value: string | string[] | undefined,
+): AppMessageCode | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return PAYMENT_STATUS_MESSAGE_CODE[value];
+}

--- a/src/utils/payments/payment-return-path.ts
+++ b/src/utils/payments/payment-return-path.ts
@@ -17,3 +17,17 @@ export function resolvePaymentReturnPath(value: string | string[] | undefined): 
 
   return value;
 }
+
+// 정규화한 복귀 경로에 paymentStatus 쿼리를 안전하게 병합한다.
+// resolvePaymentReturnPath는 현재 쿼리(?)를 허용하지 않지만, 계약이 바뀌어
+// 경로에 쿼리가 섞여도 깨지지 않도록 URL로 병합한다(문자열 결합 회피).
+export function buildPaymentReturnRedirect(
+  value: string | string[] | undefined,
+  paymentStatus: string,
+): string {
+  const returnPath = resolvePaymentReturnPath(value);
+  const nextUrl = new URL(returnPath, "http://localhost");
+  nextUrl.searchParams.set("paymentStatus", paymentStatus);
+
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+}

--- a/src/utils/payments/payment-return-path.ts
+++ b/src/utils/payments/payment-return-path.ts
@@ -1,0 +1,19 @@
+// 결제 성공/실패 리다이렉트의 복귀 경로를 안전한 내부 상대경로로 정규화합니다.
+// 라이브 화면 등 충전 시작 지점으로 되돌리되, 오픈 리다이렉트(외부 URL·프로토콜 상대 경로)는 차단합니다.
+
+export const DEFAULT_PAYMENT_RETURN_PATH = "/user/donations";
+
+// 단일 "/"로 시작하는 내부 경로만 허용한다. "//evil"·"/\evil"·"http://..."는 차단.
+const SAFE_INTERNAL_PATH_PATTERN = /^\/[A-Za-z0-9/_-]*$/;
+
+export function resolvePaymentReturnPath(value: string | string[] | undefined): string {
+  if (typeof value !== "string") {
+    return DEFAULT_PAYMENT_RETURN_PATH;
+  }
+
+  if (!SAFE_INTERNAL_PATH_PATTERN.test(value) || value.startsWith("//")) {
+    return DEFAULT_PAYMENT_RETURN_PATH;
+  }
+
+  return value;
+}

--- a/src/utils/payments/toss-sdk.ts
+++ b/src/utils/payments/toss-sdk.ts
@@ -1,0 +1,56 @@
+// TossPayments v2 표준 SDK(CDN)를 한 번만 로드하고 전역 팩토리를 돌려줍니다.
+// 여러 화면(지갑 충전 카드·라이브 후원 충전)이 SDK 로딩을 중복하지 않도록 공유합니다.
+
+import type { TossPaymentsFactory } from "@/types/payments/toss-payments";
+
+export const TOSS_PAYMENTS_SDK_URL = "https://js.tosspayments.com/v2/standard";
+
+let sdkPromise: Promise<TossPaymentsFactory> | null = null;
+
+export function loadTossPayments(): Promise<TossPaymentsFactory> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("TossPayments SDK는 브라우저에서만 로드할 수 있습니다."));
+  }
+
+  if (window.TossPayments) {
+    return Promise.resolve(window.TossPayments);
+  }
+
+  if (sdkPromise) {
+    return sdkPromise;
+  }
+
+  sdkPromise = new Promise<TossPaymentsFactory>((resolve, reject) => {
+    const onLoaded = () => {
+      if (window.TossPayments) {
+        resolve(window.TossPayments);
+      } else {
+        sdkPromise = null;
+        reject(new Error("TossPayments SDK 로드 후 전역 객체를 찾지 못했습니다."));
+      }
+    };
+    const onError = () => {
+      sdkPromise = null;
+      reject(new Error("TossPayments SDK 로드에 실패했습니다."));
+    };
+
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TOSS_PAYMENTS_SDK_URL}"]`,
+    );
+
+    if (existing) {
+      existing.addEventListener("load", onLoaded, { once: true });
+      existing.addEventListener("error", onError, { once: true });
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = TOSS_PAYMENTS_SDK_URL;
+    script.async = true;
+    script.addEventListener("load", onLoaded, { once: true });
+    script.addEventListener("error", onError, { once: true });
+    document.head.appendChild(script);
+  });
+
+  return sdkPromise;
+}

--- a/src/utils/payments/toss-wallet-charge-client.ts
+++ b/src/utils/payments/toss-wallet-charge-client.ts
@@ -1,0 +1,72 @@
+// 후원 지갑 충전(TossPayments)의 클라이언트 공용 로직입니다.
+// 지갑 충전 카드(/user/donations)와 라이브 후원 충전이 함께 재사용합니다.
+
+import {
+  WALLET_CHARGE_MAX_AMOUNT,
+  WALLET_CHARGE_MIN_AMOUNT,
+  WALLET_CHARGE_STEP_AMOUNT,
+} from "@/constants/payments/wallet-charge";
+import type { TossPaymentPrepareResponse } from "@/types/payments/toss-payment-api";
+
+// 사용자가 결제창/QR을 닫아 취소한 경우의 토스 에러 코드. 취소는 실패가 아니라 정상 흐름으로 다룬다.
+const TOSS_PAYMENT_CANCEL_CODES = new Set([
+  "USER_CANCEL",
+  "PAY_PROCESS_CANCELED",
+  "PAY_PROCESS_ABORTED",
+]);
+
+export function isValidChargeAmount(value: number | undefined): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= WALLET_CHARGE_MIN_AMOUNT &&
+    value <= WALLET_CHARGE_MAX_AMOUNT &&
+    value % WALLET_CHARGE_STEP_AMOUNT === 0
+  );
+}
+
+export function isTossPaymentCancelError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+
+  return typeof code === "string" && TOSS_PAYMENT_CANCEL_CODES.has(code);
+}
+
+export async function prepareTossWalletCharge(amount: number): Promise<TossPaymentPrepareResponse> {
+  const response = await fetch("/api/payments/toss/prepare", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ amount }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Toss 결제 준비 실패");
+  }
+
+  const data = (await response.json()) as unknown;
+
+  if (!isTossPaymentPrepareResponse(data)) {
+    throw new Error("Toss 결제 준비 응답 형식 오류");
+  }
+
+  return data;
+}
+
+function isTossPaymentPrepareResponse(value: unknown): value is TossPaymentPrepareResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const response = value as Partial<TossPaymentPrepareResponse>;
+
+  return (
+    typeof response.orderId === "string" &&
+    typeof response.orderName === "string" &&
+    isValidChargeAmount(response.amount)
+  );
+}


### PR DESCRIPTION
### 📌 반영 브랜치

#### feat/live/donation-charge/#129 -> dev


### ✅ 작업 내용 `기능 추가` `기능 개선` `리팩토링` `버그 수정`

라이브 시청 화면 후원 popover에서 보유 후원금이 부족할 때, 화면 이탈 없이 부족분을 자동 충전(TossPayments)하고 이어서 후원할 수 있도록 연동했습니다. 
**주영님이 `/user/donations`에 만든 충전 플로우(prepare/confirm 라우트 + `confirm_wallet_charge`RPC)를 재사용했습니다.**
**DB / RPC / RLS / Realtime 변경: 없음** (`confirm_wallet_charge` RPC·prepare/confirm 라우트 재사용)

#### 후원 충전 (치지직식 일원화)
- 후원 금액만 입력 → 잔액 부족 시 하단 버튼이 `후원하기` → `{부족분}P 충전`으로 전환
- 부족분 = 1,000P 단위 올림(`ceil((후원액−잔액)/1,000)×1,000`), 충전 최소/최대 한도로 클램프
- **충전만 자동, 후원은 확인**: 충전 성공 → 잔액 갱신 → 버튼이 다시 `후원하기` → 사용자가 후원 확정
- 충전 금액 수동 선택 UI 제거(일원화)

#### 신규 충전 훅 / 공용 헬퍼 추출
- 신규 훅 `useTossWalletCharge`: 결제창 fire-and-forget(토스 결제창은 닫힘/취소 이벤트가 없어
  `await` 시 사용자가 X로 닫으면 모달이 멈추므로, 결제창만 열고 즉시 반환 → `paymentRequest`
  콜백에서 승인). PC=Promise(리로드 없음) / 모바일=리다이렉트 폴백.
- 결제 공용 헬퍼 추출: `toss-sdk` / `toss-wallet-charge-client`(prepare·금액검증·취소판정) /
  `payment-result-code` / `payment-return-path`(오픈리다이렉트 가드).

#### 리팩토링 — 공용 결제 카드(주영님 코드) 수정
- `wallet-charge-card.tsx` 안에 인라인돼 있던 `prepareTossWalletCharge`·`isValidChargeAmount`·
  `isTossPaymentPrepareResponse`·SDK URL 상수를 위 공용 헬퍼로 추출해 import 재사용(중복 제거).
- 결제창을 닫아 reject되는 취소를 구분해 취소→info 토스트 + 재충전 가능 복귀, 실패→error 토스트 보강.
- public API(props)·기존 redirect 동작은 불변. 유일 소비자 `/user/donations`는 그대로 동작.

#### 버그 수정 — 코드 리뷰 후속(이 PR 포함)
- 후원 금액 무상한으로 부족분이 1회 충전 한도(100만P)를 넘으면 충전해도 못 메우는 무한 루프 →
  한도 초과 시 충전 버튼 숨기고 안내 문구 노출.
- 결제수단 선택 전 결제창을 닫으면 보존 플래그가 고착돼 전체화면 후원 버튼이 영구 비활성 →
  닫을 때 항상 정산 + 결제창 정리, 충전 중 바깥클릭 차단(취소 버튼이 명시적 탈출구).
- 결제창 여는 중 더블클릭 시 prepare 중복/고아 거래 → `isOpeningRef` 가드 추가.


### 🎯 단독 테스트 결과

- `npm run typecheck` 정상 완료.
- `npm run build` 정상 완료.
- (DB 스키마 변경 없어 `npm run db:types` 해당 없음)
- 직접 확인한 시나리오:
  - 충전 한도 초과 시 안내 문구 노출 / 한도 내로 낮추면 충전 버튼 복귀
  - 결제창을 수단 선택 전 X로 닫아도 popover 유지(입력값 보존), 취소 버튼으로 정상 종료
  - 전체화면 후원 → 충전창 닫기 후 전체화면 후원 버튼이 다시 정상 동작(회귀 확인)
  - 충전 버튼 더블클릭 시 결제창 1개만 생성
  - 모바일 리다이렉트 폴백 복귀 + 토스트
  - `/user/donations` 기존 충전 회귀(결제창 X로 닫으면 취소 안내 + 재충전 가능)
- 미확인: **PC 카드 결제 완료 → 잔액 증가** — 테스터 환경에서 카드가 간편결제로 자동전환되어 안전한 테스트결제가 불가. 정식 토스 샌드박스에서 추후 확인 예정(실패 시 PC도 리다이렉트 폴백).


### 🚨 연관 이슈

closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 라이브 채팅 후원에서 지갑 잔액 부족 시 Toss 결제창 기반 충전 플로우 추가
  * 충전/후원 복귀 시 결제 결과 토스트 및 안전한 복귀 경로 지원

* **개선 사항**
  * 결제 취소 시 안내 후 재시도 가능하도록 UX 개선
  * 성공/실패 리다이렉트를 반환 경로 중심으로 전환
  * 팝오버 충돌 회피 옵션 추가 및 UI 라벨 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->