### PR TITLE
fix(community): 게시글 이미지 원본 비율 하단 정렬 복원

### DIFF
--- a/src/components/community/community-post-detail-view.tsx
+++ b/src/components/community/community-post-detail-view.tsx
@@ -125,23 +125,21 @@ export default function CommunityPostDetailView({
           />
 
           {detail.imageUrl && (
-            // 로드 전후 높이를 고정해 본문·댓글이 점프하지 않게 한다(CLS 방지). 비율은 object-contain으로 보존.
-            <div className="border-border/60 bg-muted/20 mt-4 flex h-96 items-center justify-center overflow-hidden rounded-xl border">
-              <Image
-                src={detail.imageUrl}
-                alt="첨부 이미지"
-                width={imageDim?.width ?? 800}
-                height={imageDim?.height ?? 600}
-                onLoad={(event) =>
-                  setImageDim({
-                    width: event.currentTarget.naturalWidth,
-                    height: event.currentTarget.naturalHeight,
-                  })
-                }
-                unoptimized
-                className="h-full w-auto max-w-full object-contain"
-              />
-            </div>
+            // 작성기와 동일하게 본문 하단에 원본 비율로 좌측 정렬한다(카드 폭을 넘을 때만 max-w로 축소).
+            <Image
+              src={detail.imageUrl}
+              alt="첨부 이미지"
+              width={imageDim?.width ?? 800}
+              height={imageDim?.height ?? 600}
+              onLoad={(event) =>
+                setImageDim({
+                  width: event.currentTarget.naturalWidth,
+                  height: event.currentTarget.naturalHeight,
+                })
+              }
+              unoptimized
+              className="border-border/60 mt-4 h-auto w-auto max-w-full rounded-xl border"
+            />
           )}
 
           <div className="mt-4 flex items-center justify-end">


### PR DESCRIPTION
### 📌 반영 브랜치

#### dev -> main

### ✅ 작업 내용 `버그 수정`

커뮤니티 게시글 상세에서 첨부 이미지가 고정 높이(h-96) 박스에 중앙 정렬·회색 배경으로 크게 뜨던 것을, 작성기와 동일하게 본문 하단 원본 비율 좌측 정렬로 되돌립니다.

- 고정 박스·중앙 정렬·배경 제거 -> 원본 비율 유지(카드 폭 넘을 때만 max-w 축소)

### 🎯 단독 테스트 결과

- tsc(0)·eslint·prettier 통과

### 🚨 연관 이슈

-