### PR TITLE
fix(ui): 스켈레톤 인위적 지연 제거 — 즉시 표시로 복원

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,30 +1,13 @@
-"use client";
-// 빠른 로딩에서 Skeleton이 번쩍 떴다 사라지는 깜빡임을 막는다 — 마운트 후 짧은 지연이 지난 뒤에만
-// 부드럽게 나타나, 데이터가 그 전에 도착하면 Skeleton 자체가 보이지 않는다(지연 노출 패턴).
-
-import { useEffect, useState } from "react";
+// 로딩 중 콘텐츠 자리를 잡아주는 스켈레톤. 데이터가 도착하면 즉시 교체된다.
+// 인위적 지연 없이 곧바로 표시한다 — 로딩이 빠르면 잠깐 보였다 사라지는 게 정직하고 예측 가능하다.
 
 import { cn } from "@/lib/utils/index";
 
-// 이 시간 안에 끝나는 로딩은 Skeleton을 아예 보여주지 않는다(번쩍임 방지). 넘기면 부드럽게 fade-in.
-const SKELETON_REVEAL_DELAY_MS = 250;
-
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
-  const [revealed, setRevealed] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setRevealed(true), SKELETON_REVEAL_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, []);
-
   return (
     <div
       data-slot="skeleton"
-      className={cn(
-        "bg-muted animate-pulse rounded-md transition-opacity duration-200",
-        revealed ? "opacity-100" : "opacity-0",
-        className,
-      )}
+      className={cn("bg-muted animate-pulse rounded-md", className)}
       {...props}
     />
   );


### PR DESCRIPTION
### 📌 반영 브랜치

#### dev -> main

### ✅ 작업 내용 `버그 수정`

스켈레톤이 데이터가 빠른데도 인위적 지연(250ms) 뒤에 떠서 오히려 더 어설프게 번쩍이던 문제를 수정합니다.

- ui/skeleton의 지연 노출 로직 제거 -> 로딩 시 즉시 표시, 데이터 도착 시 즉시 교체

### 🎯 단독 테스트 결과

- tsc(0)·eslint·prettier 통과

### 🚨 연관 이슈

-