### PR TITLE
fix(notification): 알림 채널 이모지 평문 노출 수정

### DIFF
--- a/src/components/common/channel-emoji-text.tsx
+++ b/src/components/common/channel-emoji-text.tsx
@@ -14,9 +14,11 @@ interface Props {
   className?: string;
   // http(s) 링크 자동 연결 — 게시글 본문만 true.
   linkify?: boolean;
+  // 인라인 스티커 픽셀 크기 — 알림 미리보기처럼 작은 텍스트에선 줄여서 넘긴다.
+  stickerPx?: number;
 }
 
-export default function ChannelEmojiText({ text, as, className, linkify }: Props) {
+export default function ChannelEmojiText({ text, as, className, linkify, stickerPx }: Props) {
   const emojiIds = extractStickerTokenIds(text);
   const { data: stickers } = useChannelEmojiStickersByIds(emojiIds);
 
@@ -26,6 +28,7 @@ export default function ChannelEmojiText({ text, as, className, linkify }: Props
       as={as}
       className={className}
       linkify={linkify}
+      stickerPx={stickerPx}
       extraStickers={stickers}
     />
   );

--- a/src/components/notification/notification-item.tsx
+++ b/src/components/notification/notification-item.tsx
@@ -3,11 +3,11 @@
 import Link from "next/link";
 import { X } from "lucide-react";
 
+import ChannelEmojiText from "@/components/common/channel-emoji-text";
 import RelativeTime from "@/components/common/relative-time";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import type { AppNotification } from "@/types/notification/notification";
-import { stickerTokensToText } from "@/utils/sticker/sticker-token";
 import { getAvatarFallbackText, getAvatarImageSrc } from "@/utils/profile/avatar";
 
 interface Props {
@@ -38,9 +38,12 @@ export default function NotificationItem({ notification, onNavigate, onDelete }:
         <div className="min-w-0 flex-1">
           <p className="text-foreground truncate text-sm font-bold">{notification.title}</p>
           {notification.body && (
-            <p className="text-muted-foreground line-clamp-1 text-xs">
-              {stickerTokensToText(notification.body)}
-            </p>
+            <ChannelEmojiText
+              as="p"
+              text={notification.body}
+              className="text-muted-foreground line-clamp-1 text-xs"
+              stickerPx={16}
+            />
           )}
           <p className="text-muted-foreground/70 mt-0.5 text-xs">
             <RelativeTime iso={notification.createdAt} />


### PR DESCRIPTION
### 📌 반영 브랜치

#### dev -> main

### ✅ 작업 내용 `버그 수정`

알림 미리보기에서 채널 구독 이모티콘이 :pp-<id>: 토큰 평문으로 노출되던 문제를 수정합니다.

- 알림 본문을 ChannelEmojiText로 렌더(채팅·커뮤니티와 동일) -> 채널 이모지를 이미지로 표시
- ChannelEmojiText에 stickerPx 옵션 추가(알림 미리보기는 16px로 작게)

### 🎯 단독 테스트 결과

- tsc(0)·eslint·prettier 통과

### 🚨 연관 이슈

-