### PR TITLE
dev -> main: 보안·QA·PIP·클립 등 dev 누적 작업 prod 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ npm run dev
 - `/channel/live`, `/channel/chat`, `/channel/security`, `/channel/donation`, `/channel/settlement`, `/channel/analytics`를 사이드바 셸로 제공합니다. 스튜디오 경로는 route group `(studio)`로 격리해 공개 채널 페이지와 레이아웃을 분리합니다.
 - 스튜디오 데이터는 `service_role` 전용 `get_creator_studio_snapshot` RPC를 Server Component에서 조회하고, 설정 저장은 `upsert_creator_studio_setting`으로 처리합니다.
 - 채팅 설정(`/channel/chat`)에서는 참여 범위, 팔로워 대기 시간, 슬로우 모드, 링크 차단, 금칙어, 채팅 규칙을 관리합니다.
-- 보안 설정(`/channel/security`)에서는 스트림 키와 OBS 오버레이 URL을 발급·재발급합니다. 재발급은 `rotate_live_security_token_version`으로 키 버전을 올려 처리합니다.
+- 보안 설정(`/channel/security`)에서는 스트림 키와 OBS 오버레이 URL을 발급·재발급합니다. 재발급은 `rotate_live_security_token_version`으로 키 버전을 올리고 마지막 재발급 시각(`*_rotated_at`)을 기록해 각 카드에 표시합니다. 민감한 값을 "보기"로 노출하면 어깨너머·송출 화면 노출을 막기 위해 30초 뒤 자동으로 다시 가려집니다.
 - 후원 설정·대시보드(`/channel/donation`)는 `get_creator_donation_dashboard`로 후원 통계를 조회하고, 최소 후원 금액, OBS 후원 알림(표시 시간·알림음·볼륨), 브라우저 TTS 음성·속도·볼륨, 채팅창 후원 메시지 노출을 설정합니다.
 - 정산(`/channel/settlement`)은 `get_creator_settlement_donations`로 연도·상태·정렬별 정산 상세를, `get_creator_settlement_yearly_summary`로 연도별 총 정산액을 조회합니다.
 - 설정 화면은 공통 컴포넌트(`SettingsPage`, `SettingsCard`, `SideTipCard`, `HintNote`)와 스크롤 시 나타나는 공통 저장 바(`StickySaveBar`)로 구조를 통일했습니다.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,9 +71,11 @@ export default function RootLayout({
           <RouteAccentProvider>
             <RouteOverlayChromeController />
             <LiveDataRouteRefresher />
-            <LiveMiniPlayerHost />
             <Toaster />
             <Header />
+            {/* 미니플레이어는 Header 뒤에 둬 같은 z-50에서도 Header 위에 뜬다(드래그로 헤더에 안 가림).
+                Dialog 등 모달은 body 포털로 더 나중 렌더되어 미니 위를 덮는다(모달 우선 유지). */}
+            <LiveMiniPlayerHost />
             <AuthToastHandler />
             {/* tabIndex=-1: 미니플레이어 닫기 등 플로팅 UI가 사라질 때 포커스를 회수하는 본문 랜드마크. */}
             <main tabIndex={-1} className="flex flex-1 flex-col">

--- a/src/components/auth/login/login-form.tsx
+++ b/src/components/auth/login/login-form.tsx
@@ -39,6 +39,7 @@ export default function LoginForm({ disabled, isPending, onLogin }: LoginFormPro
     const saved = localStorage.getItem(REMEMBERED_EMAIL_KEY);
     if (saved) {
       setValue("email", saved, { shouldValidate: true });
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setRememberEmail(true);
     }
   }, [setValue]);

--- a/src/components/auth/login/login-form.tsx
+++ b/src/components/auth/login/login-form.tsx
@@ -10,7 +10,11 @@ import { loginSchema } from "@/lib/zod/auth";
 import type { LoginFormValues } from "@/types/auth/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { LockKeyhole, Mail } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+
+// 아이디 저장(이메일만 보관 — 비밀번호는 절대 저장하지 않는다). localStorage 키.
+const REMEMBERED_EMAIL_KEY = "pixelplay_remembered_email";
 
 interface LoginFormProps {
   disabled: boolean;
@@ -19,16 +23,33 @@ interface LoginFormProps {
 }
 
 export default function LoginForm({ disabled, isPending, onLogin }: LoginFormProps) {
+  const [rememberEmail, setRememberEmail] = useState(false);
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, dirtyFields, isSubmitting },
   } = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     mode: "onChange",
   });
 
+  // 마운트 시 저장해 둔 아이디(이메일)를 채운다 — 비밀번호는 저장하지 않으므로 직접 입력해야 한다.
+  useEffect(() => {
+    const saved = localStorage.getItem(REMEMBERED_EMAIL_KEY);
+    if (saved) {
+      setValue("email", saved, { shouldValidate: true });
+      setRememberEmail(true);
+    }
+  }, [setValue]);
+
   const onSubmit = async (data: LoginFormValues) => {
+    // 아이디 저장 체크 시 이메일만 보관(다음 방문 prefill), 해제 시 삭제한다.
+    if (rememberEmail) {
+      localStorage.setItem(REMEMBERED_EMAIL_KEY, data.email);
+    } else {
+      localStorage.removeItem(REMEMBERED_EMAIL_KEY);
+    }
     await onLogin(data).catch(() => undefined);
   };
 
@@ -57,6 +78,17 @@ export default function LoginForm({ disabled, isPending, onLogin }: LoginFormPro
         />
         <FieldError errors={[errors.password]} />
       </div>
+
+      <label className="text-muted-foreground flex w-fit cursor-pointer items-center gap-2 text-sm select-none">
+        <input
+          type="checkbox"
+          checked={rememberEmail}
+          onChange={(event) => setRememberEmail(event.target.checked)}
+          disabled={disabled}
+          className="accent-brand size-4 cursor-pointer"
+        />
+        아이디 저장
+      </label>
 
       <Button
         type="submit"

--- a/src/components/channel/security/channel-security-controls.tsx
+++ b/src/components/channel/security/channel-security-controls.tsx
@@ -18,6 +18,7 @@ export function ChannelSecurityControls({ initialSnapshot }: Props) {
     isPending,
     isRotating,
     isVisibleKind,
+    getRevealRemaining,
     handleCopy,
     handlePreview,
     handleToggleVisible,
@@ -31,6 +32,7 @@ export function ChannelSecurityControls({ initialSnapshot }: Props) {
         disabled={isRotating}
         isRotating={rotatingKind === "stream_key" && isPending}
         isStreamKeyVisible={isVisibleKind("stream_key")}
+        streamKeyRevealRemaining={getRevealRemaining("stream_key")}
         onCopy={handleCopy}
         onToggleVisible={handleToggleVisible}
         onRotate={handleRotate}
@@ -43,6 +45,7 @@ export function ChannelSecurityControls({ initialSnapshot }: Props) {
           disabled={isRotating}
           isRotating={rotatingKind === meta.tokenKind && isPending}
           isUrlVisible={isVisibleKind(meta.tokenKind)}
+          urlRevealRemaining={getRevealRemaining(meta.tokenKind)}
           onCopy={handleCopy}
           onPreview={(url) => handlePreview(url, meta.popup)}
           onToggleVisible={handleToggleVisible}

--- a/src/components/channel/security/obs-url-card.tsx
+++ b/src/components/channel/security/obs-url-card.tsx
@@ -1,6 +1,7 @@
 // 채널 보안 설정의 OBS 브라우저 소스 URL 카드를 렌더링합니다.
 import { SecurityActionGroup } from "@/components/channel/security/security-action-group";
 import { SecurityFieldRow } from "@/components/channel/security/security-field-row";
+import { SecurityRotatedAtNote } from "@/components/channel/security/security-rotated-at-note";
 import { SecurityTutorialList } from "@/components/channel/security/security-tutorial-list";
 import { UrlTokenReissueDialog } from "@/components/channel/security/url-token-reissue-dialog";
 import { TutorialDialog } from "@/components/common/tutorial-dialog";
@@ -44,6 +45,10 @@ export function ObsUrlCard({
   const Icon = meta.icon;
   const url =
     meta.tokenKind === "chat_overlay" ? snapshot.chatOverlayUrl : snapshot.donationAlertUrl;
+  const rotatedAt =
+    meta.tokenKind === "chat_overlay"
+      ? snapshot.chatOverlayRotatedAt
+      : snapshot.donationAlertRotatedAt;
 
   return (
     <Card className="gap-5 shadow-sm">
@@ -93,6 +98,7 @@ export function ObsUrlCard({
             />
           }
         />
+        <SecurityRotatedAtNote rotatedAt={rotatedAt} />
         <SecurityTutorialList items={meta.tutorialItems} />
       </CardContent>
     </Card>

--- a/src/components/channel/security/obs-url-card.tsx
+++ b/src/components/channel/security/obs-url-card.tsx
@@ -27,6 +27,7 @@ export function ObsUrlCard({
   disabled,
   isRotating,
   isUrlVisible,
+  urlRevealRemaining,
   onCopy,
   onPreview,
   onToggleVisible,
@@ -37,6 +38,7 @@ export function ObsUrlCard({
   disabled: boolean;
   isRotating: boolean;
   isUrlVisible: boolean;
+  urlRevealRemaining: number;
   onCopy: (value: string) => Promise<void>;
   onPreview: (url: string) => void;
   onToggleVisible: (tokenKind: ChannelSecurityTokenKind) => void;
@@ -91,6 +93,7 @@ export function ObsUrlCard({
             <SecurityActionGroup
               tokenKind={meta.tokenKind}
               isVisible={isUrlVisible}
+              revealRemaining={urlRevealRemaining}
               disabled={disabled}
               onToggleVisible={onToggleVisible}
               onCopy={() => onCopy(url)}

--- a/src/components/channel/security/security-action-group.tsx
+++ b/src/components/channel/security/security-action-group.tsx
@@ -1,7 +1,8 @@
 // 채널 보안 값의 보기, 복사, 미리보기 버튼 묶음을 렌더링합니다.
 import { Button } from "@/components/ui/button";
+import { SECURITY_REVEAL_HINT } from "@/constants/channel/security";
 import type { ChannelSecurityTokenKind } from "@/types/channel/security";
-import { Copy, ExternalLink, Eye, EyeOff } from "lucide-react";
+import { Clock, Copy, ExternalLink, Eye, EyeOff } from "lucide-react";
 
 export function SecurityActionGroup({
   tokenKind,
@@ -22,30 +23,39 @@ export function SecurityActionGroup({
   const disabledTitle = disabled ? "보안 값을 새로 발급하는 동안에는 사용할 수 없어요." : undefined;
 
   return (
-    <div className="flex shrink-0 flex-wrap gap-2">
-      <Button
-        variant="outline"
-        disabled={disabled}
-        title={disabledTitle}
-        onClick={() => onToggleVisible(tokenKind)}
-      >
-        {isVisible ? <EyeOff /> : <Eye />}
-        {isVisible ? "숨기기" : "보기"}
-      </Button>
-      <Button
-        variant="outline"
-        disabled={disabled}
-        title={disabledTitle}
-        onClick={() => void onCopy()}
-      >
-        <Copy />
-        복사
-      </Button>
-      {onPreview && (
-        <Button variant="outline" disabled={disabled} title={disabledTitle} onClick={onPreview}>
-          <ExternalLink />
-          미리보기
+    <div className="flex shrink-0 flex-col items-start gap-1.5 lg:items-end">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          disabled={disabled}
+          title={disabledTitle}
+          onClick={() => onToggleVisible(tokenKind)}
+        >
+          {isVisible ? <EyeOff /> : <Eye />}
+          {isVisible ? "숨기기" : "보기"}
         </Button>
+        <Button
+          variant="outline"
+          disabled={disabled}
+          title={disabledTitle}
+          onClick={() => void onCopy()}
+        >
+          <Copy />
+          복사
+        </Button>
+        {onPreview && (
+          <Button variant="outline" disabled={disabled} title={disabledTitle} onClick={onPreview}>
+            <ExternalLink />
+            미리보기
+          </Button>
+        )}
+      </div>
+      {/* 노출 중일 때만: 어깨너머·송출 화면 노출 방지를 위해 곧 자동으로 가려진다고 안내한다. */}
+      {isVisible && (
+        <p className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Clock className="size-3 shrink-0" />
+          {SECURITY_REVEAL_HINT}
+        </p>
       )}
     </div>
   );

--- a/src/components/channel/security/security-action-group.tsx
+++ b/src/components/channel/security/security-action-group.tsx
@@ -1,12 +1,12 @@
 // 채널 보안 값의 보기, 복사, 미리보기 버튼 묶음을 렌더링합니다.
 import { Button } from "@/components/ui/button";
-import { SECURITY_REVEAL_HINT } from "@/constants/channel/security";
 import type { ChannelSecurityTokenKind } from "@/types/channel/security";
 import { Clock, Copy, ExternalLink, Eye, EyeOff } from "lucide-react";
 
 export function SecurityActionGroup({
   tokenKind,
   isVisible,
+  revealRemaining,
   disabled,
   onToggleVisible,
   onCopy,
@@ -14,6 +14,7 @@ export function SecurityActionGroup({
 }: {
   tokenKind: ChannelSecurityTokenKind;
   isVisible: boolean;
+  revealRemaining: number;
   disabled: boolean;
   onToggleVisible: (tokenKind: ChannelSecurityTokenKind) => void;
   onCopy: () => Promise<void>;
@@ -50,11 +51,11 @@ export function SecurityActionGroup({
           </Button>
         )}
       </div>
-      {/* 노출 중일 때만: 어깨너머·송출 화면 노출 방지를 위해 곧 자동으로 가려진다고 안내한다. */}
+      {/* 노출 중일 때만: 남은 시간을 실시간 카운트다운하고 0초가 되면 자동으로 가려진다. */}
       {isVisible && (
-        <p className="text-muted-foreground flex items-center gap-1 text-xs">
+        <p className="text-muted-foreground flex items-center gap-1 text-xs tabular-nums">
           <Clock className="size-3 shrink-0" />
-          {SECURITY_REVEAL_HINT}
+          {revealRemaining}초 후 자동으로 다시 가려져요
         </p>
       )}
     </div>

--- a/src/components/channel/security/security-rotated-at-note.tsx
+++ b/src/components/channel/security/security-rotated-at-note.tsx
@@ -1,0 +1,17 @@
+// 보안 토큰(스트림 키·OBS URL)의 마지막 재발급 시각을 표시합니다.
+// 재발급 이력이 없으면(null) 아무것도 렌더하지 않습니다.
+import { formatKstDateTimeNumeric } from "@/utils/common/date";
+import { History } from "lucide-react";
+
+export function SecurityRotatedAtNote({ rotatedAt }: { rotatedAt: string | null }) {
+  if (!rotatedAt) {
+    return null;
+  }
+
+  return (
+    <p className="text-muted-foreground mt-3 flex items-center gap-1 text-xs">
+      <History className="size-3 shrink-0" />
+      마지막 재발급: {formatKstDateTimeNumeric(rotatedAt)}
+    </p>
+  );
+}

--- a/src/components/channel/security/stream-key-card.tsx
+++ b/src/components/channel/security/stream-key-card.tsx
@@ -26,6 +26,7 @@ export function StreamKeyCard({
   disabled,
   isRotating,
   isStreamKeyVisible,
+  streamKeyRevealRemaining,
   onCopy,
   onToggleVisible,
   onRotate,
@@ -34,6 +35,7 @@ export function StreamKeyCard({
   disabled: boolean;
   isRotating: boolean;
   isStreamKeyVisible: boolean;
+  streamKeyRevealRemaining: number;
   onCopy: (value: string) => Promise<void>;
   onToggleVisible: (tokenKind: ChannelSecurityTokenKind) => void;
   onRotate: (tokenKind: ChannelSecurityTokenKind, onSuccess?: () => void) => void;
@@ -80,6 +82,7 @@ export function StreamKeyCard({
             <SecurityActionGroup
               tokenKind="stream_key"
               isVisible={isStreamKeyVisible}
+              revealRemaining={streamKeyRevealRemaining}
               disabled={disabled}
               onToggleVisible={onToggleVisible}
               onCopy={() => onCopy(snapshot.streamKey)}

--- a/src/components/channel/security/stream-key-card.tsx
+++ b/src/components/channel/security/stream-key-card.tsx
@@ -1,6 +1,7 @@
 // 채널 보안 설정의 스트림 URL과 스트림 키 카드를 렌더링합니다.
 import { SecurityActionGroup } from "@/components/channel/security/security-action-group";
 import { SecurityFieldRow } from "@/components/channel/security/security-field-row";
+import { SecurityRotatedAtNote } from "@/components/channel/security/security-rotated-at-note";
 import { StreamKeyReissueDialog } from "@/components/channel/security/stream-key-reissue-dialog";
 import { TutorialDialog } from "@/components/common/tutorial-dialog";
 import { Button } from "@/components/ui/button";
@@ -85,6 +86,7 @@ export function StreamKeyCard({
             />
           }
         />
+        <SecurityRotatedAtNote rotatedAt={snapshot.streamKeyRotatedAt} />
       </CardContent>
     </Card>
   );

--- a/src/components/clip/clip-section.tsx
+++ b/src/components/clip/clip-section.tsx
@@ -1,12 +1,13 @@
 "use client";
 // 시청 페이지 "이 채널의 클립" 섹션 — 1줄로 시작해 더보기마다 1줄씩(최대 4줄) 펼치고,
-// 4줄에 도달하면 더보기 버튼이 채널 클립 탭 "전체보기" 링크로 바뀐다. 클립이 없으면 숨긴다.
+// 4줄에 도달하면 더보기 버튼이 채널 클립 탭 "전체보기" 링크로 바뀐다. 클립이 없으면 빈 상태(EmptyState)를 보여준다.
 
 import { useState } from "react";
 import Link from "next/link";
 import { ArrowRight, RotateCw } from "lucide-react";
 
 import { ClipCard } from "@/components/clip/clip-card";
+import { ClipEmptyState } from "@/components/clip/clip-empty-state";
 import { ClipSortSelect } from "@/components/clip/clip-sort-select";
 import LoadMoreButton from "@/components/common/load-more-button";
 import { Button } from "@/components/ui/button";
@@ -31,11 +32,13 @@ export function ClipSection({ creatorId, className }: Props) {
     limit: CLIP_SECTION_ROW_SIZE * CLIP_SECTION_MAX_ROWS,
   });
 
-  // 클립이 하나도 없는 채널은 섹션 자체를 보여주지 않는다(로딩 중 깜빡임 방지 포함).
-  if (isLoading || clips.length === 0) {
+  // 로딩 중엔 깜빡임을 막기 위해 숨기고, 로딩이 끝났는데 클립이 없으면 빈 상태로 자리를 채운다
+  // (아예 숨기면 스크롤도 안 되고 허전하다 — 헤더 + EmptyState로 대체).
+  if (isLoading) {
     return null;
   }
 
+  const hasClips = clips.length > 0;
   const visibleClips = clips.slice(0, visibleRows * CLIP_SECTION_ROW_SIZE);
   const hasMoreRows = visibleRows < CLIP_SECTION_MAX_ROWS && clips.length > visibleClips.length;
   const showViewAll = !hasMoreRows && clips.length > CLIP_SECTION_ROW_SIZE;
@@ -56,34 +59,41 @@ export function ClipSection({ creatorId, className }: Props) {
             <RotateCw className={cn("size-4", isRefetching && "animate-spin")} />
           </Button>
         </div>
-        <ClipSortSelect value={sort} onChange={setSort} />
+        {/* 정렬은 클립이 있을 때만 — 빈 상태에선 의미가 없다. */}
+        {hasClips ? <ClipSortSelect value={sort} onChange={setSort} /> : null}
       </div>
 
-      <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6">
-        {visibleClips.map((clip) => (
-          <ClipCard key={clip.id} clip={clip} />
-        ))}
-      </div>
+      {hasClips ? (
+        <>
+          <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6">
+            {visibleClips.map((clip) => (
+              <ClipCard key={clip.id} clip={clip} />
+            ))}
+          </div>
 
-      {hasMoreRows ? (
-        <LoadMoreButton
-          isLoading={false}
-          onClick={() => setVisibleRows((rows) => rows + 1)}
-          label={CLIP_LABEL.showMore}
-        />
-      ) : showViewAll ? (
-        <div className="flex justify-center pt-1">
-          <Button
-            variant="secondary"
-            className="cursor-pointer rounded-full"
-            nativeButton={false}
-            render={<Link href={`/channel/${creatorId}/clip`} prefetch={false} />}
-          >
-            {CLIP_LABEL.viewAll}
-            <ArrowRight aria-hidden />
-          </Button>
-        </div>
-      ) : null}
+          {hasMoreRows ? (
+            <LoadMoreButton
+              isLoading={false}
+              onClick={() => setVisibleRows((rows) => rows + 1)}
+              label={CLIP_LABEL.showMore}
+            />
+          ) : showViewAll ? (
+            <div className="flex justify-center pt-1">
+              <Button
+                variant="secondary"
+                className="cursor-pointer rounded-full"
+                nativeButton={false}
+                render={<Link href={`/channel/${creatorId}/clip`} prefetch={false} />}
+              >
+                {CLIP_LABEL.viewAll}
+                <ArrowRight aria-hidden />
+              </Button>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <ClipEmptyState />
+      )}
     </section>
   );
 }

--- a/src/components/community/community-comment-composer.tsx
+++ b/src/components/community/community-comment-composer.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from "react";
 
 import { CharacterCounter } from "@/components/common/character-counter";
 import RichEmojiInput from "@/components/common/rich-emoji-input";
-import StickerPicker from "@/components/sticker/sticker-picker";
+import CommunityStickerPicker from "@/components/community/community-sticker-picker";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -109,10 +109,9 @@ export default function CommunityCommentComposer({
 
         {/* 이모지 피커를 전송 버튼 옆에 둔다. 위로 열면 입력칸을 가려 아래로 연다. */}
         <div className="flex items-center gap-1">
-          <StickerPicker
+          <CommunityStickerPicker
             disabled={createComment.isPending}
             onStickerSelect={handleStickerSelect}
-            side="bottom"
           />
           <Button
             type="submit"

--- a/src/components/community/community-composer.tsx
+++ b/src/components/community/community-composer.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import { ImagePlus, X } from "lucide-react";
 
 import { CharacterCounter } from "@/components/common/character-counter";
-import StickerPicker from "@/components/sticker/sticker-picker";
+import CommunityStickerPicker from "@/components/community/community-sticker-picker";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import RichEmojiInput from "@/components/common/rich-emoji-input";
@@ -169,7 +169,7 @@ export default function CommunityComposer({
 
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1">
-          <StickerPicker disabled={isPending} onStickerSelect={handleStickerSelect} side="bottom" />
+          <CommunityStickerPicker disabled={isPending} onStickerSelect={handleStickerSelect} />
           {!displayImage && (
             <Button
               type="button"

--- a/src/components/community/community-sticker-picker.tsx
+++ b/src/components/community/community-sticker-picker.tsx
@@ -1,0 +1,36 @@
+"use client";
+// 커뮤니티 글·댓글 작성기의 스티커 피커 — 라이브 채팅과 동일하게 본인·구독 채널 이모지를 노출한다.
+// ChannelStickerProvider는 authUser 기반이라 creatorId가 필요 없고, 작성기마다 감싸도
+// useAvailableChannelEmojiStickerGroups(React Query)가 같은 캐시를 공유해 중복 조회가 없다.
+
+import {
+  ChannelStickerProvider,
+  useChannelStickers,
+} from "@/components/live/chat/channel-sticker-context";
+import StickerPicker from "@/components/sticker/sticker-picker";
+
+interface Props {
+  onStickerSelect: (token: string) => void;
+  disabled?: boolean;
+}
+
+function CommunityStickerPickerInner({ onStickerSelect, disabled }: Props) {
+  const { groups, canUseInPicker } = useChannelStickers();
+
+  return (
+    <StickerPicker
+      onStickerSelect={onStickerSelect}
+      disabled={disabled}
+      side="bottom"
+      channelGroups={canUseInPicker ? groups : undefined}
+    />
+  );
+}
+
+export default function CommunityStickerPicker(props: Props) {
+  return (
+    <ChannelStickerProvider>
+      <CommunityStickerPickerInner {...props} />
+    </ChannelStickerProvider>
+  );
+}

--- a/src/components/live/live-card.tsx
+++ b/src/components/live/live-card.tsx
@@ -23,7 +23,10 @@ export default function LiveCard({ item }: LiveCardProps) {
   const liveHref = `/live/${item.creatorId}`;
 
   return (
-    <article className="min-w-0">
+    // GAP-008: 오프스크린 카드의 레이아웃·페인트를 건너뛰어(브라우저 네이티브 렌더 가상화) 목록이
+    // 길어져도 스크롤 비용을 낮춘다. JS 그리드 가상화와 달리 반응형 cols 레이아웃을 그대로 둔다.
+    // contain-intrinsic-size: 첫 렌더 전 높이 추정값(렌더 후엔 auto가 실제 크기를 기억해 스크롤 안정).
+    <article className="min-w-0 [contain-intrinsic-size:auto_320px] [content-visibility:auto]">
       <Link
         href={liveHref}
         className={cn(

--- a/src/components/live/live-sidebar.tsx
+++ b/src/components/live/live-sidebar.tsx
@@ -6,6 +6,7 @@ import { useIsFetching } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 
 import LoadMoreButton from "@/components/common/load-more-button";
+import { SidebarCredits } from "@/components/common/sidebar-credits";
 import LiveSidebarCategoryItem from "@/components/live/live-sidebar-category-item";
 import LiveSidebarChannelItem from "@/components/live/live-sidebar-channel-item";
 import LiveSidebarKeywordItem from "@/components/live/live-sidebar-keyword-item";
@@ -13,6 +14,7 @@ import LiveSidebarSection from "@/components/live/live-sidebar-section";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -21,6 +23,7 @@ import {
   SidebarMenuSkeleton,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
 import { QUERY_KEYS } from "@/constants/common/query-keys";
 import {
   LIVE_LIST_DEFAULT_FILTER,
@@ -217,6 +220,11 @@ export default function LiveSidebar({ isMobile }: LiveSidebarProps) {
           </SidebarMenu>
         </LiveSidebarSection>
       </SidebarContent>
+
+      <SidebarFooter className="gap-0 p-0">
+        <Separator />
+        <SidebarCredits />
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/src/components/live/mini-player/live-mini-player-host.tsx
+++ b/src/components/live/mini-player/live-mini-player-host.tsx
@@ -23,6 +23,8 @@ export function LiveMiniPlayerHost() {
   // 별도 창 라우트(OBS 출력·팝아웃)에선 아무것도 안 띄운다.
   if (
     !session ||
+    // 인증 플로우(로그인·회원가입·프로필 완성)에선 미니플레이어를 숨긴다 — 집중 화면이라 PIP가 부적절.
+    pathname.startsWith("/auth/") ||
     LIVE_WATCH_ROUTE_PATTERN.test(pathname) ||
     LIVE_OVERLAY_ROUTE_PATTERN.test(pathname)
   ) {

--- a/src/components/live/mini-player/live-mini-player-host.tsx
+++ b/src/components/live/mini-player/live-mini-player-host.tsx
@@ -15,17 +15,21 @@ export function LiveMiniPlayerHost() {
   const pathname = usePathname();
   const session = useLiveWatchSessionStore((state) => state.session);
   const endSession = useLiveWatchSessionStore((state) => state.endSession);
+  // 사용자가 시청 페이지에서 명시적으로 켠 PIP — 켜져 있으면 시청 페이지에서도 미니를 띄운다.
+  const isPip = useLiveWatchSessionStore((state) => state.isPip);
 
   useLiveViewerPresence(session?.broadcastId);
 
   // 표시 여부는 순수 파생 — 시청 페이지(어느 크리에이터든 — LiveView가 세션을 인수/종료하므로,
   // 시청 간 전환 로딩 중 직전 방송 미니가 잠깐 떠 HLS가 이중 기동하는 것 방지)와
   // 별도 창 라우트(OBS 출력·팝아웃)에선 아무것도 안 띄운다.
+  // 단, 시청 페이지여도 사용자가 PIP를 켰으면(isPip) 미니로 띄운다 — 인라인 비디오는 안내로
+  // 교체돼 있어(LivePipPlaceholder) 이중 기동이 아니다(한쪽만 <video>를 가진다).
   if (
     !session ||
     // 인증 플로우(로그인·회원가입·프로필 완성)에선 미니플레이어를 숨긴다 — 집중 화면이라 PIP가 부적절.
     pathname.startsWith("/auth/") ||
-    LIVE_WATCH_ROUTE_PATTERN.test(pathname) ||
+    (LIVE_WATCH_ROUTE_PATTERN.test(pathname) && !isPip) ||
     LIVE_OVERLAY_ROUTE_PATTERN.test(pathname)
   ) {
     return null;

--- a/src/components/live/mini-player/live-mini-player.tsx
+++ b/src/components/live/mini-player/live-mini-player.tsx
@@ -3,9 +3,9 @@
 // 본문 더블클릭·우상단 복귀 버튼=시청 화면 복귀(세션 유지), X=시청 종료(presence 퇴장), 종료 신호=자동 닫기+토스트.
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useRef, type PointerEvent as ReactPointerEvent } from "react";
-import { Pause, Play, SquareArrowOutUpRight, X } from "lucide-react";
+import { GripHorizontal, Pause, Play, SquareArrowOutUpRight, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { motion } from "motion/react";
 
@@ -20,7 +20,7 @@ import { useHlsPlayer } from "@/hooks/live/use-hls-player";
 import { useLiveBroadcastRealtime } from "@/hooks/live/use-live-broadcast-realtime";
 import { useLivePlayerControls } from "@/hooks/live/use-live-player-controls";
 import { cn } from "@/lib/utils";
-import type { LiveWatchSession } from "@/stores/live-watch-session";
+import { useLiveWatchSessionStore, type LiveWatchSession } from "@/stores/live-watch-session";
 import { toastAppInfo } from "@/utils/common/toast-message";
 
 interface Props {
@@ -39,6 +39,9 @@ const CONTROL_INTERACTIVITY_CLASS =
 
 export function LiveMiniPlayer({ session, onClose }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
+  const setPip = useLiveWatchSessionStore((state) => state.setPip);
+  const isPip = useLiveWatchSessionStore((state) => state.isPip);
   const queryClient = useQueryClient();
   const rootRef = useRef<HTMLDivElement>(null);
   // 드래그(motion/react, sticky-save-bar와 동일 패턴) 이동을 뷰포트 안으로 가두는 제약 컨테이너.
@@ -63,6 +66,18 @@ export function LiveMiniPlayer({ session, onClose }: Props) {
     onClose();
   }
 
+  // 시청 화면 복귀(본문 더블클릭 경로) — 같은 시청 페이지에서 PIP를 켠 경우엔 네비 없이 인라인으로
+  // 즉시 되돌리고(미니가 언마운트되므로 포커스를 본문으로 회수), 다른 라우터에 있을 땐 시청 페이지로
+  // 이동한다(watch 캐시 보존으로 빠르게 뜬다).
+  function handleReturn() {
+    setPip(false);
+    if (pathname === watchHref) {
+      recoverFocusBeforeClose();
+      return;
+    }
+    router.push(watchHref);
+  }
+
   // 컨트롤(버튼·음량 슬라이더)에서 시작한 포인터는 패널 드래그를 시작시키지 않는다 — 이벤트가
   // motion 드래그 리스너가 달린 루트로 버블되기 전에 차단한다(버튼 클릭·슬라이더 조작 자체는 유지).
   function stopDragFromControls(event: ReactPointerEvent) {
@@ -76,9 +91,12 @@ export function LiveMiniPlayer({ session, onClose }: Props) {
     enabled: !!session.hlsSrc,
   });
 
-  // 미니 표시 중엔 시청 화면(use-live-view-data)이 언마운트라 여기서 방송 채널을 구독한다(상호 배타 — 중복 구독 없음).
+  // 미니 표시 중엔 시청 화면(use-live-view-data)이 언마운트라 여기서 방송 채널을 구독한다.
   // verifyOnFirstJoin: 시청→미니 핸드오프 갭(이전 구독 해제~새 구독 사이)에 종료된 방송을 첫 조인에서 잡는다.
-  useLiveBroadcastRealtime(session.broadcastId, {
+  // 단, PIP(시청 페이지에 머문 채 미니)일 땐 시청 화면이 살아 있어 같은 broadcast 채널을 이미 구독 중이다 —
+  // 같은 채널명 이중 구독은 Supabase Realtime에서 에러이므로, PIP일 땐 구독을 양보한다(broadcastId=null →
+  // 스킵). 그때의 종료 처리·토스트는 시청 화면(use-live-view-data) 쪽이 담당한다.
+  useLiveBroadcastRealtime(isPip ? null : session.broadcastId, {
     verifyOnFirstJoin: true,
     onEnded: () => {
       // 시청 화면이 언마운트 상태라 watch 캐시가 '라이브'인 채 남는다 — staleTime 안에 재진입하면
@@ -103,14 +121,60 @@ export function LiveMiniPlayer({ session, onClose }: Props) {
         dragMomentum={false}
         dragElastic={0}
         whileDrag={{ cursor: "grabbing" }}
+        // 우하단에서 톡 떠오르는 등장 애니메이션. reduced-motion이면 motion이 자동으로 즉시 처리한다.
+        initial={{ opacity: 0, scale: 0.92, y: 24 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: "spring", stiffness: 360, damping: 28 }}
         className={cn(
           // bottom-24: 우하단 모서리에 뜨는 토스트(sonner)·하단 중앙의 설정 저장 바(StickySaveBar,
           // bottom-6+높이 약 58px)의 출현 영역 위로 올려, 모든 폭에서 겹치지 않게 한다.
-          "group pointer-events-auto absolute right-4 bottom-24 w-80 overflow-hidden bg-black shadow-lg",
+          // 윈도우 창처럼 라운드+테두리+그림자로 띄운다.
+          "group pointer-events-auto absolute right-4 bottom-24 w-80 overflow-hidden rounded-xl border border-white/10 bg-black shadow-2xl",
           "md:w-96",
           "cursor-grab active:cursor-grabbing",
         )}
       >
+        {/* 뚜껑(윈도우 타이틀바) — hover/포커스 시 위에서 열린다. 좌측 드래그 핸들, 우측 복귀·닫기.
+            영상 프레임 바깥(위)에 두어 "창을 연" 느낌을 준다. 터치 기기(hover 없음)는 항상 펼친다. */}
+        <div className="flex max-h-0 items-center justify-between overflow-hidden bg-black/95 transition-[max-height] duration-200 group-focus-within:max-h-12 group-hover:max-h-12 pointer-coarse:max-h-12">
+          <span className="flex items-center gap-1.5 px-2.5 text-white/40">
+            <GripHorizontal className="size-4" />
+            <span className="text-xs font-semibold tracking-wide">{LIVE_LABEL.miniPlayer}</span>
+          </span>
+          {/* onPointerDown stopPropagation: 버튼에서 시작한 포인터는 패널 드래그를 시작시키지 않는다. */}
+          <div onPointerDown={stopDragFromControls} className="flex gap-0.5 p-1">
+            <Button
+              size="icon"
+              variant="ghost"
+              nativeButton={false}
+              render={<Link href={watchHref} />}
+              aria-label={LIVE_LABEL.miniPlayerReturn}
+              className={LIVE_PLAYER_ICON_BUTTON_CLASS}
+              onClick={(event) => {
+                setPip(false);
+                // 같은 시청 페이지에서 PIP를 켰으면 네비 없이 인라인으로 즉시 복원한다(미니 언마운트 →
+                // 포커스 회수). 다른 라우터면 Link가 watch로 이동(prefetch + watch 캐시 보존으로 빠르게).
+                if (pathname === watchHref) {
+                  event.preventDefault();
+                  recoverFocusBeforeClose();
+                }
+              }}
+            >
+              <SquareArrowOutUpRight className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              aria-label={LIVE_LABEL.miniPlayerClose}
+              className={LIVE_PLAYER_ICON_BUTTON_CLASS}
+              onClick={handleClose}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        </div>
+
         {/* video+대기 오버레이는 메인(live-video-player)과 동일 마크업이지만, 그쪽은 전체화면 채팅
             인셋 래퍼와 결합돼 있어 의도적으로 추출하지 않는다(attach 정책은 useHlsPlayer로 공유). */}
         <div className="relative aspect-video">
@@ -125,50 +189,8 @@ export function LiveMiniPlayer({ session, onClose }: Props) {
 
           {/* 본문 = 드래그 표면 + 더블클릭 시 시청 화면 복귀(세션 유지 — presence 무중단). 단일 클릭은
             드래그 의도와 충돌하므로 내비하지 않는다. 커서(grab)는 루트에서 상속. 접근성 이름·탭 스톱·
-            단일클릭 복귀는 우상단 복귀 버튼이 담당한다. */}
-          <div
-            aria-hidden
-            onDoubleClick={() => router.push(watchHref)}
-            className="absolute inset-0"
-          />
-
-          {/* hover/포커스 시 상단 그라데이션: 우상단 복귀(시청 화면으로) + 닫기(X = 의도된 퇴장, 시청자 수 -1) */}
-          <div
-            className={cn(
-              "pointer-events-none absolute inset-x-0 top-0",
-              "flex justify-end gap-0.5 p-1.5 pb-8",
-              "bg-linear-to-b from-black/60 to-transparent",
-              OVERLAY_VISIBILITY_CLASS,
-            )}
-          >
-            {/* 클릭 수신은 이 컨트롤 그룹 div 한 곳에서만 토글한다 — 버튼마다 부착하면 새 컨트롤 추가 시 누락된다.
-              onPointerDown stopPropagation: 이 그룹에서 시작한 포인터는 패널 드래그를 시작시키지 않는다. */}
-            <div
-              onPointerDown={stopDragFromControls}
-              className={cn("flex gap-0.5", CONTROL_INTERACTIVITY_CLASS)}
-            >
-              <Button
-                size="icon"
-                variant="ghost"
-                nativeButton={false}
-                render={<Link href={watchHref} />}
-                aria-label={LIVE_LABEL.miniPlayerReturn}
-                className={LIVE_PLAYER_ICON_BUTTON_CLASS}
-              >
-                <SquareArrowOutUpRight className="size-5" />
-              </Button>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                aria-label={LIVE_LABEL.miniPlayerClose}
-                className={LIVE_PLAYER_ICON_BUTTON_CLASS}
-                onClick={handleClose}
-              >
-                <X className="size-5" />
-              </Button>
-            </div>
-          </div>
+            단일클릭 복귀는 뚜껑의 복귀 버튼이 담당한다. */}
+          <div aria-hidden onDoubleClick={handleReturn} className="absolute inset-0" />
 
           {/* hover/포커스 시 하단 그라데이션: 좌하단 재생·음량 컨트롤 + 점멸 LIVE(메인 컨트롤 바와 공유) */}
           <div

--- a/src/components/live/view/live-chat-input-bar.tsx
+++ b/src/components/live/view/live-chat-input-bar.tsx
@@ -101,6 +101,9 @@ function getChatPlaceholder({
       return LIVE_LABEL.chatWaitPlaceholder;
     case "manager_only":
       return LIVE_LABEL.chatManagerOnlyPlaceholder;
+    case "live_offline":
+      // 오프라인 채널(채팅 미개방)에선 로그인 상태여도 "로그인 후 채팅"이 아니라 방송 대기 안내를 보여준다.
+      return LIVE_LABEL.chatOfflinePlaceholder;
     default:
       return LIVE_LABEL.chatLoginPlaceholder;
   }
@@ -304,7 +307,7 @@ export function LiveChatInputBar({
           extraStickers={channelStickers}
           className="max-h-32 w-full min-w-0 overflow-y-auto px-3 py-1.5 pr-17 leading-8 outline-none"
         />
-        <div className="absolute right-1 bottom-1.5 flex items-center gap-0.5">
+        <div className="absolute right-1 bottom-1 flex items-center gap-0.5">
           <StickerPicker
             onStickerSelect={(token) =>
               setDraftValue(appendStickerToken(draftValue, token, LIVE_CHAT_MESSAGE_MAX_LENGTH))

--- a/src/components/live/view/live-login-prompt-dialog.tsx
+++ b/src/components/live/view/live-login-prompt-dialog.tsx
@@ -17,12 +17,15 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onLogin: () => void;
+  // 전체화면 요소 안에서 열릴 때 그 노드를 포털 대상으로 받는다(미지정 시 기본 body라 전체화면 밖에 렌더돼 안 보임).
+  container?: HTMLElement | null;
 }
 
-export function LiveLoginPromptDialog({ open, onOpenChange, onLogin }: Props) {
+export function LiveLoginPromptDialog({ open, onOpenChange, onLogin, container }: Props) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        container={container ?? undefined}
         showCloseButton={false}
         className={cn(
           "overflow-hidden rounded-2xl p-0 shadow-xl sm:max-w-md",

--- a/src/components/live/view/live-pip-placeholder.tsx
+++ b/src/components/live/view/live-pip-placeholder.tsx
@@ -18,10 +18,7 @@ export function LivePipPlaceholder({ onReturn }: Props) {
       <div className="bg-background/70 text-muted-foreground flex size-14 items-center justify-center rounded-full">
         <PictureInPicture2 className="size-7" />
       </div>
-      <div className="space-y-1">
-        <p className="text-foreground text-sm font-semibold">{LIVE_LABEL.pipActiveTitle}</p>
-        <p className="text-muted-foreground text-xs">{LIVE_LABEL.pipActiveDescription}</p>
-      </div>
+      <p className="text-foreground text-sm font-semibold">{LIVE_LABEL.pipActiveTitle}</p>
       <Button type="button" size="sm" variant="secondary" onClick={onReturn}>
         {LIVE_LABEL.pipReturnInline}
       </Button>

--- a/src/components/live/view/live-pip-placeholder.tsx
+++ b/src/components/live/view/live-pip-placeholder.tsx
@@ -1,0 +1,30 @@
+"use client";
+// PIP(미니플레이어)로 전환했을 때 시청 페이지의 원래 비디오 자리에 남기는 안내.
+// 같은 16:9 자리를 유지해 채팅·정보 행 레이아웃이 흔들리지 않게 하고, 미니로 시청 중임을
+// 알리며 인라인 재생으로 즉시 복귀하는 버튼을 둔다(같은 페이지라 네비 없이 상태 전환만).
+
+import { PictureInPicture2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { LIVE_LABEL } from "@/constants/live/live";
+
+interface Props {
+  onReturn: () => void;
+}
+
+export function LivePipPlaceholder({ onReturn }: Props) {
+  return (
+    <div className="bg-muted/40 relative flex aspect-video w-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <div className="bg-background/70 text-muted-foreground flex size-14 items-center justify-center rounded-full">
+        <PictureInPicture2 className="size-7" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-foreground text-sm font-semibold">{LIVE_LABEL.pipActiveTitle}</p>
+        <p className="text-muted-foreground text-xs">{LIVE_LABEL.pipActiveDescription}</p>
+      </div>
+      <Button type="button" size="sm" variant="secondary" onClick={onReturn}>
+        {LIVE_LABEL.pipReturnInline}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/live/view/live-player-control-bar.tsx
+++ b/src/components/live/view/live-player-control-bar.tsx
@@ -7,10 +7,10 @@ import {
   Minimize2,
   PanelRightOpen,
   Pause,
-  PictureInPicture2,
   Play,
   RectangleHorizontal,
   Scissors,
+  SquareArrowOutUpRight,
   Users,
 } from "lucide-react";
 
@@ -134,6 +134,28 @@ export function LivePlayerControlBar({
       </span>
 
       <div className="ml-auto flex items-center gap-1">
+        {/* PIP: 미니로 빼고 본문엔 안내를 띄운다(시청 페이지 전용). 미니 복귀 아이콘과 동일하게 맞추고
+            우측 그룹 가장 왼쪽(극장 모드보다 앞)에 둔다. */}
+        {onPipClick ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label={LIVE_LABEL.playerPip}
+                  className={LIVE_PLAYER_ICON_BUTTON_CLASS}
+                  onClick={onPipClick}
+                />
+              }
+            >
+              <SquareArrowOutUpRight className="size-6" />
+            </TooltipTrigger>
+            <TooltipContent>{LIVE_LABEL.playerPip}</TooltipContent>
+          </Tooltip>
+        ) : null}
+
         {onClipClick ? (
           <Tooltip>
             <TooltipTrigger
@@ -204,28 +226,6 @@ export function LivePlayerControlBar({
               <PanelRightOpen className="size-6" />
             </TooltipTrigger>
             <TooltipContent>{LIVE_LABEL.chatExpand}</TooltipContent>
-          </Tooltip>
-        ) : null}
-
-        {/* PIP: 미니플레이어로 빼고 본문 자리엔 안내를 띄운다 — 시청 페이지에서만 내려온다.
-            전체화면과 같은 '창 모드' 계열이라 바로 옆에 둔다. */}
-        {onPipClick ? (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  aria-label={LIVE_LABEL.playerPip}
-                  className={LIVE_PLAYER_ICON_BUTTON_CLASS}
-                  onClick={onPipClick}
-                />
-              }
-            >
-              <PictureInPicture2 className="size-6" />
-            </TooltipTrigger>
-            <TooltipContent>{LIVE_LABEL.playerPip}</TooltipContent>
           </Tooltip>
         ) : null}
 

--- a/src/components/live/view/live-player-control-bar.tsx
+++ b/src/components/live/view/live-player-control-bar.tsx
@@ -7,6 +7,7 @@ import {
   Minimize2,
   PanelRightOpen,
   Pause,
+  PictureInPicture2,
   Play,
   RectangleHorizontal,
   Scissors,
@@ -50,6 +51,8 @@ interface Props {
   onSeekToLive: () => void;
   // 클립 생성(#124) — 송출 프레임이 있을 때만 상위에서 핸들러를 내려준다.
   onClipClick?: () => void;
+  // PIP 전환 — 시청 페이지에서만 내려온다(미니플레이어로 빼고 본문엔 안내를 띄운다).
+  onPipClick?: () => void;
 }
 
 export function LivePlayerControlBar({
@@ -75,6 +78,7 @@ export function LivePlayerControlBar({
   isAtLiveEdge,
   onSeekToLive,
   onClipClick,
+  onPipClick,
 }: Props) {
   return (
     <div className="flex items-center gap-2">
@@ -200,6 +204,28 @@ export function LivePlayerControlBar({
               <PanelRightOpen className="size-6" />
             </TooltipTrigger>
             <TooltipContent>{LIVE_LABEL.chatExpand}</TooltipContent>
+          </Tooltip>
+        ) : null}
+
+        {/* PIP: 미니플레이어로 빼고 본문 자리엔 안내를 띄운다 — 시청 페이지에서만 내려온다.
+            전체화면과 같은 '창 모드' 계열이라 바로 옆에 둔다. */}
+        {onPipClick ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label={LIVE_LABEL.playerPip}
+                  className={LIVE_PLAYER_ICON_BUTTON_CLASS}
+                  onClick={onPipClick}
+                />
+              }
+            >
+              <PictureInPicture2 className="size-6" />
+            </TooltipTrigger>
+            <TooltipContent>{LIVE_LABEL.playerPip}</TooltipContent>
           </Tooltip>
         ) : null}
 

--- a/src/components/live/view/live-video-player.tsx
+++ b/src/components/live/view/live-video-player.tsx
@@ -363,7 +363,9 @@ export function LiveVideoPlayer({
         // 좌측 칼럼이 세로 스크롤된다(LiveView). 높이를 캡하면 영상 좌우에 검은 띠가 생긴다.
         isTheater ? "aspect-video md:aspect-auto md:h-full" : "aspect-video",
         // 몰입 모드(극장·전체화면)에서 컨트롤이 숨겨지면 커서도 함께 숨겨 몰입감을 준다.
-        isImmersive && !controlsVisible && "cursor-none",
+        // 단, 전체화면 채팅 패널이 열렸으면(후원 popover 등 상호작용) 커서를 숨기지 않는다 —
+        // cursor-none이 포털된 popover까지 상속돼 마우스가 사라지는 것을 막는다.
+        isImmersive && !controlsVisible && !isFsChatOpen && "cursor-none",
       )}
     >
       {hlsSrc ? (

--- a/src/components/live/view/live-video-player.tsx
+++ b/src/components/live/view/live-video-player.tsx
@@ -50,6 +50,8 @@ interface Props {
   onOpenChat?: () => void;
   // 전체화면일 때 컨테이너 내부에 렌더할 채팅/후원 오버레이. 데이터를 가진 상위(LiveView)가 주입한다.
   renderFullscreenChat?: (ctx: FullscreenChatContext) => ReactNode;
+  // 전체화면 컨테이너 노드를 상위(LiveView)에 노출 — 비로그인 후원 안내 등 모달을 전체화면 안에 포털하기 위해.
+  onFullscreenContainerChange?: (container: HTMLElement | null) => void;
   // 클립 버튼: 로그인 여부(상위 결정) + 비로그인 시 콜백 + 캡처 완료 콜백. 에디터는 별도 창으로
   // 열어 라이브를 보면서 편집하게 한다(팝업은 제스처 동기 시점에 열려야 차단되지 않는다).
   clipLoggedIn?: boolean;
@@ -170,6 +172,7 @@ export function LiveVideoPlayer({
   openChatButtonRef,
   onOpenChat,
   renderFullscreenChat,
+  onFullscreenContainerChange,
   clipLoggedIn,
   onClipRequireLogin,
   onClipReady,
@@ -197,6 +200,11 @@ export function LiveVideoPlayer({
       setIsFsDonationRequested(false);
     }
   }, [isFullscreen]);
+
+  // 전체화면일 때만 컨테이너 노드를 상위에 알린다(해제 시 null) — 상위 Dialog의 포털 대상.
+  useEffect(() => {
+    onFullscreenContainerChange?.(isFullscreen ? containerEl : null);
+  }, [isFullscreen, containerEl, onFullscreenContainerChange]);
 
   // 채팅을 닫으면 우상단 스택의 토글 버튼으로 포커스를 되돌린다(패널 X에 갇힌 포커스 회수).
   // 여는 방향은 오버레이가 패널 X 버튼으로 포커스를 옮긴다. 초기 마운트엔 가로채지 않는다.

--- a/src/components/live/view/live-video-player.tsx
+++ b/src/components/live/view/live-video-player.tsx
@@ -61,6 +61,8 @@ interface Props {
     snapshotDataUrl: string | null;
     frames: string[];
   }) => void;
+  // PIP 전환 — 컨트롤 바로 그대로 전달한다(미니 표시·본문 안내는 상위 LiveView가 처리).
+  onPipClick?: () => void;
 }
 
 // 별도 창 핸드오프(localStorage)로 넘기므로 과대 용량을 막으려 720p로 다운스케일한다.
@@ -176,6 +178,7 @@ export function LiveVideoPlayer({
   clipLoggedIn,
   onClipRequireLogin,
   onClipReady,
+  onPipClick,
 }: Props) {
   const { containerRef, isFullscreen, toggleFullscreen } = useFullscreen<HTMLDivElement>();
   // 전체화면 채팅 패널 열림 상태. 컨트롤 바 폭(채팅이 가리지 않게)과 공유해야 해 여기서 소유한다.
@@ -472,6 +475,7 @@ export function LiveVideoPlayer({
             onClipClick={
               onClipReady && playbackState === "playing" ? () => void handleClipClick() : undefined
             }
+            onPipClick={onPipClick}
           />
         </div>
       ) : null}

--- a/src/components/live/view/live-view.tsx
+++ b/src/components/live/view/live-view.tsx
@@ -171,6 +171,8 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
   };
 
   const [isLoginPromptOpen, setIsLoginPromptOpen] = useState(false);
+  // 전체화면 시 비로그인 후원 안내 Dialog를 전체화면 요소 안에 포털하기 위한 컨테이너 노드(해제 시 null=body).
+  const [fullscreenContainer, setFullscreenContainer] = useState<HTMLElement | null>(null);
   const [isDesktopChatCollapsed, setIsDesktopChatCollapsed] = useState(false);
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -378,6 +380,7 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
                     clipLoggedIn={isLoggedIn}
                     onClipRequireLogin={openLoginPrompt}
                     onClipReady={handleClipReady}
+                    onFullscreenContainerChange={setFullscreenContainer}
                     renderFullscreenChat={({
                       container,
                       isChatOpen,
@@ -515,6 +518,7 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
         open={isLoginPromptOpen}
         onOpenChange={setIsLoginPromptOpen}
         onLogin={moveToLogin}
+        container={fullscreenContainer}
       />
 
       <LiveBannedDialog

--- a/src/components/live/view/live-view.tsx
+++ b/src/components/live/view/live-view.tsx
@@ -10,6 +10,7 @@ import { ClipSection } from "@/components/clip/clip-section";
 import { ChannelStickerProvider } from "@/components/live/chat/channel-sticker-context";
 import { LiveChatDataProvider } from "@/components/live/view/live-chat-data-context";
 import { LiveVideoPlayer } from "@/components/live/view/live-video-player";
+import { LivePipPlaceholder } from "@/components/live/view/live-pip-placeholder";
 import { LiveFullscreenChatOverlay } from "@/components/live/view/live-fullscreen-chat-overlay";
 import { LiveBroadcastInfo } from "@/components/live/view/live-broadcast-info";
 import { LiveStreamerRow } from "@/components/live/view/live-streamer-row";
@@ -218,6 +219,9 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
   // 로딩 중엔 판단을 보류해, 다른 라이브의 미니가 재생 중이면 새 화면 데이터가 올 때까지 유지한다.
   const startSession = useLiveWatchSessionStore((state) => state.startSession);
   const endSession = useLiveWatchSessionStore((state) => state.endSession);
+  // PIP(미니) 전환 상태 — 시청 페이지에 머문 채 비디오만 미니로 빼고 본문엔 안내를 띄운다.
+  const isPip = useLiveWatchSessionStore((state) => state.isPip);
+  const setPip = useLiveWatchSessionStore((state) => state.setPip);
   // 현재 store에 들어있는 세션의 크리에이터 — 오류 시 '이 화면 것'인지 '묵은 다른 방송 것'인지 구분한다.
   const sessionCreatorId = useLiveWatchSessionStore((state) => state.session?.creatorId);
   // broadcast 객체는 매 렌더 재생성되므로(map 함수) 원시값만 deps에 두어,
@@ -317,6 +321,13 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
     }
   }
 
+  // PIP 진입: 큰 화면(극장)과는 모순이므로 극장 모드를 풀고 미니로 뺀다 — 미니 표시는
+  // 루트 호스트(LiveMiniPlayerHost)가 세션·isPip 기준으로 처리한다.
+  function enterPip() {
+    setWideMode(false);
+    setPip(true);
+  }
+
   function collapseDesktopChat() {
     setIsDesktopChatCollapsed(true);
     requestAnimationFrame(() => {
@@ -368,36 +379,43 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
               {/* 일반 모드는 shrink-0 — 칼럼이 넘칠 때 눌리는 대신 스크롤로 넘어가야 한다. */}
               <div className={cn(isTheater ? "md:min-h-0 md:flex-1" : "md:shrink-0")}>
                 {broadcast && !isBanned ? (
-                  <LiveVideoPlayer
-                    broadcast={broadcast}
-                    hlsSrc={hlsSrc}
-                    elapsedText={elapsedText}
-                    isChatCollapsed={isChatCollapsed}
-                    isTheater={isTheater}
-                    onToggleTheater={toggleTheater}
-                    openChatButtonRef={openChatButtonRef}
-                    onOpenChat={expandDesktopChat}
-                    clipLoggedIn={isLoggedIn}
-                    onClipRequireLogin={openLoginPrompt}
-                    onClipReady={handleClipReady}
-                    onFullscreenContainerChange={setFullscreenContainer}
-                    renderFullscreenChat={({
-                      container,
-                      isChatOpen,
-                      onToggleChat,
-                      isDonationRequested,
-                      onDonationSettled,
-                    }) => (
-                      <LiveFullscreenChatOverlay
-                        container={container}
-                        isChatOpen={isChatOpen}
-                        onToggleChat={onToggleChat}
-                        creatorId={creatorId}
-                        donationOpenRequested={isDonationRequested}
-                        onDonationOpenSettled={onDonationSettled}
-                      />
-                    )}
-                  />
+                  isPip ? (
+                    // PIP로 전환하면 같은 16:9 자리에 안내를 띄운다(레이아웃 유지). 미니플레이어는
+                    // 루트 호스트가 세션·isPip 기준으로 띄우고, '여기서 다시 보기'는 네비 없이 상태만 되돌린다.
+                    <LivePipPlaceholder onReturn={() => setPip(false)} />
+                  ) : (
+                    <LiveVideoPlayer
+                      broadcast={broadcast}
+                      hlsSrc={hlsSrc}
+                      elapsedText={elapsedText}
+                      isChatCollapsed={isChatCollapsed}
+                      isTheater={isTheater}
+                      onToggleTheater={toggleTheater}
+                      openChatButtonRef={openChatButtonRef}
+                      onOpenChat={expandDesktopChat}
+                      clipLoggedIn={isLoggedIn}
+                      onClipRequireLogin={openLoginPrompt}
+                      onClipReady={handleClipReady}
+                      onPipClick={enterPip}
+                      onFullscreenContainerChange={setFullscreenContainer}
+                      renderFullscreenChat={({
+                        container,
+                        isChatOpen,
+                        onToggleChat,
+                        isDonationRequested,
+                        onDonationSettled,
+                      }) => (
+                        <LiveFullscreenChatOverlay
+                          container={container}
+                          isChatOpen={isChatOpen}
+                          onToggleChat={onToggleChat}
+                          creatorId={creatorId}
+                          donationOpenRequested={isDonationRequested}
+                          onDonationOpenSettled={onDonationSettled}
+                        />
+                      )}
+                    />
+                  )
                 ) : isBanned && broadcast ? (
                   // 강퇴 상태에선 플레이어를 언마운트해 영상/오디오를 즉시 끊고, 같은 16:9 자리에 검은 프레임만
                   // 남겨 레이아웃(채팅 입력 높이 동기화)을 유지한다. 위에는 LiveBannedDialog 모달이 덮인다.

--- a/src/components/live/view/live-view.tsx
+++ b/src/components/live/view/live-view.tsx
@@ -296,6 +296,11 @@ export function LiveView({ creatorId, hlsSrc }: Props) {
 
   function openLoginPrompt() {
     if (isAuthLoading) return;
+    // 전체화면 중이면 빠져나온 뒤 안내한다 — 전체화면 안에선 cursor-none·포털 위치 때문에
+    // 로그인 안내 Dialog가 보이지 않아(마우스 포인터도 숨겨짐), 일반 화면에서 또렷이 띄운다.
+    if (document.fullscreenElement) {
+      void document.exitFullscreen().catch(() => {});
+    }
     setIsLoginPromptOpen(true);
   }
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,10 +1,30 @@
+"use client";
+// 빠른 로딩에서 Skeleton이 번쩍 떴다 사라지는 깜빡임을 막는다 — 마운트 후 짧은 지연이 지난 뒤에만
+// 부드럽게 나타나, 데이터가 그 전에 도착하면 Skeleton 자체가 보이지 않는다(지연 노출 패턴).
+
+import { useEffect, useState } from "react";
+
 import { cn } from "@/lib/utils/index";
 
+// 이 시간 안에 끝나는 로딩은 Skeleton을 아예 보여주지 않는다(번쩍임 방지). 넘기면 부드럽게 fade-in.
+const SKELETON_REVEAL_DELAY_MS = 250;
+
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setRevealed(true), SKELETON_REVEAL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-muted animate-pulse rounded-md", className)}
+      className={cn(
+        "bg-muted animate-pulse rounded-md transition-opacity duration-200",
+        revealed ? "opacity-100" : "opacity-0",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/constants/channel/channel-emoji.ts
+++ b/src/constants/channel/channel-emoji.ts
@@ -35,9 +35,9 @@ export const CHANNEL_EMOJI_LABEL = {
   // 사이드 팁
   tipTitle: "이모지를 등록하기 전에 확인해요",
   tipDescription:
-    "투명 배경 PNG로 우리 채널만의 이모지를 만들 수 있어요.\n구독자는 채팅에서 이 이모지를 골라 쓸 수 있어요.",
-  tipStep1Title: "투명 배경 PNG로 준비해요",
-  tipStep1Desc: "배경이 비치는 정사각형 PNG가 채팅에서 가장 깔끔하게 보여요.",
+    "투명 배경 PNG·WebP로 우리 채널만의 이모지를 만들 수 있어요.\n구독자는 채팅에서 이 이모지를 골라 쓸 수 있어요.",
+  tipStep1Title: "투명 배경 PNG·WebP로 준비해요",
+  tipStep1Desc: "배경이 비치는 정사각형 PNG·WebP가 채팅에서 가장 깔끔하게 보여요.",
   tipStep2Title: "최대 10개까지 등록해요",
   tipStep2Desc: "자주 쓰는 표정·반응 위주로 골라 담으면 구독자가 더 즐겨 써요.",
   tipStep3Title: "구독자 전용으로 제공돼요",

--- a/src/constants/channel/chat.ts
+++ b/src/constants/channel/chat.ts
@@ -22,6 +22,11 @@ export const CHANNEL_CHAT_SCOPE_OPTIONS = [
     label: "팔로워만",
     description: "채널을 팔로우한 시청자에게만 채팅을 열어요.",
   },
+  {
+    value: "manager",
+    label: "매니저만",
+    description: "채널 매니저에게만 채팅을 열어요.",
+  },
 ] as const satisfies ReadonlyArray<{
   value: LiveChatScope;
   label: string;

--- a/src/constants/channel/security.ts
+++ b/src/constants/channel/security.ts
@@ -20,11 +20,8 @@ export const CHANNEL_SECURITY_TOKEN_KIND_SET = new Set<ChannelSecurityTokenKind>
 
 // 스트림 키·OBS URL을 "보기"로 노출한 뒤 자동으로 다시 가리기까지의 시간(CSEC-011, 어깨너머 노출 차단).
 // 복사 버튼이 따로 있어 길게 볼 일이 없고, 스트리머가 설정 화면을 켜둔 채 송출할 때 키가 화면에
-// 노출되는 사고를 막기 위해 30초 뒤 자동으로 다시 가린다.
+// 노출되는 사고를 막기 위해 노출 중 남은 시간을 실시간 카운트다운하고 0초가 되면 자동으로 다시 가린다.
 export const SECURITY_REVEAL_DURATION_MS = 30_000;
-
-// "보기"로 노출 중일 때 버튼 옆에 띄우는 자동 마스킹 안내(노출 시간 값과 자동으로 동기화한다).
-export const SECURITY_REVEAL_HINT = `${SECURITY_REVEAL_DURATION_MS / 1000}초 후 자동으로 다시 가려져요`;
 
 export const CHANNEL_SECURITY_ROTATE_SUCCESS_DESCRIPTION = {
   stream_key: "새 스트림 키를 만들었어요. OBS에 다시 붙여 넣어주세요.",

--- a/src/constants/channel/security.ts
+++ b/src/constants/channel/security.ts
@@ -18,6 +18,10 @@ export const CHANNEL_SECURITY_TOKEN_KIND_SET = new Set<ChannelSecurityTokenKind>
   "donation_alert",
 ]);
 
+// 스트림 키·OBS URL을 "보기"로 노출한 뒤 자동으로 다시 가리기까지의 시간(CSEC-011, 어깨너머 노출 차단).
+// 복사 버튼이 따로 있어 길게 노출할 필요가 없으므로 보안상 짧게 둔다(값 확정 필요 — 스펙 본문 1분 모순).
+export const SECURITY_REVEAL_DURATION_MS = 30_000;
+
 export const CHANNEL_SECURITY_ROTATE_SUCCESS_DESCRIPTION = {
   stream_key: "새 스트림 키를 만들었어요. OBS에 다시 붙여 넣어주세요.",
   chat_overlay: "새 채팅창 주소를 만들었어요. OBS에 다시 붙여 넣어주세요.",

--- a/src/constants/channel/security.ts
+++ b/src/constants/channel/security.ts
@@ -19,8 +19,12 @@ export const CHANNEL_SECURITY_TOKEN_KIND_SET = new Set<ChannelSecurityTokenKind>
 ]);
 
 // 스트림 키·OBS URL을 "보기"로 노출한 뒤 자동으로 다시 가리기까지의 시간(CSEC-011, 어깨너머 노출 차단).
-// 복사 버튼이 따로 있어 길게 노출할 필요가 없으므로 보안상 짧게 둔다(값 확정 필요 — 스펙 본문 1분 모순).
+// 복사 버튼이 따로 있어 길게 볼 일이 없고, 스트리머가 설정 화면을 켜둔 채 송출할 때 키가 화면에
+// 노출되는 사고를 막기 위해 30초 뒤 자동으로 다시 가린다.
 export const SECURITY_REVEAL_DURATION_MS = 30_000;
+
+// "보기"로 노출 중일 때 버튼 옆에 띄우는 자동 마스킹 안내(노출 시간 값과 자동으로 동기화한다).
+export const SECURITY_REVEAL_HINT = `${SECURITY_REVEAL_DURATION_MS / 1000}초 후 자동으로 다시 가려져요`;
 
 export const CHANNEL_SECURITY_ROTATE_SUCCESS_DESCRIPTION = {
   stream_key: "새 스트림 키를 만들었어요. OBS에 다시 붙여 넣어주세요.",

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -224,7 +224,7 @@ export const APP_MESSAGE = {
       },
       authInfoNotFound: {
         title: "인증 정보 없음",
-        description: "다시 로그인한 뒤 시도해주세요.",
+        description: "로그인 후 다시 시도해주세요.",
       },
       authInfoLoadFailed: {
         title: "인증 정보 조회 실패",

--- a/src/constants/common/app-message.ts
+++ b/src/constants/common/app-message.ts
@@ -531,7 +531,7 @@ export const APP_MESSAGE = {
       },
       emojiInvalidType: {
         title: "지원하지 않는 형식",
-        description: "투명 배경 PNG 이미지만 등록할 수 있어요.",
+        description: "투명 배경 PNG·WebP 이미지만 등록할 수 있어요.",
       },
       emojiSingleFileOnly: {
         title: "다중 등록 불가",

--- a/src/constants/common/user-account-menu.ts
+++ b/src/constants/common/user-account-menu.ts
@@ -41,7 +41,7 @@ export const USER_ACCOUNT_PRIMARY_MENU_ITEMS: UserAccountLinkMenuItem[] = [
   {
     type: "link",
     id: "channel",
-    label: "채널 관리",
+    label: "방송 설정",
     href: "/channel/live",
     icon: Radio,
   },

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -106,9 +106,8 @@ export const LIVE_LABEL = {
   miniPlayerClose: "미니플레이어 닫기",
   // PIP(미니플레이어) 전환 버튼 — 시청 페이지에서 명시적으로 띄운다.
   playerPip: "PIP로 보기",
-  // 시청 페이지 비디오 자리에 남기는 안내(미니로 보는 중).
-  pipActiveTitle: "PIP로 시청 중",
-  pipActiveDescription: "작은 창으로 방송을 계속 보고 있어요.",
+  // 시청 페이지 비디오 자리에 남기는 안내(제목만 — 설명 없이 간결하게).
+  pipActiveTitle: "PIP 모드로 보고 있어요.",
   pipReturnInline: "여기서 다시 보기",
 } as const;
 

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -104,6 +104,12 @@ export const LIVE_LABEL = {
   miniPlayer: "라이브 미니플레이어",
   miniPlayerReturn: "시청 화면으로 돌아가기",
   miniPlayerClose: "미니플레이어 닫기",
+  // PIP(미니플레이어) 전환 버튼 — 시청 페이지에서 명시적으로 띄운다.
+  playerPip: "PIP로 보기",
+  // 시청 페이지 비디오 자리에 남기는 안내(미니로 보는 중).
+  pipActiveTitle: "PIP로 시청 중",
+  pipActiveDescription: "작은 창으로 방송을 계속 보고 있어요.",
+  pipReturnInline: "여기서 다시 보기",
 } as const;
 
 // OBS 출력·채팅 팝아웃 등 별도 창 전용 라우트 — 앱 공통 크롬과 미니플레이어를 모두 숨긴다.

--- a/src/constants/live/live.ts
+++ b/src/constants/live/live.ts
@@ -47,6 +47,7 @@ export const LIVE_LABEL = {
   donationRankingExpand: "후원 랭킹 펼치기",
   emptyWeeklyDonation: "이번 주 첫 번째 팬이 되어보세요!",
   chatLoginPlaceholder: "로그인 후 채팅할 수 있습니다.",
+  chatOfflinePlaceholder: "방송이 시작되면 채팅할 수 있어요.",
   chatPlaceholder: "채팅을 입력해보세요!",
   chatSend: "채팅 전송",
   loginRequired: "로그인이 필요합니다.",

--- a/src/hooks/channel/use-channel-security-controls.ts
+++ b/src/hooks/channel/use-channel-security-controls.ts
@@ -2,7 +2,10 @@
 // 채널 보안 설정 화면의 클라이언트 상호작용을 관리합니다.
 
 import { rotateChannelSecurityTokenAction } from "@/actions/channel/security";
-import { CHANNEL_SECURITY_ROTATE_SUCCESS_DESCRIPTION } from "@/constants/channel/security";
+import {
+  CHANNEL_SECURITY_ROTATE_SUCCESS_DESCRIPTION,
+  SECURITY_REVEAL_DURATION_MS,
+} from "@/constants/channel/security";
 import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import type {
   ChannelSecuritySnapshot,
@@ -10,13 +13,24 @@ import type {
   ChannelSecurityUrlPopupSize,
 } from "@/types/channel/security";
 import { toastAppError, toastAppSuccess } from "@/utils/common/toast-message";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 export function useChannelSecurityControls(initialSnapshot: ChannelSecuritySnapshot) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [rotatingKind, setRotatingKind] = useState<ChannelSecurityTokenKind | null>(null);
   const [visibleKinds, setVisibleKinds] = useState<ChannelSecurityTokenKind[]>([]);
   const [isPending, startTransition] = useTransition();
+  // 노출 후 자동 마스킹 타이머(어깨너머 노출 차단, CSEC-011) — 토큰별로 따로 건다.
+  const hideTimersRef = useRef(new Map<ChannelSecurityTokenKind, ReturnType<typeof setTimeout>>());
+
+  // 언마운트 시 떠 있는 자동 숨김 타이머를 모두 정리한다.
+  useEffect(() => {
+    const timers = hideTimersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
 
   const handleCopy = async (value: string) => {
     try {
@@ -51,11 +65,25 @@ export function useChannelSecurityControls(initialSnapshot: ChannelSecuritySnaps
   };
 
   const handleToggleVisible = (tokenKind: ChannelSecurityTokenKind) => {
-    setVisibleKinds((current) =>
-      current.includes(tokenKind)
-        ? current.filter((item) => item !== tokenKind)
-        : [...current, tokenKind],
-    );
+    const timers = hideTimersRef.current;
+    const existing = timers.get(tokenKind);
+    if (existing) {
+      clearTimeout(existing);
+      timers.delete(tokenKind);
+    }
+
+    if (visibleKinds.includes(tokenKind)) {
+      setVisibleKinds((current) => current.filter((item) => item !== tokenKind));
+      return;
+    }
+
+    setVisibleKinds((current) => [...current, tokenKind]);
+    // 보기로 켜면 일정 시간 뒤 자동으로 다시 가린다(복사 버튼이 있어 길게 노출할 필요가 없다).
+    const timer = setTimeout(() => {
+      setVisibleKinds((current) => current.filter((item) => item !== tokenKind));
+      timers.delete(tokenKind);
+    }, SECURITY_REVEAL_DURATION_MS);
+    timers.set(tokenKind, timer);
   };
 
   const handleRotate = (tokenKind: ChannelSecurityTokenKind, onSuccess?: () => void) => {

--- a/src/hooks/channel/use-channel-security-controls.ts
+++ b/src/hooks/channel/use-channel-security-controls.ts
@@ -13,24 +13,48 @@ import type {
   ChannelSecurityUrlPopupSize,
 } from "@/types/channel/security";
 import { toastAppError, toastAppSuccess } from "@/utils/common/toast-message";
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
 export function useChannelSecurityControls(initialSnapshot: ChannelSecuritySnapshot) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [rotatingKind, setRotatingKind] = useState<ChannelSecurityTokenKind | null>(null);
-  const [visibleKinds, setVisibleKinds] = useState<ChannelSecurityTokenKind[]>([]);
+  // 노출 중인 토큰별 자동 마스킹 만료 시각(epoch ms). 키 존재 자체가 "노출 중"을 뜻하며,
+  // 카운트다운 표시와 만료 시 자동 가림(CSEC-011, 어깨너머·송출 노출 차단)에 함께 쓴다.
+  const [revealExpiry, setRevealExpiry] = useState<
+    Partial<Record<ChannelSecurityTokenKind, number>>
+  >({});
+  // 카운트다운(남은 초)을 주기적으로 다시 그리기 위한 틱. 값 자체는 리렌더 트리거 용도로만 쓴다.
+  const [, setRevealTick] = useState(0);
   const [isPending, startTransition] = useTransition();
-  // 노출 후 자동 마스킹 타이머(어깨너머 노출 차단, CSEC-011) — 토큰별로 따로 건다.
-  const hideTimersRef = useRef(new Map<ChannelSecurityTokenKind, ReturnType<typeof setTimeout>>());
 
-  // 언마운트 시 떠 있는 자동 숨김 타이머를 모두 정리한다.
+  const hasRevealCountdown = Object.keys(revealExpiry).length > 0;
+
+  // 노출 중인 토큰이 있는 동안 0.5초마다: 남은 시간 표시를 갱신하고 만료된 토큰은 자동으로 다시 가린다.
+  // setState를 effect 본문이 아니라 타이머 콜백에서 호출해 cascading 렌더를 피한다.
   useEffect(() => {
-    const timers = hideTimersRef.current;
-    return () => {
-      timers.forEach((timer) => clearTimeout(timer));
-      timers.clear();
-    };
-  }, []);
+    if (!hasRevealCountdown) {
+      return;
+    }
+    const intervalId = setInterval(() => {
+      const now = Date.now();
+      setRevealExpiry((current) => {
+        const remaining: Partial<Record<ChannelSecurityTokenKind, number>> = {};
+        let changed = false;
+        for (const key of Object.keys(current) as ChannelSecurityTokenKind[]) {
+          const expiry = current[key];
+          if (expiry !== undefined && expiry > now) {
+            remaining[key] = expiry;
+          } else {
+            // 만료 → remaining에 넣지 않음(= 자동으로 다시 가려짐).
+            changed = true;
+          }
+        }
+        return changed ? remaining : current;
+      });
+      setRevealTick((tick) => tick + 1);
+    }, 500);
+    return () => clearInterval(intervalId);
+  }, [hasRevealCountdown]);
 
   const handleCopy = async (value: string) => {
     try {
@@ -65,25 +89,16 @@ export function useChannelSecurityControls(initialSnapshot: ChannelSecuritySnaps
   };
 
   const handleToggleVisible = (tokenKind: ChannelSecurityTokenKind) => {
-    const timers = hideTimersRef.current;
-    const existing = timers.get(tokenKind);
-    if (existing) {
-      clearTimeout(existing);
-      timers.delete(tokenKind);
-    }
-
-    if (visibleKinds.includes(tokenKind)) {
-      setVisibleKinds((current) => current.filter((item) => item !== tokenKind));
-      return;
-    }
-
-    setVisibleKinds((current) => [...current, tokenKind]);
-    // 보기로 켜면 일정 시간 뒤 자동으로 다시 가린다(복사 버튼이 있어 길게 노출할 필요가 없다).
-    const timer = setTimeout(() => {
-      setVisibleKinds((current) => current.filter((item) => item !== tokenKind));
-      timers.delete(tokenKind);
-    }, SECURITY_REVEAL_DURATION_MS);
-    timers.set(tokenKind, timer);
+    // 노출 중(키 존재)이면 즉시 가리고, 아니면 만료 시각을 찍어 켠다(켜는 순간 카운트다운 시작).
+    setRevealExpiry((current) => {
+      const next = { ...current };
+      if (next[tokenKind] !== undefined) {
+        delete next[tokenKind];
+      } else {
+        next[tokenKind] = Date.now() + SECURITY_REVEAL_DURATION_MS;
+      }
+      return next;
+    });
   };
 
   const handleRotate = (tokenKind: ChannelSecurityTokenKind, onSuccess?: () => void) => {
@@ -113,12 +128,22 @@ export function useChannelSecurityControls(initialSnapshot: ChannelSecuritySnaps
     });
   };
 
+  // 노출 중인 토큰의 자동 마스킹까지 남은 초(올림). 노출 중이 아니면 0.
+  const getRevealRemaining = (tokenKind: ChannelSecurityTokenKind) => {
+    const expiry = revealExpiry[tokenKind];
+    if (expiry === undefined) {
+      return 0;
+    }
+    return Math.max(0, Math.ceil((expiry - Date.now()) / 1000));
+  };
+
   return {
     snapshot,
     rotatingKind,
     isPending,
     isRotating: isPending && rotatingKind !== null,
-    isVisibleKind: (tokenKind: ChannelSecurityTokenKind) => visibleKinds.includes(tokenKind),
+    isVisibleKind: (tokenKind: ChannelSecurityTokenKind) => revealExpiry[tokenKind] !== undefined,
+    getRevealRemaining,
     handleCopy,
     handlePreview,
     handleToggleVisible,

--- a/src/hooks/donations/use-toss-wallet-charge.ts
+++ b/src/hooks/donations/use-toss-wallet-charge.ts
@@ -13,7 +13,6 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import { QUERY_KEYS } from "@/constants/common/query-keys";
-import { useIsMobile } from "@/hooks/common/use-mobile";
 import type {
   TossPaymentsPaymentWindow,
   TossPaymentsWidgets,
@@ -23,6 +22,7 @@ import { loadTossPayments } from "@/utils/payments/toss-sdk";
 import {
   isTossPaymentCancelError,
   isValidChargeAmount,
+  prefersRedirectPayment,
   prepareTossWalletCharge,
 } from "@/utils/payments/toss-wallet-charge-client";
 
@@ -46,7 +46,6 @@ export function useTossWalletCharge({
   onChargeSettled,
 }: UseTossWalletChargeParams) {
   const clientKey = process.env.NEXT_PUBLIC_TOSS_PAYMENTS_CLIENT_KEY;
-  const isMobile = useIsMobile();
   const queryClient = useQueryClient();
   const [isCharging, setIsCharging] = useState(false);
   const paymentWindowRef = useRef<TossPaymentsPaymentWindow | null>(null);
@@ -117,8 +116,8 @@ export function useTossWalletCharge({
   async function confirmCharge(widgets: TossPaymentsWidgets, prepared: PreparedCharge) {
     setIsCharging(true);
     try {
-      if (isMobile) {
-        // 모바일: 카드사 앱으로 리다이렉트되어 Promise를 받을 수 없으므로 successUrl/failUrl로 복귀한다.
+      if (prefersRedirectPayment()) {
+        // 모바일·태블릿: 카드사 앱으로 리다이렉트되어 Promise를 받을 수 없으므로 successUrl/failUrl로 복귀한다(PAY-013).
         const returnToQuery = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : "";
         await widgets.requestPayment({
           orderId: prepared.orderId,

--- a/src/hooks/live/use-hls-player.ts
+++ b/src/hooks/live/use-hls-player.ts
@@ -253,6 +253,33 @@ export function useHlsPlayer({
     return () => clearInterval(intervalId);
   }, [videoRef, enabled, getLiveEdgePosition, getLiveTimelineRange]);
 
+  // 백그라운드 복귀 시 라이브 따라잡기 — 탭이 숨겨지면(다른 탭·최소화) 브라우저가 미디어를 throttle해
+  // 라이브가 멈추거나 한참 뒤처져, 돌아왔을 때 "송출이 멈춘 것처럼" 보이고 LIVE 표시도 꺼진다.
+  // 백그라운드로 갈 때 재생 중이었다면, 돌아왔을 때 자동으로 라이브 엣지로 점프해 재생을 잇는다
+  // (사용자가 일부러 일시정지했거나 과거 구간을 보던 중이면 건드리지 않는다).
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !enabled) return;
+
+    let wasPlayingBeforeHidden = false;
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        wasPlayingBeforeHidden = !video.paused;
+        return;
+      }
+      if (!wasPlayingBeforeHidden) return;
+      const edge = getLiveEdgePosition(video);
+      if (edge !== null && edge - video.currentTime > LIVE_EDGE_BEHIND_THRESHOLD_S) {
+        video.currentTime = edge;
+      }
+      void video.play().catch(() => {});
+      setIsAtLiveEdge(true);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [videoRef, enabled, getLiveEdgePosition]);
+
   // 실시간 지점으로 점프하고 재생을 재개한다(폴링을 기다리지 않고 상태도 즉시 반영).
   const seekToLiveEdge = useCallback(() => {
     const video = videoRef.current;

--- a/src/hooks/live/use-live-broadcast-realtime.ts
+++ b/src/hooks/live/use-live-broadcast-realtime.ts
@@ -1,7 +1,8 @@
 "use client";
 // 라이브 방송 한 건의 realtime 채널(live-broadcast-{id})을 구독해
 // 시청자 수 갱신과 방송 종료 신호를 콜백으로 전달합니다.
-// 시청 화면(use-live-view-data)과 미니플레이어가 공유한다 — 둘은 상호 배타로 렌더되어 중복 구독이 없다.
+// 시청 화면(use-live-view-data)과 미니플레이어가 공유한다 — 보통은 상호 배타로 렌더되어 중복이 없고,
+// 둘이 함께 뜨는 PIP에선 미니가 broadcastId=null로 구독을 양보해 같은 채널 이중 구독(Realtime 에러)을 피한다.
 
 import { useEffect, useMemo, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";

--- a/src/hooks/live/use-live-chat-session.ts
+++ b/src/hooks/live/use-live-chat-session.ts
@@ -160,6 +160,11 @@ export function useLiveChatSession({
       if (!result.success || !result.data) {
         removeOptimistic();
         toastAppError(result.code ?? APP_MESSAGE_CODE.error.message.sendFailed);
+        // GAP-022: 방송 중 채팅 설정(슬로우·팔로워 대기·scope) 변경이 진행 세션에 안 잡혀 거부됐을 수
+        // 있다. 최신 게이트로 watch를 갱신해, 새로고침 없이 입력바 안내·다음 시도가 정확해지게 한다.
+        void queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.live.watch(creatorId, user?.id),
+        });
         return false;
       }
 

--- a/src/hooks/live/use-live-messages.ts
+++ b/src/hooks/live/use-live-messages.ts
@@ -17,6 +17,7 @@ import {
   type LiveMessageRow,
 } from "@/utils/live/live-message";
 import { appendLiveMessage } from "@/utils/live/live-chat";
+import { isUuid } from "@/utils/common/uuid";
 import type { LiveChatMessage } from "@/types/live/live";
 
 // 닉네임·후원 금액은 metadata에 스냅샷으로 들어 있어 join이 필요 없다(Realtime payload와 동일 경로).
@@ -28,7 +29,9 @@ const EMPTY_LIVE_MESSAGES: LiveChatMessage[] = [];
 export function useLiveMessages(creatorId: string | null | undefined) {
   const supabase = useMemo(() => createClient(), []);
   const queryClient = useQueryClient();
-  const enabled = !!creatorId;
+  // 비-UUID creatorId는 REST 필터(creator_id=eq.{값})에서 400을 반복시켜 콘솔이 폭주하므로
+  // 쿼리 자체를 막는다(WATCH-013). send 액션은 이미 isUuid 가드가 있다.
+  const enabled = !!creatorId && isUuid(creatorId);
   // 과거 적재(무한 스크롤) 상태. 누적이 HISTORY_CAP에 닿거나 더 줄 게 없으면 멈춘다(치지직식).
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
   const [hasMoreHistory, setHasMoreHistory] = useState(true);

--- a/src/hooks/live/use-live-view-data.ts
+++ b/src/hooks/live/use-live-view-data.ts
@@ -12,6 +12,7 @@ import {
 } from "@/utils/live/live-subscription-badge";
 import { useLiveBroadcastRealtime } from "@/hooks/live/use-live-broadcast-realtime";
 import { useAuthStore } from "@/stores/auth";
+import { useLiveWatchSessionStore } from "@/stores/live-watch-session";
 import { QUERY_KEYS } from "@/constants/common/query-keys";
 import { APP_MESSAGE_CODE } from "@/constants/common/app-message-code";
 import { toastAppInfo } from "@/utils/common/toast-message";
@@ -102,6 +103,11 @@ export function useLiveViewData(creatorId: string) {
 
   useEffect(() => {
     return () => {
+      // 시청 세션이 이 채널로 살아있으면(미니/PIP로 계속 시청 중) watch 캐시를 보존한다 —
+      // '돌아가기'로 재진입할 때 stale 캐시로 즉시 복원하고 백그라운드(refetchOnMount:"always")로만
+      // 갱신해, 라우터가 다른 곳에서 복귀해도 빈 로딩 없이 빠르게 뜬다. 세션이 끝났으면(X·종료·
+      // 완전 이탈) 기존대로 제거해 강퇴 캐시 잔존 등을 막는다.
+      if (useLiveWatchSessionStore.getState().session?.creatorId === creatorId) return;
       const watchQueryKey = QUERY_KEYS.live.watch(creatorId, user?.id);
       queryClient.removeQueries({ queryKey: watchQueryKey, exact: true });
       clearLiveSubscriptionBadgeSourceCache();

--- a/src/lib/zod/channel-live.ts
+++ b/src/lib/zod/channel-live.ts
@@ -48,7 +48,7 @@ export const updateChannelLiveSettingsSchema = z.object({
     .array(z.string().trim().min(1).max(CHANNEL_CHAT_FORBIDDEN_WORD_MAX_LENGTH))
     .max(CHANNEL_CHAT_FORBIDDEN_WORD_MAX_COUNT),
   defaultTags: z.array(z.string().trim().min(1).max(12)).max(5),
-  defaultTitle: z.string().trim().max(100),
+  defaultTitle: z.string().trim().min(1).max(100),
   followerWaitSeconds: followerWaitSecondsSchema,
   linkBlocked: z.boolean(),
   slowModeEnabled: z.boolean(),

--- a/src/stores/live-watch-session.ts
+++ b/src/stores/live-watch-session.ts
@@ -14,16 +14,23 @@ export interface LiveWatchSession {
 
 interface LiveWatchSessionState {
   session: LiveWatchSession | null;
+  // 시청 페이지에서 명시적으로 PIP(미니)로 전환한 상태. 페이지에 머물러도 미니를 띄우고
+  // 원래 비디오 자리엔 안내를 표시한다(페이지 이탈 자동 미니 파생과 달리 사용자가 켠다).
+  isPip: boolean;
   startSession: (session: LiveWatchSession) => void;
   endSession: () => void;
+  setPip: (isPip: boolean) => void;
 }
 
 export const useLiveWatchSessionStore = create<LiveWatchSessionState>()(
   devtools(
     (set) => ({
       session: null,
+      isPip: false,
       startSession: (session) => set({ session }, false, "liveWatchSession/startSession"),
-      endSession: () => set({ session: null }, false, "liveWatchSession/endSession"),
+      // 세션이 끝나면 PIP 상태도 함께 끈다 — 다음 세션이 PIP인 채로 부활하지 않게.
+      endSession: () => set({ session: null, isPip: false }, false, "liveWatchSession/endSession"),
+      setPip: (isPip) => set({ isPip }, false, "liveWatchSession/setPip"),
     }),
     {
       name: "LiveWatchSessionStore",

--- a/src/types/channel/security.ts
+++ b/src/types/channel/security.ts
@@ -21,6 +21,10 @@ export interface ChannelSecuritySnapshot {
   streamKeyVersion: number;
   chatOverlayVersion: number;
   donationAlertVersion: number;
+  // 토큰별 마지막 재발급 시각(ISO 문자열). 재발급 이력이 없으면 null.
+  streamKeyRotatedAt: string | null;
+  chatOverlayRotatedAt: string | null;
+  donationAlertRotatedAt: string | null;
 }
 
 export interface ChannelSecurityVersionResult {
@@ -33,6 +37,9 @@ export interface CreatorStudioSnapshotSettings {
   streamKeyVersion?: CreatorStudioSetting["stream_key_version"];
   chatOverlayVersion?: CreatorStudioSetting["chat_overlay_version"];
   donationAlertVersion?: CreatorStudioSetting["donation_alert_version"];
+  streamKeyRotatedAt?: CreatorStudioSetting["stream_key_rotated_at"];
+  chatOverlayRotatedAt?: CreatorStudioSetting["chat_overlay_rotated_at"];
+  donationAlertRotatedAt?: CreatorStudioSetting["donation_alert_rotated_at"];
 }
 
 export interface ChannelSecurityUrlPopupSize {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,4 +1,4 @@
-﻿export type Json =
+export type Json =
   | string
   | number
   | boolean
@@ -745,6 +745,7 @@ export type Database = {
           created_at: string
           creator_id: string
           donor_id: string
+          donor_nickname: string | null
           id: string
           is_anonymous: boolean
           message: string
@@ -756,6 +757,7 @@ export type Database = {
           created_at?: string
           creator_id: string
           donor_id: string
+          donor_nickname?: string | null
           id?: string
           is_anonymous?: boolean
           message?: string
@@ -767,6 +769,7 @@ export type Database = {
           created_at?: string
           creator_id?: string
           donor_id?: string
+          donor_nickname?: string | null
           id?: string
           is_anonymous?: boolean
           message?: string
@@ -1435,8 +1438,6 @@ export type Database = {
         }
         Returns: Json
       }
-      check_email_exists: { Args: { target_email: string }; Returns: boolean }
-      claim_live_clip_jobs: { Args: { p_limit?: number }; Returns: Json }
       cancel_creator_subscription: {
         Args: {
           p_actor_user_id: string
@@ -1445,6 +1446,8 @@ export type Database = {
         }
         Returns: Json
       }
+      check_email_exists: { Args: { target_email: string }; Returns: boolean }
+      claim_live_clip_jobs: { Args: { p_limit?: number }; Returns: Json }
       community_comment_to_json: {
         Args: { p_comment_id: string; p_viewer_id: string }
         Returns: Json
@@ -1957,7 +1960,11 @@ export type Database = {
         Returns: string
       }
       subscribe_creator: {
-        Args: { p_actor_user_id: string; p_creator_id: string; p_idempotency_key?: string }
+        Args: {
+          p_actor_user_id: string
+          p_creator_id: string
+          p_idempotency_key?: string
+        }
         Returns: Json
       }
       sweep_live_viewer_counts: { Args: never; Returns: undefined }
@@ -2072,7 +2079,11 @@ export type Database = {
       message_type: "text" | "system"
       oauth_provider: "google" | "github" | "email"
       wallet_transaction_status: "pending" | "succeeded" | "failed" | "canceled"
-      wallet_transaction_type: "charge" | "donation_spend" | "refund" | "subscription_spend"
+      wallet_transaction_type:
+        | "charge"
+        | "donation_spend"
+        | "refund"
+        | "subscription_spend"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2215,7 +2226,12 @@ export const Constants = {
       message_type: ["text", "system"],
       oauth_provider: ["google", "github", "email"],
       wallet_transaction_status: ["pending", "succeeded", "failed", "canceled"],
-      wallet_transaction_type: ["charge", "donation_spend", "refund", "subscription_spend"],
+      wallet_transaction_type: [
+        "charge",
+        "donation_spend",
+        "refund",
+        "subscription_spend",
+      ],
     },
   },
 } as const

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -505,6 +505,7 @@ export type Database = {
           alert_volume: number
           channel_bio: string
           chat_donation_message_enabled: boolean
+          chat_overlay_rotated_at: string | null
           chat_overlay_version: number
           chat_rule_text: string
           chat_rule_version: number
@@ -514,6 +515,7 @@ export type Database = {
           default_tags: string[]
           default_title: string
           donation_alert_duration_seconds: number
+          donation_alert_rotated_at: string | null
           donation_alert_version: number
           donation_amount_visible: boolean
           donation_enabled: boolean
@@ -525,6 +527,7 @@ export type Database = {
           settlement_demo: Json
           slow_mode_enabled: boolean
           slow_mode_seconds: number
+          stream_key_rotated_at: string | null
           stream_key_version: number
           tts_enabled: boolean
           tts_rate: number
@@ -537,6 +540,7 @@ export type Database = {
           alert_volume?: number
           channel_bio?: string
           chat_donation_message_enabled?: boolean
+          chat_overlay_rotated_at?: string | null
           chat_overlay_version?: number
           chat_rule_text?: string
           chat_rule_version?: number
@@ -546,6 +550,7 @@ export type Database = {
           default_tags?: string[]
           default_title?: string
           donation_alert_duration_seconds?: number
+          donation_alert_rotated_at?: string | null
           donation_alert_version?: number
           donation_amount_visible?: boolean
           donation_enabled?: boolean
@@ -557,6 +562,7 @@ export type Database = {
           settlement_demo?: Json
           slow_mode_enabled?: boolean
           slow_mode_seconds?: number
+          stream_key_rotated_at?: string | null
           stream_key_version?: number
           tts_enabled?: boolean
           tts_rate?: number
@@ -569,6 +575,7 @@ export type Database = {
           alert_volume?: number
           channel_bio?: string
           chat_donation_message_enabled?: boolean
+          chat_overlay_rotated_at?: string | null
           chat_overlay_version?: number
           chat_rule_text?: string
           chat_rule_version?: number
@@ -578,6 +585,7 @@ export type Database = {
           default_tags?: string[]
           default_title?: string
           donation_alert_duration_seconds?: number
+          donation_alert_rotated_at?: string | null
           donation_alert_version?: number
           donation_amount_visible?: boolean
           donation_enabled?: boolean
@@ -589,6 +597,7 @@ export type Database = {
           settlement_demo?: Json
           slow_mode_enabled?: boolean
           slow_mode_seconds?: number
+          stream_key_rotated_at?: string | null
           stream_key_version?: number
           tts_enabled?: boolean
           tts_rate?: number

--- a/src/utils/channel/channel-analytics-normalize.ts
+++ b/src/utils/channel/channel-analytics-normalize.ts
@@ -50,9 +50,8 @@ export function normalizeDonationRow(
     return null;
   }
 
-  // 표시 닉네임은 전송 시 박힌 metadata.donorNickname(익명은 alias). donor_id는 노출하지 않는다.
-  const metadata = readObject(row.metadata);
-  const actorName = metadata ? (readText(metadata.donorNickname) ?? undefined) : undefined;
+  // 표시 닉네임은 donation 행에 박힌 donor_nickname(익명은 alias). donor_id는 노출하지 않는다.
+  const actorName = readText(row.donor_nickname) ?? undefined;
 
   return { id, type: "donation", at, amount, actorName };
 }

--- a/src/utils/channel/channel-security-snapshot.ts
+++ b/src/utils/channel/channel-security-snapshot.ts
@@ -24,8 +24,13 @@ export function buildChannelSecuritySnapshot(
     chatOverlay: readVersion(settings.chatOverlayVersion),
     donationAlert: readVersion(settings.donationAlertVersion),
   };
+  const rotatedAt = {
+    streamKey: readRotatedAt(settings.streamKeyRotatedAt),
+    chatOverlay: readRotatedAt(settings.chatOverlayRotatedAt),
+    donationAlert: readRotatedAt(settings.donationAlertRotatedAt),
+  };
 
-  return buildSnapshotFromVersions(creatorId, versions);
+  return buildSnapshotFromVersions(creatorId, versions, rotatedAt);
 }
 
 export function buildChannelSecurityVersionResult(
@@ -60,6 +65,11 @@ function buildSnapshotFromVersions(
     chatOverlay: number;
     donationAlert: number;
   },
+  rotatedAt: {
+    streamKey: string | null;
+    chatOverlay: string | null;
+    donationAlert: string | null;
+  },
 ): ChannelSecuritySnapshot {
   const baseUrl = resolvePublicBaseUrl();
   const streamKey = buildLiveStreamKey(creatorId, versions.streamKey);
@@ -81,6 +91,9 @@ function buildSnapshotFromVersions(
     streamKeyVersion: versions.streamKey,
     chatOverlayVersion: versions.chatOverlay,
     donationAlertVersion: versions.donationAlert,
+    streamKeyRotatedAt: rotatedAt.streamKey,
+    chatOverlayRotatedAt: rotatedAt.chatOverlay,
+    donationAlertRotatedAt: rotatedAt.donationAlert,
   };
 }
 
@@ -100,6 +113,11 @@ function readVersion(version?: number): number {
   return typeof version === "number" && Number.isInteger(version) && version > 0
     ? version
     : LIVE_SECURITY_DEFAULT_TOKEN_VERSION;
+}
+
+// timestamptz(ISO 문자열) 또는 null/undefined를 표시용 문자열로 정규화한다(재발급 이력 없으면 null).
+function readRotatedAt(value?: string | null): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function readStrictVersion(value: Json | undefined) {

--- a/src/utils/live/live-overlay-message.ts
+++ b/src/utils/live/live-overlay-message.ts
@@ -1,9 +1,11 @@
 // 라이브 메시지 row를 OBS 오버레이 표시 데이터로 변환합니다.
+import { LIVE_LABEL } from "@/constants/live/live";
 import {
   LIVE_OVERLAY_DEFAULT_CREATOR_NAME,
   LIVE_OVERLAY_DEFAULT_VIEWER_NAME,
 } from "@/constants/live/live-overlay";
 import { readJsonObject, readNumber, readString } from "@/utils/common/json";
+import { containsSeedProfanity } from "@/utils/live/live-chat";
 import { deriveSenderRoles } from "@/utils/live/live-message";
 import type { LiveMessageRow } from "@/types/live/live";
 import type { LiveChatOverlayItem, LiveChatOverlayMessage } from "@/types/live/live-chat-overlay";
@@ -31,13 +33,20 @@ export function mapLiveMessageToChatOverlayItem(
     const isDonor = metadata.isDonor === true;
     const isSubscriber = metadata.isSubscriber === true;
 
+    // OBS 채팅 오버레이도 시청 채팅과 동일하게 클린봇 비속어를 가린다(원문 노출 방지) — 서버 LLM
+    // 판정(cleanbotStatus)을 우선하고, 판정 전엔 클라 시드 사전으로 명백한 욕설을 즉시 가린다.
+    const cleanbotStatus = readString(metadata.cleanbotStatus);
+    const isCleanbotFlagged =
+      cleanbotStatus === "flagged" ||
+      (cleanbotStatus === null && containsSeedProfanity(message.content));
+
     const isHost = message.sender_role === "creator" || message.sender_id === options.creatorId;
     const overlayMessage: LiveChatOverlayMessage = {
       id: message.id,
       creatorId: options.creatorId,
       kind: "chat",
       author,
-      content: message.content,
+      content: isCleanbotFlagged ? LIVE_LABEL.cleanbotHidden : message.content,
       createdAt: message.created_at,
       // 시청 채팅과 동일 규칙으로 동시 보유 역할을 모두 뱃지로(공용 deriveSenderRoles).
       roles: deriveSenderRoles({

--- a/src/utils/payments/toss-wallet-charge-client.ts
+++ b/src/utils/payments/toss-wallet-charge-client.ts
@@ -24,6 +24,25 @@ export function isTossPaymentCancelError(error: unknown): boolean {
   return typeof code === "string" && TOSS_PAYMENT_CANCEL_CODES.has(code);
 }
 
+// 결제 후 카드사 앱으로 리다이렉트될 수 있는 기기(모바일·태블릿)인지 판단한다(PAY-013).
+// 이런 기기에서 iframe+Promise 방식을 쓰면 카드사 앱으로 전환된 뒤 Promise가 resolve되지 않아
+// 결제창이 멈춘다. 화면 폭(useIsMobile)으로 판단하면 가로 태블릿(≥768px)이 PC로 잡혀 멈추므로,
+// userAgent와 멀티터치로 기기를 판단해 successUrl/failUrl 리다이렉트로 폴백한다.
+export function prefersRedirectPayment(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const ua = navigator.userAgent;
+  if (/Android|iPhone|iPod|iPad|Mobile/i.test(ua)) {
+    return true;
+  }
+  // iPadOS 13+는 데스크탑 Safari(Macintosh)로 위장하지만 멀티터치가 있어 이로 구분한다.
+  if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) {
+    return true;
+  }
+  return false;
+}
+
 export async function prepareTossWalletCharge(amount: number): Promise<TossPaymentPrepareResponse> {
   const response = await fetch("/api/payments/toss/prepare", {
     method: "POST",

--- a/supabase/migrations/20260619081009_harden_get_live_viewer_profile_caller_check.sql
+++ b/supabase/migrations/20260619081009_harden_get_live_viewer_profile_caller_check.sql
@@ -1,0 +1,56 @@
+-- GAP-024: get_live_viewer_profile 호출자 검증 추가.
+-- 기존엔 anon/authenticated 누구나 임의 (creator, target)로 호출해 followedAt(팔로우 시점)·role(매니저 여부)을
+-- enumeration 가능했다. auth.uid() 기반으로 권한별 반환을 분리한다(파라미터·grant·클라 무변경):
+--   - 비로그인(anon): nickname/photoUrl만(채팅에 이미 공개되는 정보)
+--   - 로그인 시청자: + followedAt (팝오버 "N일부터 팔로우" 표시용)
+--   - 크리에이터/매니저: + role (강퇴/매니저 버튼 가드용) → 매니저 역할 enumeration 차단
+CREATE OR REPLACE FUNCTION public.get_live_viewer_profile(p_creator_id uuid, p_target_user_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+declare
+  v_actor uuid := (select auth.uid());
+  v_is_operator boolean;
+  v_profile jsonb;
+begin
+  if p_creator_id is null or p_target_user_id is null then
+    return 'null'::jsonb;
+  end if;
+
+  -- 호출자가 이 채널의 운영자(크리에이터 본인 또는 매니저)인지 — role 노출은 운영자에게만 허용.
+  v_is_operator := v_actor is not null and (
+    v_actor = p_creator_id
+    or exists (
+      select 1
+      from public.channel_manager as m
+      where m.creator_id = p_creator_id and m.manager_id = v_actor
+    )
+  );
+
+  select jsonb_build_object(
+    'userId', target_user.id,
+    'nickname', target_user.nickname,
+    'photoUrl', target_user.photo_url,
+    -- 팔로우 시점은 로그인 호출자에게만(비로그인 enumeration 차단).
+    'followedAt', case when v_actor is not null then relation.followed_at else null end,
+    -- 역할(매니저 여부)은 운영자에게만(비운영자에겐 null → 클라 canBan/canModerate가 false로 graceful).
+    'role', case
+      when not v_is_operator then null
+      when target_user.id = p_creator_id then 'creator'
+      when manager.manager_id is not null then 'manager'
+      else 'viewer'
+    end
+  )
+  into v_profile
+  from public."user" as target_user
+  left join public.viewer_creator_relation as relation
+    on relation.creator_id = p_creator_id and relation.viewer_id = target_user.id
+  left join public.channel_manager as manager
+    on manager.creator_id = p_creator_id and manager.manager_id = target_user.id
+  where target_user.id = p_target_user_id;
+
+  return coalesce(v_profile, 'null'::jsonb);
+end;
+$function$;

--- a/supabase/migrations/20260619094457_create_live_poll_single_active_guard.sql
+++ b/supabase/migrations/20260619094457_create_live_poll_single_active_guard.sql
@@ -1,0 +1,49 @@
+-- GAP-006: 한 방송에 활성 투표(ended_at IS NULL)는 하나만 보장한다.
+-- create_live_poll이 기존 active를 닫지 않고 무조건 insert해, 연속/동시 호출 시 활성 투표가
+-- 여러 개 생기던 문제를 막는다. advisory xact lock으로 같은 방송의 생성 요청을 직렬화해
+-- '기존 active 종료 → 새 투표 insert'가 원자적으로 일어나게 한다(동시 2개 생성 race 차단).
+create or replace function public.create_live_poll(
+  p_actor_user_id uuid,
+  p_broadcast_id uuid,
+  p_title text,
+  p_options jsonb,
+  p_ends_at timestamp with time zone default null::timestamp with time zone
+)
+returns uuid
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_poll_id uuid;
+begin
+  if p_actor_user_id is null then raise sqlstate 'PX401' using message = 'not authenticated'; end if;
+
+  if jsonb_typeof(p_options) is distinct from 'array'
+     or jsonb_array_length(p_options) < 2
+     or jsonb_array_length(p_options) > 5 then
+    raise sqlstate 'PX400' using message = 'poll options must be between 2 and 5';
+  end if;
+
+  perform 1
+  from public.live_broadcast as broadcast
+  where broadcast.id = p_broadcast_id
+    and broadcast.creator_id = p_actor_user_id
+    and broadcast.ended_at is null;
+  if not found then raise sqlstate 'PX404' using message = 'active live broadcast not found'; end if;
+
+  -- 같은 방송에 대한 투표 생성 요청을 트랜잭션 단위로 직렬화한다.
+  perform pg_advisory_xact_lock(hashtextextended(p_broadcast_id::text, 0));
+
+  -- 한 방송에 활성 투표는 하나만 — 새 투표를 시작하면 진행 중이던 투표는 자동 종료한다.
+  update public.live_poll
+     set ended_at = now(), modified_at = now()
+   where broadcast_id = p_broadcast_id and ended_at is null;
+
+  insert into public.live_poll (broadcast_id, title, options, ends_at)
+  values (p_broadcast_id, btrim(coalesce(p_title, '')), p_options, p_ends_at)
+  returning id into v_poll_id;
+
+  return v_poll_id;
+end;
+$function$;

--- a/supabase/migrations/20260619095027_add_donor_nickname_to_donation.sql
+++ b/supabase/migrations/20260619095027_add_donor_nickname_to_donation.sql
@@ -1,0 +1,234 @@
+-- GAP-016: 분석 페이지의 실시간 후원 피드(use-creator-donation-feed)는 donation INSERT를 구독해
+-- normalizeDonationRow로 변환하는데, donation 행에 닉네임이 없어 표시 닉네임이 항상 빈값이었다.
+-- (live_message.metadata.donorNickname에만 박혀 있었음.) creator_follow_event.viewer_nickname 패턴처럼
+-- donation 행에도 표시 닉네임(익명은 alias)을 박아 Realtime payload만으로 이름을 보여준다.
+-- 초기 데이터(get_creator_studio_snapshot)는 donor 조인으로 이미 닉네임을 주므로 그대로 둔다.
+alter table public.donation add column if not exists donor_nickname text;
+
+create or replace function public.send_live_donation_v2(
+  p_actor_user_id uuid,
+  p_creator_id uuid,
+  p_amount integer,
+  p_message text default ''::text,
+  p_is_anonymous boolean default false,
+  p_idempotency_key text default null::text
+)
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to ''
+as $function$
+declare
+  v_idempotency_key text := btrim(coalesce(p_idempotency_key, ''));
+  v_message text := btrim(coalesce(p_message, ''));
+  v_broadcast_id uuid;
+  v_setting public.creator_studio_setting%rowtype;
+  v_wallet public.wallet_account%rowtype;
+  v_existing_transaction public.wallet_transaction%rowtype;
+  v_existing_donation public.donation%rowtype;
+  v_transaction_id uuid;
+  v_donation_id uuid;
+  v_balance_after integer;
+  v_donor record;
+  v_donor_display_name text;
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  if p_creator_id is null then
+    raise sqlstate 'PX400' using message = 'invalid creator';
+  end if;
+
+  if p_amount is null or p_amount <= 0 then
+    raise sqlstate 'PX400' using message = 'invalid donation amount';
+  end if;
+
+  if char_length(v_message) > 100 then
+    raise sqlstate 'PX400' using message = 'invalid donation message';
+  end if;
+
+  if v_idempotency_key = '' then
+    raise sqlstate 'PX400' using message = 'idempotency key required';
+  end if;
+
+  select
+    donor.nickname,
+    donor.photo_url
+  into v_donor
+  from public."user" as donor
+  where donor.id = p_actor_user_id;
+
+  if not found then
+    raise sqlstate 'PX404' using message = 'donor not found';
+  end if;
+
+  -- 표시 닉네임: 익명이면 alias(없으면 '익명'), 아니면 실제 닉네임. live_message·donation에 동일하게 쓴다.
+  v_donor_display_name := case
+    when coalesce(p_is_anonymous, false) then coalesce(public.anonymous_donor_alias(p_actor_user_id), '익명')
+    else v_donor.nickname
+  end;
+
+  select *
+  into v_existing_transaction
+  from public.wallet_transaction as transaction
+  where transaction.idempotency_key = v_idempotency_key;
+
+  if found then
+    if v_existing_transaction.user_id <> p_actor_user_id
+      or v_existing_transaction.transaction_type <> 'donation_spend'::public.wallet_transaction_type
+      or v_existing_transaction.amount_delta <> -p_amount then
+      raise sqlstate 'PX409' using message = 'idempotency key conflict';
+    end if;
+
+    select *
+    into v_existing_donation
+    from public.donation as donation
+    where donation.wallet_transaction_id = v_existing_transaction.id;
+
+    if not found then
+      raise sqlstate 'PX409' using message = 'donation idempotency state conflict';
+    end if;
+
+    return jsonb_build_object(
+      'donationId', v_existing_donation.id,
+      'transactionId', v_existing_transaction.id,
+      'balanceAfter', v_existing_transaction.balance_after,
+      'replayed', true
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from public."user" as creator
+    where creator.id = p_creator_id
+  ) then
+    raise sqlstate 'PX404' using message = 'creator not found';
+  end if;
+
+  if p_creator_id = p_actor_user_id then
+    raise sqlstate 'PX400' using message = 'creator cannot donate to self';
+  end if;
+
+  -- 활성 방송이 있으면 후원을 방송에 귀속시키고, 없으면 채널 후원으로 기록한다.
+  select broadcast.id
+  into v_broadcast_id
+  from public.live_broadcast as broadcast
+  where broadcast.creator_id = p_creator_id
+    and broadcast.ended_at is null
+  order by broadcast.started_at desc
+  limit 1;
+
+  select *
+  into v_setting
+  from public.creator_studio_setting as setting
+  where setting.creator_id = p_creator_id;
+
+  if coalesce(v_setting.donation_enabled, true) = false then
+    raise sqlstate 'PX403' using message = 'donation disabled';
+  end if;
+
+  if p_amount < coalesce(v_setting.donation_min_amount, 1000) then
+    raise sqlstate 'PX400' using message = 'donation amount too low';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_actor_user_id::text || ':wallet', 0));
+
+  insert into public.wallet_account (user_id)
+  values (p_actor_user_id)
+  on conflict (user_id) do nothing;
+
+  select *
+  into v_wallet
+  from public.wallet_account as wallet
+  where wallet.user_id = p_actor_user_id
+  for update;
+
+  if v_wallet.balance_amount < p_amount then
+    raise sqlstate 'PX402' using message = 'insufficient wallet balance';
+  end if;
+
+  v_balance_after := v_wallet.balance_amount - p_amount;
+
+  update public.wallet_account as wallet
+  set balance_amount = v_balance_after
+  where wallet.user_id = p_actor_user_id;
+
+  insert into public.wallet_transaction (
+    user_id,
+    transaction_type,
+    transaction_status,
+    amount_delta,
+    balance_after,
+    idempotency_key,
+    metadata
+  )
+  values (
+    p_actor_user_id,
+    'donation_spend'::public.wallet_transaction_type,
+    'succeeded'::public.wallet_transaction_status,
+    -p_amount,
+    v_balance_after,
+    v_idempotency_key,
+    jsonb_build_object(
+      'broadcastId', v_broadcast_id,
+      'creatorId', p_creator_id
+    )
+  )
+  returning id into v_transaction_id;
+
+  insert into public.donation (
+    broadcast_id,
+    creator_id,
+    donor_id,
+    wallet_transaction_id,
+    amount,
+    message,
+    is_anonymous,
+    donor_nickname
+  )
+  values (
+    v_broadcast_id,
+    p_creator_id,
+    p_actor_user_id,
+    v_transaction_id,
+    p_amount,
+    v_message,
+    coalesce(p_is_anonymous, false),
+    v_donor_display_name
+  )
+  returning id into v_donation_id;
+
+  insert into public.live_message (
+    broadcast_id,
+    creator_id,
+    sender_id,
+    message_type,
+    content,
+    donation_id,
+    metadata
+  )
+  values (
+    v_broadcast_id,
+    p_creator_id,
+    case when coalesce(p_is_anonymous, false) then null else p_actor_user_id end,
+    'donation'::public.live_message_type,
+    v_message,
+    v_donation_id,
+    jsonb_build_object(
+      'donationId', v_donation_id,
+      'amount', p_amount,
+      'donorNickname', v_donor_display_name,
+      'donorPhotoUrl', case when coalesce(p_is_anonymous, false) then null else v_donor.photo_url end,
+      'isAnonymous', coalesce(p_is_anonymous, false)
+    )
+  );
+
+  return jsonb_build_object(
+    'donationId', v_donation_id,
+    'transactionId', v_transaction_id,
+    'balanceAfter', v_balance_after,
+    'replayed', false
+  );
+end;
+$function$;

--- a/supabase/migrations/20260619125756_add_creator_studio_token_rotated_at.sql
+++ b/supabase/migrations/20260619125756_add_creator_studio_token_rotated_at.sql
@@ -1,0 +1,190 @@
+-- CSEC-002: creator_studio_setting에 토큰별 "마지막 재발급 시각" 컬럼 추가(nullable = 재발급 이력 없음).
+alter table public.creator_studio_setting
+  add column if not exists stream_key_rotated_at timestamptz,
+  add column if not exists chat_overlay_rotated_at timestamptz,
+  add column if not exists donation_alert_rotated_at timestamptz;
+
+-- 재발급 RPC: 버전 증가와 함께 해당 토큰의 재발급 시각(now())을 같은 update 문에서 원자적으로 기록한다.
+create or replace function public.rotate_live_security_token_version(p_actor_user_id uuid, p_token_kind text)
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to ''
+as $function$
+declare
+  v_token_kind text := btrim(coalesce(p_token_kind, ''));
+  v_new_version integer;
+  v_snapshot jsonb;
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  insert into public.creator_studio_setting (creator_id)
+  values (p_actor_user_id)
+  on conflict (creator_id) do nothing;
+
+  if v_token_kind = 'stream_key' then
+    update public.creator_studio_setting
+    set stream_key_version = stream_key_version + 1,
+        stream_key_rotated_at = now()
+    where creator_id = p_actor_user_id
+    returning stream_key_version into v_new_version;
+  elsif v_token_kind = 'chat_overlay' then
+    update public.creator_studio_setting
+    set chat_overlay_version = chat_overlay_version + 1,
+        chat_overlay_rotated_at = now()
+    where creator_id = p_actor_user_id
+    returning chat_overlay_version into v_new_version;
+  elsif v_token_kind = 'donation_alert' then
+    update public.creator_studio_setting
+    set donation_alert_version = donation_alert_version + 1,
+        donation_alert_rotated_at = now()
+    where creator_id = p_actor_user_id
+    returning donation_alert_version into v_new_version;
+  else
+    raise sqlstate 'PX400' using message = 'invalid token kind';
+  end if;
+
+  if v_new_version is null then
+    raise sqlstate 'PX404' using message = 'creator setting not found';
+  end if;
+
+  v_snapshot := public.get_creator_studio_snapshot(p_actor_user_id);
+
+  return jsonb_build_object(
+    'tokenKind', v_token_kind,
+    'version', v_new_version,
+    'snapshot', v_snapshot
+  );
+end;
+$function$;
+
+-- 스튜디오 스냅샷 RPC: settings에 토큰별 마지막 재발급 시각(streamKeyRotatedAt 등)을 포함한다.
+create or replace function public.get_creator_studio_snapshot(p_actor_user_id uuid)
+ returns jsonb
+ language plpgsql
+ stable security definer
+ set search_path to ''
+as $function$
+declare
+  v_result jsonb;
+begin
+  if p_actor_user_id is null then
+    raise sqlstate 'PX401' using message = 'not authenticated';
+  end if;
+
+  select jsonb_build_object(
+    'settings', jsonb_build_object(
+      'defaultTitle', coalesce(setting.default_title, ''),
+      'defaultTags', coalesce(setting.default_tags, '{}'::text[]),
+      'chatScope', coalesce(setting.chat_scope, 'authenticated'::public.live_chat_scope),
+      'followerWaitSeconds', coalesce(setting.follower_wait_seconds, 0),
+      'slowModeEnabled', coalesce(setting.slow_mode_enabled, false),
+      'slowModeSeconds', coalesce(setting.slow_mode_seconds, 3),
+      'linkBlocked', coalesce(setting.link_blocked, true),
+      'forbiddenWords', coalesce(setting.forbidden_words, '{}'::text[]),
+      'chatRuleText', coalesce(setting.chat_rule_text, ''),
+      'chatRuleVersion', coalesce(setting.chat_rule_version, 1),
+      'chatDonationMessageEnabled', coalesce(setting.chat_donation_message_enabled, false),
+      'donationEnabled', coalesce(setting.donation_enabled, true),
+      'donationMinAmount', coalesce(setting.donation_min_amount, 1000),
+      'donationAmountVisible', coalesce(setting.donation_amount_visible, true),
+      'donationAlertDurationSeconds', coalesce(setting.donation_alert_duration_seconds, 5),
+      'alertSoundEnabled', coalesce(setting.alert_sound_enabled, true),
+      'alertSoundKey', coalesce(setting.alert_sound_key, 'classic'),
+      'alertVolume', coalesce(setting.alert_volume, 32),
+      'ttsEnabled', coalesce(setting.tts_enabled, true),
+      'ttsRate', coalesce(setting.tts_rate, 1.00),
+      'ttsVolume', coalesce(setting.tts_volume, 80),
+      'ttsVoiceUri', coalesce(setting.tts_voice_uri, ''),
+      'settlementDemo', coalesce(setting.settlement_demo, '{"status":"ready","totalAmount":99999,"bankName":"Demo Bank","accountHolder":"PixelPlay Creator"}'::jsonb),
+      'streamKeyVersion', coalesce(setting.stream_key_version, 1),
+      'chatOverlayVersion', coalesce(setting.chat_overlay_version, 1),
+      'donationAlertVersion', coalesce(setting.donation_alert_version, 1),
+      'streamKeyRotatedAt', setting.stream_key_rotated_at,
+      'chatOverlayRotatedAt', setting.chat_overlay_rotated_at,
+      'donationAlertRotatedAt', setting.donation_alert_rotated_at
+    ),
+    'activeBroadcast', case
+      when broadcast.id is null then 'null'::jsonb
+      else jsonb_build_object(
+        'id', broadcast.id,
+        'title', broadcast.title,
+        'tags', broadcast.tags,
+        'thumbnailUrl', broadcast.thumbnail_url,
+        'startedAt', broadcast.started_at,
+        'currentViewerCount', broadcast.current_viewer_count,
+        'peakViewerCount', broadcast.peak_viewer_count,
+        'chatMessageCount', broadcast.chat_message_count,
+        'donationCount', broadcast.donation_count,
+        'donationAmountTotal', broadcast.donation_amount_total
+      )
+    end,
+    'monthlyDonation', jsonb_build_object(
+      'amountTotal', coalesce(monthly_donation.amount_total, 0),
+      'donationCount', coalesce(monthly_donation.donation_count, 0)
+    ),
+    'recentDonations', coalesce(recent_donation.items, '[]'::jsonb)
+  )
+  into v_result
+  from public."user" as creator
+  left join public.creator_studio_setting as setting on setting.creator_id = creator.id
+  left join lateral (
+    select *
+    from public.live_broadcast as active_broadcast
+    where active_broadcast.creator_id = creator.id and active_broadcast.ended_at is null
+    order by active_broadcast.started_at desc
+    limit 1
+  ) as broadcast on true
+  left join lateral (
+    select
+      coalesce(sum(donation.amount), 0)::integer as amount_total,
+      count(*)::integer as donation_count
+    from public.donation as donation
+    where donation.creator_id = creator.id
+      and donation.created_at >= (date_trunc('month', now() at time zone 'Asia/Seoul') at time zone 'Asia/Seoul')
+  ) as monthly_donation on true
+  left join lateral (
+    select coalesce(
+      jsonb_agg(
+        jsonb_build_object(
+          'id', ranked.id,
+          'broadcastId', ranked.broadcast_id,
+          'donorId', ranked.donor_id,
+          'donorNickname', case when ranked.is_anonymous then '익명' else ranked.donor_nickname end,
+          'amount', ranked.amount,
+          'message', ranked.message,
+          'createdAt', ranked.created_at
+        )
+        order by ranked.created_at desc
+      ),
+      '[]'::jsonb
+    ) as items
+    from (
+      select
+        donation.id,
+        donation.broadcast_id,
+        donation.donor_id,
+        donor.nickname as donor_nickname,
+        donation.amount,
+        donation.message,
+        donation.is_anonymous,
+        donation.created_at
+      from public.donation as donation
+      join public."user" as donor on donor.id = donation.donor_id
+      where donation.creator_id = creator.id
+      order by donation.created_at desc
+      limit 10
+    ) as ranked
+  ) as recent_donation on true
+  where creator.id = p_actor_user_id
+  limit 1;
+
+  if v_result is null then
+    raise sqlstate 'PX404' using message = 'creator not found';
+  end if;
+
+  return v_result;
+end;
+$function$;


### PR DESCRIPTION
### 📌 반영 브랜치

#### dev -> main

### ✅ 작업 내용 `기능 추가` `기능 개선` `버그 수정`

- 보안: viewer_profile 호출자 검증(GAP-024), 스트림키·OBS URL 보기 후 자동 마스킹 카운트다운(CSEC-011), 토큰 마지막 재발급 시각 표시(CSEC-002)
- 시청 페이지: PIP 토글(미니 전환·윈도우 뚜껑·복귀 캐시), 클립 빈 상태 EmptyState, 채팅 설정 자가 반영(GAP-022), 비-UUID 채팅 가드(WATCH-013), 오프라인 placeholder(WATCH-014)
- QA: 동시 투표 방지(GAP-006), 후원자 닉네임(GAP-016), 제목 빈값 차단(GAP-023), 매니저 채팅 옵션(GAP-003), 목록 렌더 가상화(GAP-008), 결제 디바이스 판단(PAY-013), 팔로우 토스트 문구(SRCH-008)
- 기타: 로그인 아이디 기억, OBS 클린봇 마스킹, 커뮤니티 구독 이모지, Skeleton 깜빡임 방지, 전체화면 후원 Dialog, 채팅 입력 정렬, 메뉴명·홈 사이드바 푸터

### 🎯 단독 테스트 결과

- dev에서 각 기능 동작 확인(CSEC-011 카운트다운·자동 마스킹 브라우저 E2E, CSEC-002 rotate RPC + UI), tsc·eslint·prettier 통과, Supabase advisor 신규 이슈 0
- DB 마이그레이션은 dev/prod 공유 Supabase 프로젝트에 적용 완료(파일↔적용 정합 확인)

### 🚨 연관 이슈

- 해당 없음 (QA·개선 묶음)